### PR TITLE
feat(agent): add Phase 2D - per-project watching with individual configs

### DIFF
--- a/envdrift-agent/internal/guardian/guardian.go
+++ b/envdrift-agent/internal/guardian/guardian.go
@@ -6,46 +6,115 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/jainal09/envdrift-agent/internal/config"
 	"github.com/jainal09/envdrift-agent/internal/encrypt"
 	"github.com/jainal09/envdrift-agent/internal/lockcheck"
 	"github.com/jainal09/envdrift-agent/internal/notify"
+	"github.com/jainal09/envdrift-agent/internal/project"
+	"github.com/jainal09/envdrift-agent/internal/registry"
 	"github.com/jainal09/envdrift-agent/internal/watcher"
 )
 
 var errNoEnvdrift = fmt.Errorf("envdrift not found. Install it: pip install envdrift")
 
-// Guardian orchestrates file watching and auto-encryption
-type Guardian struct {
-	config    *config.Config
-	watcher   *watcher.Watcher
-	lastMod   map[string]time.Time
-	checkTick time.Duration
+// ProjectWatcher manages watching a single project with its own config.
+type ProjectWatcher struct {
+	projectPath string
+	config      *project.GuardianConfig
+	watcher     *watcher.Watcher
+	lastMod     map[string]time.Time
+	mu          sync.RWMutex
 }
 
-// New creates a Guardian configured with cfg, initializing its file watcher, last-mod tracking, and a 30-second idle-check interval.
-// It returns an error if the underlying watcher cannot be created.
-func New(cfg *config.Config) (*Guardian, error) {
-	w, err := watcher.New(
-		cfg.Guardian.Patterns,
-		cfg.Guardian.Exclude,
-		cfg.Directories.Recursive,
-	)
+// NewProjectWatcher creates a watcher for a single project.
+func NewProjectWatcher(projectPath string, cfg *project.GuardianConfig) (*ProjectWatcher, error) {
+	w, err := watcher.New(cfg.Patterns, cfg.Exclude, true)
 	if err != nil {
 		return nil, err
 	}
 
-	return &Guardian{
-		config:    cfg,
-		watcher:   w,
-		lastMod:   make(map[string]time.Time),
-		checkTick: 30 * time.Second, // Check for idle files every 30s
+	return &ProjectWatcher{
+		projectPath: projectPath,
+		config:      cfg,
+		watcher:     w,
+		lastMod:     make(map[string]time.Time),
 	}, nil
 }
 
-// Start begins the guardian loop
+// Start begins watching the project directory.
+func (pw *ProjectWatcher) Start() error {
+	if err := pw.watcher.AddDirectory(pw.projectPath); err != nil {
+		return err
+	}
+	pw.watcher.Start()
+	return nil
+}
+
+// Stop stops the project watcher.
+func (pw *ProjectWatcher) Stop() {
+	pw.watcher.Stop()
+}
+
+// Events returns the file events channel.
+func (pw *ProjectWatcher) Events() <-chan watcher.FileEvent {
+	return pw.watcher.Events()
+}
+
+// TrackFile records a file modification.
+func (pw *ProjectWatcher) TrackFile(path string, modTime time.Time) {
+	pw.mu.Lock()
+	defer pw.mu.Unlock()
+	pw.lastMod[path] = modTime
+}
+
+// GetIdleFiles returns files that have been idle longer than the configured timeout.
+func (pw *ProjectWatcher) GetIdleFiles() []string {
+	pw.mu.RLock()
+	defer pw.mu.RUnlock()
+
+	now := time.Now()
+	var idle []string
+
+	for path, modTime := range pw.lastMod {
+		if now.Sub(modTime) >= pw.config.IdleTimeout {
+			idle = append(idle, path)
+		}
+	}
+
+	return idle
+}
+
+// RemoveFile stops tracking a file.
+func (pw *ProjectWatcher) RemoveFile(path string) {
+	pw.mu.Lock()
+	defer pw.mu.Unlock()
+	delete(pw.lastMod, path)
+}
+
+// Guardian orchestrates file watching and auto-encryption for multiple projects.
+type Guardian struct {
+	globalConfig    *config.Config
+	projects        map[string]*ProjectWatcher // path -> watcher
+	registryWatcher *registry.RegistryWatcher
+	checkTick       time.Duration
+	mu              sync.RWMutex
+}
+
+// New creates a Guardian configured with cfg.
+func New(cfg *config.Config) (*Guardian, error) {
+	g := &Guardian{
+		globalConfig: cfg,
+		projects:     make(map[string]*ProjectWatcher),
+		checkTick:    30 * time.Second,
+	}
+
+	return g, nil
+}
+
+// Start begins the guardian loop.
 func (g *Guardian) Start(ctx context.Context) error {
 	// Check envdrift availability
 	if !encrypt.IsEnvdriftAvailable() {
@@ -53,97 +122,243 @@ func (g *Guardian) Start(ctx context.Context) error {
 	}
 
 	log.Println("EnvDrift Guardian starting...")
-	log.Printf("Idle timeout: %v", g.config.Guardian.IdleTimeout)
-	log.Printf("Watch patterns: %v", g.config.Guardian.Patterns)
-	log.Printf("Exclude patterns: %v", g.config.Guardian.Exclude)
 
-	// Add watch directories
-	for _, dir := range g.config.Directories.Watch {
-		log.Printf("Adding watch directory: %s", dir)
-		if err := g.watcher.AddDirectory(dir); err != nil {
-			log.Printf("Warning: could not watch %s: %v", dir, err)
-		}
+	// Set up registry watcher
+	rw, err := registry.NewRegistryWatcher(g.onRegistryChange)
+	if err != nil {
+		return fmt.Errorf("failed to create registry watcher: %w", err)
+	}
+	g.registryWatcher = rw
+
+	// Start watching the registry file
+	if err := rw.Start(); err != nil {
+		return fmt.Errorf("failed to start registry watcher: %w", err)
 	}
 
-	// Also watch current directory
-	if cwd, err := os.Getwd(); err == nil {
-		_ = g.watcher.AddDirectory(cwd)
-	}
-
-	g.watcher.Start()
+	// Load initial projects
+	g.loadProjects(rw.GetRegistry())
 
 	// Start the check loop
 	ticker := time.NewTicker(g.checkTick)
 	defer ticker.Stop()
 
+	// Create an aggregated events channel
+	events := make(chan projectEvent, 100)
+
+	// Start event forwarding for existing projects
+	g.mu.RLock()
+	for path, pw := range g.projects {
+		go g.forwardEvents(ctx, path, pw, events)
+	}
+	g.mu.RUnlock()
+
 	for {
 		select {
 		case <-ctx.Done():
 			log.Println("Guardian shutting down...")
-			g.watcher.Stop()
+			g.stopAllProjects()
+			g.registryWatcher.Stop()
 			return nil
 
-		case event := <-g.watcher.Events():
-			// File was modified, update last mod time
-			g.lastMod[event.Path] = event.ModTime
-			log.Printf("File modified: %s", event.Path)
+		case event := <-events:
+			// File was modified in a project
+			g.mu.RLock()
+			pw, ok := g.projects[event.projectPath]
+			g.mu.RUnlock()
+			if ok {
+				pw.TrackFile(event.filePath, event.modTime)
+				log.Printf("[%s] File modified: %s", event.projectPath, event.filePath)
+			}
 
 		case <-ticker.C:
-			// Check for files that are idle
+			// Check for idle files in all projects
 			g.checkIdleFiles()
 		}
 	}
 }
 
-// checkIdleFiles looks for files that haven't been modified in a while
-func (g *Guardian) checkIdleFiles() {
-	now := time.Now()
-	idleTimeout := g.config.Guardian.IdleTimeout
+// projectEvent represents a file event from a specific project.
+type projectEvent struct {
+	projectPath string
+	filePath    string
+	modTime     time.Time
+}
 
-	for path, modTime := range g.lastMod {
-		// Check if file has been idle long enough
-		if now.Sub(modTime) < idleTimeout {
-			continue
-		}
-
-		// Check if file exists
-		if _, err := os.Stat(path); os.IsNotExist(err) {
-			delete(g.lastMod, path)
-			continue
-		}
-
-		// Check if already encrypted
-		encrypted, err := encrypt.IsEncrypted(path)
-		if err != nil {
-			log.Printf("Error checking encryption status: %v", err)
-			continue
-		}
-		if encrypted {
-			delete(g.lastMod, path)
-			continue
-		}
-
-		// Check if file is open by another process
-		if lockcheck.IsFileOpen(path) {
-			log.Printf("File still open, skipping: %s", path)
-			continue
-		}
-
-		log.Printf("Encrypting idle file: %s", path)
-		if err := encrypt.EncryptSilent(path); err != nil {
-			log.Printf("Error encrypting %s: %v", path, err)
-			if g.config.Guardian.Notify {
-				_ = notify.Error("Failed to encrypt: " + path)
+// forwardEvents forwards events from a project watcher to the aggregated channel.
+func (g *Guardian) forwardEvents(ctx context.Context, projectPath string, pw *ProjectWatcher, out chan<- projectEvent) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case event, ok := <-pw.Events():
+			if !ok {
+				return
 			}
+			out <- projectEvent{
+				projectPath: projectPath,
+				filePath:    event.Path,
+				modTime:     event.ModTime,
+			}
+		}
+	}
+}
+
+// loadProjects initializes watchers for all registered projects.
+func (g *Guardian) loadProjects(reg *registry.Registry) {
+	if reg == nil {
+		return
+	}
+
+	projectPaths := reg.GetProjectPaths()
+	log.Printf("Loading %d registered projects", len(projectPaths))
+
+	// Load project configs
+	configs, err := project.LoadAllProjectConfigs(projectPaths)
+	if err != nil {
+		log.Printf("Error loading project configs: %v", err)
+		return
+	}
+
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	for _, pc := range configs {
+		if _, exists := g.projects[pc.Path]; exists {
+			continue // Already watching
+		}
+
+		pw, err := NewProjectWatcher(pc.Path, pc.Guardian)
+		if err != nil {
+			log.Printf("Error creating watcher for %s: %v", pc.Path, err)
 			continue
 		}
 
-		log.Printf("Successfully encrypted: %s", path)
-		if g.config.Guardian.Notify {
-			_ = notify.Encrypted(path)
+		if err := pw.Start(); err != nil {
+			log.Printf("Error starting watcher for %s: %v", pc.Path, err)
+			continue
 		}
 
-		// Remove from tracking
-		delete(g.lastMod, path)
+		g.projects[pc.Path] = pw
+		log.Printf("Watching project: %s (idle_timeout: %v, patterns: %v)",
+			pc.Path, pc.Guardian.IdleTimeout, pc.Guardian.Patterns)
+	}
+}
+
+// onRegistryChange handles changes to the projects registry.
+func (g *Guardian) onRegistryChange(reg *registry.Registry) {
+	log.Println("Registry changed, reloading projects...")
+
+	// Get new project list
+	newPaths := make(map[string]bool)
+	for _, p := range reg.GetProjectPaths() {
+		newPaths[p] = true
+	}
+
+	// Load configs for new projects
+	configs, _ := project.LoadAllProjectConfigs(reg.GetProjectPaths())
+	enabledPaths := make(map[string]*project.GuardianConfig)
+	for _, pc := range configs {
+		enabledPaths[pc.Path] = pc.Guardian
+	}
+
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	// Stop watchers for removed projects
+	for path, pw := range g.projects {
+		if _, exists := enabledPaths[path]; !exists {
+			log.Printf("Stopping watcher for removed project: %s", path)
+			pw.Stop()
+			delete(g.projects, path)
+		}
+	}
+
+	// Add watchers for new projects
+	for path, cfg := range enabledPaths {
+		if _, exists := g.projects[path]; exists {
+			continue
+		}
+
+		pw, err := NewProjectWatcher(path, cfg)
+		if err != nil {
+			log.Printf("Error creating watcher for %s: %v", path, err)
+			continue
+		}
+
+		if err := pw.Start(); err != nil {
+			log.Printf("Error starting watcher for %s: %v", path, err)
+			continue
+		}
+
+		g.projects[path] = pw
+		log.Printf("Added project: %s (idle_timeout: %v)", path, cfg.IdleTimeout)
+	}
+}
+
+// stopAllProjects stops all project watchers.
+func (g *Guardian) stopAllProjects() {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	for path, pw := range g.projects {
+		log.Printf("Stopping watcher for: %s", path)
+		pw.Stop()
+	}
+	g.projects = make(map[string]*ProjectWatcher)
+}
+
+// checkIdleFiles looks for files that haven't been modified in a while.
+func (g *Guardian) checkIdleFiles() {
+	g.mu.RLock()
+	projects := make(map[string]*ProjectWatcher)
+	for k, v := range g.projects {
+		projects[k] = v
+	}
+	g.mu.RUnlock()
+
+	for projectPath, pw := range projects {
+		idleFiles := pw.GetIdleFiles()
+
+		for _, path := range idleFiles {
+			// Check if file exists
+			if _, err := os.Stat(path); os.IsNotExist(err) {
+				pw.RemoveFile(path)
+				continue
+			}
+
+			// Check if already encrypted
+			encrypted, err := encrypt.IsEncrypted(path)
+			if err != nil {
+				log.Printf("Error checking encryption status: %v", err)
+				continue
+			}
+			if encrypted {
+				pw.RemoveFile(path)
+				continue
+			}
+
+			// Check if file is open by another process
+			if lockcheck.IsFileOpen(path) {
+				log.Printf("[%s] File still open, skipping: %s", projectPath, path)
+				continue
+			}
+
+			log.Printf("[%s] Encrypting idle file: %s", projectPath, path)
+			if err := encrypt.EncryptSilent(path); err != nil {
+				log.Printf("[%s] Error encrypting %s: %v", projectPath, path, err)
+				if pw.config.Notify {
+					_ = notify.Error("Failed to encrypt: " + path)
+				}
+				continue
+			}
+
+			log.Printf("[%s] Successfully encrypted: %s", projectPath, path)
+			if pw.config.Notify {
+				_ = notify.Encrypted(path)
+			}
+
+			// Remove from tracking
+			pw.RemoveFile(path)
+		}
 	}
 }

--- a/envdrift-agent/internal/project/config.go
+++ b/envdrift-agent/internal/project/config.go
@@ -1,0 +1,168 @@
+// Package project handles loading per-project configuration from envdrift.toml files.
+package project
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"time"
+
+	"github.com/pelletier/go-toml/v2"
+)
+
+// Default values for guardian config
+var (
+	DefaultIdleTimeout = 5 * time.Minute
+	DefaultPatterns    = []string{".env*"}
+	DefaultExclude     = []string{".env.example", ".env.sample", ".env.keys"}
+)
+
+// idleTimeoutPattern matches duration strings like "5m", "30s", "1h", "2d"
+var idleTimeoutPattern = regexp.MustCompile(`^(\d+)(s|m|h|d)$`)
+
+// GuardianConfig holds the per-project guardian settings from envdrift.toml.
+type GuardianConfig struct {
+	Enabled     bool          `toml:"enabled"`
+	IdleTimeout time.Duration `toml:"-"` // Parsed from string
+	Patterns    []string      `toml:"patterns"`
+	Exclude     []string      `toml:"exclude"`
+	Notify      bool          `toml:"notify"`
+
+	// Raw idle_timeout string for TOML parsing
+	IdleTimeoutStr string `toml:"idle_timeout"`
+}
+
+// envdriftConfig represents the full envdrift.toml structure (we only need guardian section).
+type envdriftConfig struct {
+	Guardian guardianToml `toml:"guardian"`
+}
+
+// guardianToml is the raw TOML representation.
+type guardianToml struct {
+	Enabled     *bool    `toml:"enabled"`
+	IdleTimeout string   `toml:"idle_timeout"`
+	Patterns    []string `toml:"patterns"`
+	Exclude     []string `toml:"exclude"`
+	Notify      *bool    `toml:"notify"`
+}
+
+// LoadProjectConfig loads the guardian configuration from a project's envdrift.toml.
+// If the file doesn't exist or has no guardian section, returns default config.
+func LoadProjectConfig(projectPath string) (*GuardianConfig, error) {
+	configPath := filepath.Join(projectPath, "envdrift.toml")
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return DefaultGuardianConfig(), nil
+		}
+		return nil, err
+	}
+
+	var cfg envdriftConfig
+	if err := toml.Unmarshal(data, &cfg); err != nil {
+		return nil, err
+	}
+
+	return parseGuardianConfig(&cfg.Guardian)
+}
+
+// DefaultGuardianConfig returns a GuardianConfig with default values.
+func DefaultGuardianConfig() *GuardianConfig {
+	return &GuardianConfig{
+		Enabled:     false,
+		IdleTimeout: DefaultIdleTimeout,
+		Patterns:    DefaultPatterns,
+		Exclude:     DefaultExclude,
+		Notify:      true,
+	}
+}
+
+// parseGuardianConfig converts the raw TOML config to GuardianConfig with defaults.
+func parseGuardianConfig(raw *guardianToml) (*GuardianConfig, error) {
+	cfg := DefaultGuardianConfig()
+
+	// Apply values from TOML if present
+	if raw.Enabled != nil {
+		cfg.Enabled = *raw.Enabled
+	}
+
+	if raw.IdleTimeout != "" {
+		duration, err := ParseIdleTimeout(raw.IdleTimeout)
+		if err != nil {
+			return nil, err
+		}
+		cfg.IdleTimeout = duration
+		cfg.IdleTimeoutStr = raw.IdleTimeout
+	}
+
+	if len(raw.Patterns) > 0 {
+		cfg.Patterns = raw.Patterns
+	}
+
+	if len(raw.Exclude) > 0 {
+		cfg.Exclude = raw.Exclude
+	}
+
+	if raw.Notify != nil {
+		cfg.Notify = *raw.Notify
+	}
+
+	return cfg, nil
+}
+
+// ParseIdleTimeout parses a duration string like "5m", "30s", "1h", "2d" into time.Duration.
+func ParseIdleTimeout(s string) (time.Duration, error) {
+	matches := idleTimeoutPattern.FindStringSubmatch(s)
+	if matches == nil {
+		// Try standard Go duration parsing as fallback
+		return time.ParseDuration(s)
+	}
+
+	value, _ := strconv.Atoi(matches[1])
+	unit := matches[2]
+
+	switch unit {
+	case "s":
+		return time.Duration(value) * time.Second, nil
+	case "m":
+		return time.Duration(value) * time.Minute, nil
+	case "h":
+		return time.Duration(value) * time.Hour, nil
+	case "d":
+		return time.Duration(value) * 24 * time.Hour, nil
+	default:
+		return time.ParseDuration(s)
+	}
+}
+
+// ProjectConfig holds a project path and its guardian configuration.
+type ProjectConfig struct {
+	Path     string
+	Guardian *GuardianConfig
+}
+
+// LoadAllProjectConfigs loads guardian configs for all given project paths.
+// Projects with guardian.enabled = false are excluded from the result.
+func LoadAllProjectConfigs(projectPaths []string) ([]*ProjectConfig, error) {
+	var configs []*ProjectConfig
+
+	for _, path := range projectPaths {
+		cfg, err := LoadProjectConfig(path)
+		if err != nil {
+			// Log but continue with other projects
+			continue
+		}
+
+		// Only include enabled projects
+		if cfg.Enabled {
+			configs = append(configs, &ProjectConfig{
+				Path:     path,
+				Guardian: cfg,
+			})
+		}
+	}
+
+	return configs, nil
+}

--- a/envdrift-agent/internal/project/config_test.go
+++ b/envdrift-agent/internal/project/config_test.go
@@ -1,0 +1,183 @@
+package project
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestParseIdleTimeout(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected time.Duration
+		wantErr  bool
+	}{
+		{"5m", 5 * time.Minute, false},
+		{"30s", 30 * time.Second, false},
+		{"1h", 1 * time.Hour, false},
+		{"2d", 48 * time.Hour, false},
+		{"10m", 10 * time.Minute, false},
+		{"invalid", 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := ParseIdleTimeout(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseIdleTimeout(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && got != tt.expected {
+				t.Errorf("ParseIdleTimeout(%q) = %v, want %v", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestDefaultGuardianConfig(t *testing.T) {
+	cfg := DefaultGuardianConfig()
+
+	if cfg.Enabled != false {
+		t.Errorf("Expected Enabled=false, got %v", cfg.Enabled)
+	}
+
+	if cfg.IdleTimeout != 5*time.Minute {
+		t.Errorf("Expected IdleTimeout=5m, got %v", cfg.IdleTimeout)
+	}
+
+	if len(cfg.Patterns) != 1 || cfg.Patterns[0] != ".env*" {
+		t.Errorf("Unexpected patterns: %v", cfg.Patterns)
+	}
+
+	if cfg.Notify != true {
+		t.Errorf("Expected Notify=true, got %v", cfg.Notify)
+	}
+}
+
+func TestLoadProjectConfig_NoFile(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	cfg, err := LoadProjectConfig(tmpDir)
+	if err != nil {
+		t.Fatalf("LoadProjectConfig() error = %v", err)
+	}
+
+	// Should return defaults
+	if cfg.Enabled != false {
+		t.Errorf("Expected Enabled=false, got %v", cfg.Enabled)
+	}
+}
+
+func TestLoadProjectConfig_WithGuardianSection(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	tomlContent := `
+[guardian]
+enabled = true
+idle_timeout = "10m"
+patterns = [".env*", ".secret*"]
+exclude = [".env.example"]
+notify = false
+`
+	if err := os.WriteFile(filepath.Join(tmpDir, "envdrift.toml"), []byte(tomlContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadProjectConfig(tmpDir)
+	if err != nil {
+		t.Fatalf("LoadProjectConfig() error = %v", err)
+	}
+
+	if cfg.Enabled != true {
+		t.Errorf("Expected Enabled=true, got %v", cfg.Enabled)
+	}
+
+	if cfg.IdleTimeout != 10*time.Minute {
+		t.Errorf("Expected IdleTimeout=10m, got %v", cfg.IdleTimeout)
+	}
+
+	if len(cfg.Patterns) != 2 {
+		t.Errorf("Expected 2 patterns, got %d", len(cfg.Patterns))
+	}
+
+	if len(cfg.Exclude) != 1 || cfg.Exclude[0] != ".env.example" {
+		t.Errorf("Unexpected exclude: %v", cfg.Exclude)
+	}
+
+	if cfg.Notify != false {
+		t.Errorf("Expected Notify=false, got %v", cfg.Notify)
+	}
+}
+
+func TestLoadProjectConfig_PartialConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Only set some fields, others should use defaults
+	tomlContent := `
+[guardian]
+enabled = true
+idle_timeout = "1m"
+`
+	if err := os.WriteFile(filepath.Join(tmpDir, "envdrift.toml"), []byte(tomlContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadProjectConfig(tmpDir)
+	if err != nil {
+		t.Fatalf("LoadProjectConfig() error = %v", err)
+	}
+
+	if cfg.Enabled != true {
+		t.Errorf("Expected Enabled=true, got %v", cfg.Enabled)
+	}
+
+	if cfg.IdleTimeout != 1*time.Minute {
+		t.Errorf("Expected IdleTimeout=1m, got %v", cfg.IdleTimeout)
+	}
+
+	// Should use defaults for unset fields
+	if len(cfg.Patterns) != 1 || cfg.Patterns[0] != ".env*" {
+		t.Errorf("Expected default patterns, got %v", cfg.Patterns)
+	}
+
+	if cfg.Notify != true {
+		t.Errorf("Expected default Notify=true, got %v", cfg.Notify)
+	}
+}
+
+func TestLoadAllProjectConfigs(t *testing.T) {
+	// Create two project directories
+	proj1 := t.TempDir()
+	proj2 := t.TempDir()
+	proj3 := t.TempDir() // No config
+
+	// proj1: enabled
+	os.WriteFile(filepath.Join(proj1, "envdrift.toml"), []byte(`
+[guardian]
+enabled = true
+idle_timeout = "5m"
+`), 0644)
+
+	// proj2: disabled
+	os.WriteFile(filepath.Join(proj2, "envdrift.toml"), []byte(`
+[guardian]
+enabled = false
+`), 0644)
+
+	// proj3: no envdrift.toml (defaults to disabled)
+
+	configs, err := LoadAllProjectConfigs([]string{proj1, proj2, proj3})
+	if err != nil {
+		t.Fatalf("LoadAllProjectConfigs() error = %v", err)
+	}
+
+	// Only proj1 should be returned (enabled)
+	if len(configs) != 1 {
+		t.Errorf("Expected 1 enabled project, got %d", len(configs))
+	}
+
+	if configs[0].Path != proj1 {
+		t.Errorf("Expected path %s, got %s", proj1, configs[0].Path)
+	}
+}

--- a/envdrift-agent/internal/project/config_test.go
+++ b/envdrift-agent/internal/project/config_test.go
@@ -153,17 +153,21 @@ func TestLoadAllProjectConfigs(t *testing.T) {
 	proj3 := t.TempDir() // No config
 
 	// proj1: enabled
-	os.WriteFile(filepath.Join(proj1, "envdrift.toml"), []byte(`
+	if err := os.WriteFile(filepath.Join(proj1, "envdrift.toml"), []byte(`
 [guardian]
 enabled = true
 idle_timeout = "5m"
-`), 0644)
+`), 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	// proj2: disabled
-	os.WriteFile(filepath.Join(proj2, "envdrift.toml"), []byte(`
+	if err := os.WriteFile(filepath.Join(proj2, "envdrift.toml"), []byte(`
 [guardian]
 enabled = false
-`), 0644)
+`), 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	// proj3: no envdrift.toml (defaults to disabled)
 

--- a/envdrift-agent/internal/registry/registry.go
+++ b/envdrift-agent/internal/registry/registry.go
@@ -87,7 +87,7 @@ func NewRegistryWatcher(onChange func(*Registry)) (*RegistryWatcher, error) {
 
 	reg, err := Load()
 	if err != nil {
-		fsw.Close()
+		_ = fsw.Close()
 		return nil, err
 	}
 
@@ -123,7 +123,7 @@ func (rw *RegistryWatcher) Start() error {
 // Stop stops watching the registry file.
 func (rw *RegistryWatcher) Stop() {
 	close(rw.done)
-	rw.fsWatcher.Close()
+	_ = rw.fsWatcher.Close()
 }
 
 // GetRegistry returns the current registry.

--- a/envdrift-agent/internal/registry/registry.go
+++ b/envdrift-agent/internal/registry/registry.go
@@ -1,0 +1,186 @@
+// Package registry handles loading the project registry from ~/.envdrift/projects.json.
+package registry
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+// ProjectEntry represents a single registered project.
+type ProjectEntry struct {
+	Path  string `json:"path"`
+	Added string `json:"added"`
+}
+
+// Registry holds the list of registered projects.
+type Registry struct {
+	Projects []ProjectEntry `json:"projects"`
+}
+
+// RegistryPath returns the path to the projects registry file: ~/.envdrift/projects.json
+func RegistryPath() string {
+	homeDir, _ := os.UserHomeDir()
+	return filepath.Join(homeDir, ".envdrift", "projects.json")
+}
+
+// Load reads the projects registry from ~/.envdrift/projects.json.
+// Returns an empty registry if the file doesn't exist.
+func Load() (*Registry, error) {
+	registryPath := RegistryPath()
+
+	data, err := os.ReadFile(registryPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &Registry{Projects: []ProjectEntry{}}, nil
+		}
+		return nil, err
+	}
+
+	var reg Registry
+	if err := json.Unmarshal(data, &reg); err != nil {
+		return nil, err
+	}
+
+	return &reg, nil
+}
+
+// GetProjectPaths returns a slice of all registered project paths.
+func (r *Registry) GetProjectPaths() []string {
+	paths := make([]string, len(r.Projects))
+	for i, p := range r.Projects {
+		paths[i] = p.Path
+	}
+	return paths
+}
+
+// HasProject checks if a path is registered.
+func (r *Registry) HasProject(path string) bool {
+	for _, p := range r.Projects {
+		if p.Path == path {
+			return true
+		}
+	}
+	return false
+}
+
+// RegistryWatcher watches the projects.json file for changes.
+type RegistryWatcher struct {
+	fsWatcher *fsnotify.Watcher
+	registry  *Registry
+	onChange  func(*Registry)
+	done      chan struct{}
+	mu        sync.RWMutex
+}
+
+// NewRegistryWatcher creates a watcher for the projects.json file.
+// The onChange callback is called whenever the registry changes.
+func NewRegistryWatcher(onChange func(*Registry)) (*RegistryWatcher, error) {
+	fsw, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, err
+	}
+
+	reg, err := Load()
+	if err != nil {
+		fsw.Close()
+		return nil, err
+	}
+
+	rw := &RegistryWatcher{
+		fsWatcher: fsw,
+		registry:  reg,
+		onChange:  onChange,
+		done:      make(chan struct{}),
+	}
+
+	return rw, nil
+}
+
+// Start begins watching the registry file for changes.
+func (rw *RegistryWatcher) Start() error {
+	registryPath := RegistryPath()
+
+	// Ensure the directory exists
+	dir := filepath.Dir(registryPath)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+
+	// Watch the directory (to catch file creation)
+	if err := rw.fsWatcher.Add(dir); err != nil {
+		return err
+	}
+
+	go rw.run()
+	return nil
+}
+
+// Stop stops watching the registry file.
+func (rw *RegistryWatcher) Stop() {
+	close(rw.done)
+	rw.fsWatcher.Close()
+}
+
+// GetRegistry returns the current registry.
+func (rw *RegistryWatcher) GetRegistry() *Registry {
+	rw.mu.RLock()
+	defer rw.mu.RUnlock()
+	return rw.registry
+}
+
+func (rw *RegistryWatcher) run() {
+	var debounceTimer *time.Timer
+
+	for {
+		select {
+		case <-rw.done:
+			if debounceTimer != nil {
+				debounceTimer.Stop()
+			}
+			return
+
+		case event, ok := <-rw.fsWatcher.Events:
+			if !ok {
+				return
+			}
+
+			// Check if it's the projects.json file
+			if filepath.Base(event.Name) != "projects.json" {
+				continue
+			}
+
+			// Debounce rapid changes
+			if debounceTimer != nil {
+				debounceTimer.Stop()
+			}
+			debounceTimer = time.AfterFunc(100*time.Millisecond, func() {
+				rw.reload()
+			})
+
+		case _, ok := <-rw.fsWatcher.Errors:
+			if !ok {
+				return
+			}
+		}
+	}
+}
+
+func (rw *RegistryWatcher) reload() {
+	reg, err := Load()
+	if err != nil {
+		return
+	}
+
+	rw.mu.Lock()
+	rw.registry = reg
+	rw.mu.Unlock()
+
+	if rw.onChange != nil {
+		rw.onChange(reg)
+	}
+}

--- a/envdrift-agent/internal/registry/registry_test.go
+++ b/envdrift-agent/internal/registry/registry_test.go
@@ -10,9 +10,9 @@ import (
 func TestLoad_NoFile(t *testing.T) {
 	// Create a temp directory and set HOME to it
 	tmpDir := t.TempDir()
-	originalHome := os.Getenv("HOME")
-	os.Setenv("HOME", tmpDir)
-	defer os.Setenv("HOME", originalHome)
+	// Set both HOME (Unix) and USERPROFILE (Windows) for cross-platform support
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("USERPROFILE", tmpDir)
 
 	reg, err := Load()
 	if err != nil {
@@ -30,9 +30,9 @@ func TestLoad_NoFile(t *testing.T) {
 
 func TestLoad_ValidFile(t *testing.T) {
 	tmpDir := t.TempDir()
-	originalHome := os.Getenv("HOME")
-	os.Setenv("HOME", tmpDir)
-	defer os.Setenv("HOME", originalHome)
+	// Set both HOME (Unix) and USERPROFILE (Windows) for cross-platform support
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("USERPROFILE", tmpDir)
 
 	// Create .envdrift directory and projects.json
 	envdriftDir := filepath.Join(tmpDir, ".envdrift")
@@ -58,7 +58,7 @@ func TestLoad_ValidFile(t *testing.T) {
 	}
 
 	if len(reg.Projects) != 2 {
-		t.Errorf("Expected 2 projects, got %d", len(reg.Projects))
+		t.Fatalf("Expected 2 projects, got %d", len(reg.Projects))
 	}
 
 	if reg.Projects[0].Path != "/home/user/project1" {

--- a/envdrift-agent/internal/registry/registry_test.go
+++ b/envdrift-agent/internal/registry/registry_test.go
@@ -1,0 +1,102 @@
+package registry
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoad_NoFile(t *testing.T) {
+	// Create a temp directory and set HOME to it
+	tmpDir := t.TempDir()
+	originalHome := os.Getenv("HOME")
+	os.Setenv("HOME", tmpDir)
+	defer os.Setenv("HOME", originalHome)
+
+	reg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	if reg == nil {
+		t.Fatal("Load() returned nil registry")
+	}
+
+	if len(reg.Projects) != 0 {
+		t.Errorf("Expected empty projects, got %d", len(reg.Projects))
+	}
+}
+
+func TestLoad_ValidFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	originalHome := os.Getenv("HOME")
+	os.Setenv("HOME", tmpDir)
+	defer os.Setenv("HOME", originalHome)
+
+	// Create .envdrift directory and projects.json
+	envdriftDir := filepath.Join(tmpDir, ".envdrift")
+	if err := os.MkdirAll(envdriftDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	registry := Registry{
+		Projects: []ProjectEntry{
+			{Path: "/home/user/project1", Added: "2025-01-01T00:00:00Z"},
+			{Path: "/home/user/project2", Added: "2025-01-02T00:00:00Z"},
+		},
+	}
+
+	data, _ := json.Marshal(registry)
+	if err := os.WriteFile(filepath.Join(envdriftDir, "projects.json"), data, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	reg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	if len(reg.Projects) != 2 {
+		t.Errorf("Expected 2 projects, got %d", len(reg.Projects))
+	}
+
+	if reg.Projects[0].Path != "/home/user/project1" {
+		t.Errorf("Expected path /home/user/project1, got %s", reg.Projects[0].Path)
+	}
+}
+
+func TestRegistry_GetProjectPaths(t *testing.T) {
+	reg := &Registry{
+		Projects: []ProjectEntry{
+			{Path: "/path/a", Added: "2025-01-01T00:00:00Z"},
+			{Path: "/path/b", Added: "2025-01-02T00:00:00Z"},
+		},
+	}
+
+	paths := reg.GetProjectPaths()
+
+	if len(paths) != 2 {
+		t.Errorf("Expected 2 paths, got %d", len(paths))
+	}
+
+	if paths[0] != "/path/a" || paths[1] != "/path/b" {
+		t.Errorf("Unexpected paths: %v", paths)
+	}
+}
+
+func TestRegistry_HasProject(t *testing.T) {
+	reg := &Registry{
+		Projects: []ProjectEntry{
+			{Path: "/path/a", Added: "2025-01-01T00:00:00Z"},
+		},
+	}
+
+	if !reg.HasProject("/path/a") {
+		t.Error("Expected HasProject to return true for /path/a")
+	}
+
+	if reg.HasProject("/path/b") {
+		t.Error("Expected HasProject to return false for /path/b")
+	}
+}


### PR DESCRIPTION
## Summary

Refactors the Go agent to support multi-project watching with per-project configuration settings from each project's `envdrift.toml` file.

- Add `internal/registry` package to load and watch `~/.envdrift/projects.json`
- Add `internal/project` package to load per-project `[guardian]` settings
- Refactor guardian to create per-project watchers with individual configs
- Update agent-spec.md to reflect Phase 2D completion

## New Go Packages

### `internal/registry`
- `Load()` - Reads `~/.envdrift/projects.json`
- `RegistryWatcher` - Monitors registry file for changes (fsnotify)
- Debounced reloading on file changes

### `internal/project`
- `LoadProjectConfig()` - Loads `[guardian]` section from project's `envdrift.toml`
- `ParseIdleTimeout()` - Parses duration strings like "5m", "1h", "2d"
- `LoadAllProjectConfigs()` - Loads configs for all registered projects

## Key Features

| Feature | Description |
|---------|-------------|
| Per-project patterns | Each project uses its own `.env*` patterns |
| Per-project excludes | Custom exclude patterns per project |
| Per-project idle timeout | Different encryption delays (e.g., "1m" vs "10m") |
| Per-project notifications | Enable/disable desktop notifications |
| Dynamic registry watching | Auto-reload when projects are added/removed |
| Enabled filtering | Only watches projects with `guardian.enabled = true` |

## Architecture

```
~/.envdrift/projects.json
         │
         ▼
   RegistryWatcher
         │
    ┌────┼────┐
    ▼    ▼    ▼
  Proj  Proj  Proj
    A    B    C
    │    │    │
    ▼    ▼    ▼
 Project Project Project
 Watcher Watcher Watcher
    │    │    │
    └────┼────┘
         ▼
     Guardian
```

## Test plan

- [x] Go tests pass (`go test ./...`)
- [ ] Manual test: Register project with `envdrift agent register`
- [ ] Manual test: Verify agent watches registered project
- [ ] Manual test: Verify per-project settings are respected
- [ ] Manual test: Add/remove project and verify hot reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Refactored the Go agent to support multi-project watching with per-project configuration from individual `envdrift.toml` files. This implements Phase 2D of the agent specification.

**Major changes:**
- Added `internal/registry` package to load and watch `~/.envdrift/projects.json` with fsnotify-based hot-reload
- Added `internal/project` package to parse per-project `[guardian]` settings (patterns, excludes, idle timeout, notifications)
- Refactored `Guardian` to manage multiple `ProjectWatcher` instances, one per registered project
- Each project now uses its own configuration for file patterns, excludes, idle timeout, and notification preferences
- Registry changes trigger dynamic project loading/unloading

**Architecture improvements:**
- Central registry file (`~/.envdrift/projects.json`) acts as single source of truth
- Per-project settings loaded from each project's `envdrift.toml`
- Debounced registry watching prevents rapid reloads
- Projects with `guardian.enabled = false` are filtered out

**Issue found:**
- Goroutine leak in `guardian.go:147-153` - dynamically added projects don't have their events forwarded to the main event loop

<h3>Confidence Score: 3/5</h3>


- This PR has a goroutine management issue that affects dynamically added projects
- The refactoring is well-structured with good test coverage for new packages, but there's a critical logic bug in `guardian.go` where dynamically added projects via registry changes won't have their file events forwarded to the main event loop. The initial projects loaded at startup work correctly, but projects added after the agent starts running will be watched but their events will be lost. This reduces the score from 4 to 3.
- Pay close attention to `envdrift-agent/internal/guardian/guardian.go` - specifically the goroutine management for event forwarding

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| envdrift-agent/internal/guardian/guardian.go | Refactored to support multi-project watching with per-project configs. Contains a goroutine leak issue when projects are dynamically added. |
| envdrift-agent/internal/project/config.go | Loads per-project guardian settings from envdrift.toml with proper defaults and validation. |
| envdrift-agent/internal/registry/registry.go | Manages projects.json registry with fsnotify-based hot-reload capability. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant CLI as envdrift CLI
    participant Registry as projects.json
    participant RW as RegistryWatcher
    participant Guardian
    participant PW as ProjectWatcher
    participant FS as File System

    User->>CLI: envdrift agent register
    CLI->>Registry: Add project path
    Registry-->>RW: File change event
    RW->>RW: Debounce (100ms)
    RW->>Guardian: onRegistryChange(registry)
    Guardian->>Guardian: Load project configs
    Guardian->>PW: NewProjectWatcher(path, config)
    PW->>PW: Create watcher with patterns
    Guardian->>PW: Start()
    PW->>FS: Watch directory (fsnotify)
    
    loop Every file event
        FS-->>PW: File modified
        PW->>PW: Filter by patterns & excludes
        PW->>Guardian: Send event via channel
        Guardian->>PW: TrackFile(path, modTime)
    end
    
    loop Every 30 seconds
        Guardian->>PW: GetIdleFiles()
        PW-->>Guardian: List of idle files
        Guardian->>Guardian: Check if encrypted
        Guardian->>Guardian: Check if file open
        Guardian->>Guardian: Encrypt idle files
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-project orchestration: agent now monitors multiple projects concurrently with per-project watchers.
  * Per-project customization: per-project idle timeouts, include/exclude patterns, and notifications via project configs.
  * Dynamic registry: projects discovered and reconciled at runtime without restarts.

* **Documentation**
  * Updated architecture diagrams, phases, and examples to reflect registry-based tracking and per-project configs.

* **Tests**
  * Added unit tests for project config parsing and registry behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->