### PR TITLE
fix(vscode): update stale pip install references to universal installer

### DIFF
--- a/.github/workflows/vscode-release.yml
+++ b/.github/workflows/vscode-release.yml
@@ -130,7 +130,7 @@ jobs:
 
             ### Requirements
             - VS Code 1.85.0 or higher
-            - `envdrift` Python package installed (`pip install envdrift`)
+            - `envdrift` installed via the [universal installer](https://github.com/jainal09/envdrift#installation)
           files: |
             release/*.vsix
           draft: false

--- a/envdrift-vscode/README.md
+++ b/envdrift-vscode/README.md
@@ -15,7 +15,11 @@ Automatically encrypt `.env` files when you close them in VS Code.
 [envdrift](https://github.com/jainal09/envdrift) must be installed:
 
 ```bash
-pip install envdrift
+# macOS / Linux
+curl -sSL https://raw.githubusercontent.com/jainal09/envdrift/main/install.sh | sh
+
+# Windows (PowerShell)
+irm https://raw.githubusercontent.com/jainal09/envdrift/main/install.ps1 | iex
 ```
 
 ## Quick Start

--- a/envdrift-vscode/README.md
+++ b/envdrift-vscode/README.md
@@ -20,6 +20,10 @@ curl -sSL https://raw.githubusercontent.com/jainal09/envdrift/main/install.sh | 
 
 # Windows (PowerShell)
 irm https://raw.githubusercontent.com/jainal09/envdrift/main/install.ps1 | iex
+
+# Or download and inspect first:
+# curl -sSL https://raw.githubusercontent.com/jainal09/envdrift/main/install.sh -o install.sh
+# less install.sh && sh install.sh
 ```
 
 ## Quick Start


### PR DESCRIPTION
## Summary
- Updates `envdrift-vscode/README.md` to use the universal installer (`install.sh` / `install.ps1`) instead of the stale `pip install envdrift`
- Updates `vscode-release.yml` release body with the same fix

This `fix(vscode):` commit will trigger release-please to create a vscode release PR, picking up the unreleased source changes from PR #157 (agentStatus.ts, encryption.ts) that were squash-merged under `ci:` and never released.

## Test plan
- [ ] Verify release-please creates a `vscode` release PR after merge
- [ ] Verify the release PR includes changes from PR #157 in the changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated release workflow requirements wording to recommend using the universal installer instead of pip.
  * Revised extension README installation instructions with platform-specific guidance for macOS/Linux and Windows, plus an alternative download/inspection path for install scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates stale installation instructions from `pip install envdrift` to the universal installer scripts (`install.sh` / `install.ps1`) in both the VSCode extension README and the release workflow template.

**Changes:**
- `envdrift-vscode/README.md`: Replaced pip install command with platform-specific curl/irm commands that match the main repository's installation documentation
- `.github/workflows/vscode-release.yml`: Updated release body to link to the main repo's installation section instead of showing outdated pip command

**Verification:**
- Installation scripts (`install.sh`, `install.ps1`) exist in the repository
- URLs point to correct location (`raw.githubusercontent.com/.../main/`)
- Link to `#installation` correctly targets the Installation section in main README (line 40)
- Commands are consistent with main repository documentation

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge - documentation-only changes with no runtime impact
- Perfect score because these are purely documentation updates that correctly align installation instructions with the project's current universal installer approach. All URLs are valid, commands are correct, and changes are consistent with the main repository's documentation.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/vscode-release.yml | Updated release body to reference universal installer instead of pip install |
| envdrift-vscode/README.md | Updated installation instructions to use universal installer scripts for macOS/Linux/Windows |

</details>



<sub>Last reviewed commit: d04d49a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->