### PR TITLE
fix(release): unblock release-please from legacy grouped PR title

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,13 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "separate-pull-requests": true,
-  "plugins": [
-    {
-      "type": "linked-versions",
-      "groupName": "envdrift",
-      "components": ["envdrift"]
-    }
-  ],
+  "group-pull-request-title-pattern": "chore${scope}: release ${component} libraries",
   "packages": {
     ".": {
       "release-type": "python",


### PR DESCRIPTION
## Summary
- remove the `linked-versions` plugin that was merging a single-component release into a non-standard grouped title
- add `group-pull-request-title-pattern` matching the already-merged legacy title format (`chore(main): release envdrift libraries`)
- allow release-please to parse PR #153, create missing `v10.8.0`, and resume normal release PR generation

## Why this fixes it
release-please currently aborts because it finds an untagged merged release PR (#153) whose title cannot be parsed by the default manifest grouped-title pattern. This change provides a compatible parser pattern for that historical PR while removing the config path that generated fragile grouped titles.

## Validation
- JSON config parses (`jq`)
- local parser sanity check confirms the pattern matches `chore(main): release envdrift libraries`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release process configuration to adjust plugin settings and release pull request title formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a release-please configuration issue that was blocking new releases. PR #153 merged with a non-standard grouped title format (`chore(main): release envdrift libraries`) but never created the corresponding v10.8.0 tag, causing release-please to abort on subsequent runs.

**Changes made:**
- Removed the `linked-versions` plugin that was generating non-standard grouped PR titles for single-component releases
- Added `group-pull-request-title-pattern` to match the legacy grouped title format from PR #153
- This allows release-please to parse the historical PR, create the missing v10.8.0 tag, and resume normal release PR generation with `separate-pull-requests: true`

**Configuration correctness:**
- Pattern `chore${scope}: release ${component} libraries` correctly matches the legacy title `chore(main): release envdrift libraries`
- Compatible with `separate-pull-requests: true` (pattern used only for parsing historical grouped PRs)
- JSON syntax is valid

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a focused configuration fix that removes a problematic plugin and adds backward-compatible pattern matching. The pattern correctly matches the legacy PR title format, and the removal of `linked-versions` prevents future non-standard grouped titles. The configuration change is well-documented and addresses a specific blocking issue without introducing new risks.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| release-please-config.json | Removed `linked-versions` plugin and added `group-pull-request-title-pattern` to parse legacy grouped PR #153 title format |

</details>



<sub>Last reviewed commit: e74c4f9</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->