### PR TITLE
fix: Use context.payload for workflow_run event data

### DIFF
--- a/.github/workflows/automerge-version-bump.yml
+++ b/.github/workflows/automerge-version-bump.yml
@@ -1,10 +1,6 @@
 name: Auto-merge Version Bumps
 
 on:
-  pull_request:
-    types: [labeled, synchronize]
-  check_suite:
-    types: [completed]
   workflow_run:
     workflows: ["CI"]
     types: [completed]
@@ -26,12 +22,15 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            const headBranch = context.payload.workflow_run.head_branch;
+            console.log(`Workflow run branch: ${headBranch}`);
+
             // Find PRs associated with this workflow run
             const { data: prs } = await github.rest.pulls.list({
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: 'open',
-              head: `${context.repo.owner}:${github.event.workflow_run.head_branch}`
+              head: `${context.repo.owner}:${headBranch}`
             });
 
             if (prs.length === 0) {


### PR DESCRIPTION
## Summary

Fixes the automerge workflow failure by:
- Using `context.payload.workflow_run` instead of `github.event.workflow_run` in the GitHub Script action
- Removing unnecessary triggers (`pull_request`, `check_suite`) - only `workflow_run` is needed

## Issue

The workflow was failing with:
```
TypeError: Cannot read properties of undefined (reading 'workflow_run')
```

## Fix

In `actions/github-script`, event data is accessed via `context.payload`, not `github.event`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved reliability of the automated version bump workflow by enhancing how the system identifies and processes pull requests during automated version updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->