### PR TITLE
fix: Disable Renovate silent mode to auto-create PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
+  "dependencyDashboardApproval": false,
   "labels": ["dependencies", "version-bump-auto"],
   "customManagers": [
     {


### PR DESCRIPTION
## Summary

Adds `dependencyDashboardApproval: false` to `renovate.json` to disable the default silent mode on Mend Hosted Renovate.

## Problem

Mend Hosted Renovate runs in `mode=silent` by default, which:
- Detects updates but doesn't create PRs automatically
- Requires manual approval on the Mend dashboard

## Solution

Setting `dependencyDashboardApproval: false` tells Renovate to create PRs automatically without requiring dashboard approval.

After this change, Renovate will:
1. Auto-create PRs for detected updates
2. PRs will have labels (`minor-version-bump` or `major-version-bump`)
3. Our automerge workflow will merge minor bumps after CI passes