### PR TITLE
Fix venv detection for global tool installs (uv, pipx, pip)

### DIFF
--- a/src/envdrift/integrations/dotenvx.py
+++ b/src/envdrift/integrations/dotenvx.py
@@ -161,11 +161,14 @@ def get_venv_bin_dir() -> Path:
                 if platform.system() == "Windows":
                     # Windows: site-packages -> Lib -> tool_venv
                     tool_venv = p.parent.parent
-                    return tool_venv / "Scripts"
+                    bin_dir = tool_venv / "Scripts"
                 else:
                     # Linux: site-packages -> pythonX.Y -> lib -> tool_venv
                     tool_venv = p.parent.parent.parent
-                    return tool_venv / "bin"
+                    bin_dir = tool_venv / "bin"
+                # Validate path exists before returning
+                if bin_dir.parent.exists():
+                    return bin_dir
 
     # Default to creating in current directory's .venv
     cwd_venv = Path.cwd() / ".venv"
@@ -189,9 +192,11 @@ def get_venv_bin_dir() -> Path:
         user_bin.mkdir(parents=True, exist_ok=True)
         return user_bin
 
+    # Only reachable on Windows when APPDATA is not set
     raise RuntimeError(
         "Cannot find virtual environment or user bin directory. "
-        "Please activate a virtual environment or create one with: python -m venv .venv"
+        "On Windows, ensure the APPDATA environment variable is set, "
+        "or activate a virtual environment with: python -m venv .venv"
     )
 
 

--- a/tests/unit/test_dotenvx.py
+++ b/tests/unit/test_dotenvx.py
@@ -267,6 +267,21 @@ class TestGetVenvBinDir:
             assert result == tmp_path / "AppData" / "Roaming" / "Python" / "Scripts"
             assert result.exists()  # Should be created
 
+    def test_raises_when_no_appdata_on_windows(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Test raises RuntimeError on Windows when APPDATA is not set."""
+        monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+        monkeypatch.delenv("APPDATA", raising=False)
+        monkeypatch.chdir(tmp_path)
+
+        with (
+            patch("sys.path", ["C:\\Python313\\Lib\\site-packages"]),
+            patch("platform.system", return_value="Windows"),
+            pytest.raises(RuntimeError, match="APPDATA"),
+        ):
+            get_venv_bin_dir()
+
 
 class TestGetDotenvxPath:
     """Tests for get_dotenvx_path function."""


### PR DESCRIPTION
## Summary

- Add detection for `uv tool install` paths (`~/.local/share/uv/tools/`)
- Add detection for `pipx install` paths (`~/.local/pipx/venvs/`)
- Add fallback to user bin directories for plain `pip install`
  - Linux/macOS: `~/.local/bin`
  - Windows: `%APPDATA%\Python\Scripts`

## Problem

When `envdrift` was installed as a global CLI tool via `uv tool install` or `pipx`, running commands like `envdrift encrypt .env` would fail with:

```
RuntimeError: Cannot find virtual environment. 
Please activate a virtual environment or create one with: python -m venv .venv
```

This happened because `get_venv_bin_dir()` only looked for:
1. `VIRTUAL_ENV` env var (not set for global tools)
2. `.venv` or `venv` in `sys.path` (global tools use different paths)
3. `.venv` in cwd

## Solution

Extended `get_venv_bin_dir()` to detect:

| Install Method | Detection | Bin Directory |
|----------------|-----------|---------------|
| `VIRTUAL_ENV` set | env var | `$VIRTUAL_ENV/bin` |
| Standard `.venv`/`venv` | path contains `.venv` or `venv` | `<venv>/bin` |
| `uv tool install` | path has `uv` + `tools` | `~/.local/share/uv/tools/<pkg>/bin` |
| `pipx install` | path has `pipx` + `venvs` | `~/.local/pipx/venvs/<pkg>/bin` |
| `pip install --user` | fallback | `~/.local/bin` |
| `pip install` (system) | fallback | `~/.local/bin` |
| **Windows variants** | same logic | Uses `Scripts` instead of `bin` |

## Test plan

- [x] Added tests for uv tool install detection (Linux + Windows)
- [x] Added tests for pipx install detection (Linux + Windows)
- [x] Added tests for fallback to user bin (Linux + Windows)
- [x] All 66 dotenvx tests passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended environment detection to support uv and pipx tool installations
  * Added user-level writable bin fallbacks (POSIX ~/.local/bin and Windows APPDATA Python Scripts)

* **Improvements**
  * Updated installation guidance and clarified messaging for non-venv installation locations
  * Improved error text when environment/bin location cannot be determined

* **Tests**
  * Expanded cross-platform test coverage for discovery, fallbacks and directory creation scenarios

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->