### PR TITLE
ci: allow manual agent workflow runs

### DIFF
--- a/.github/workflows/agent-ci.yml
+++ b/.github/workflows/agent-ci.yml
@@ -11,6 +11,7 @@ on:
     paths:
       - 'envdrift-agent/**'
       - '.github/workflows/agent-ci.yml'
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- add workflow_dispatch to EnvDrift Agent CI so it can be run on demand from main

## Validation
- git diff --check
- go test -race ./... in envdrift-agent

After this merges, I will dispatch EnvDrift Agent CI on main and watch it complete.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow to support manual triggering alongside automated triggers for push and pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a single `workflow_dispatch:` trigger to `agent-ci.yml`, enabling on-demand manual runs of the EnvDrift Agent CI pipeline from the GitHub UI. The change is minimal and correct. A pre-existing inconsistency is worth noting: the `test` job uses Go 1.23 while `build` and `lint` both use 1.26, meaning tests are validated against a different toolchain than what produces the shipping binary.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the one-line change is correct and the only finding is a pre-existing P2 issue unrelated to the diff.

The PR adds a single `workflow_dispatch:` trigger with no functional risk. The Go version mismatch (1.23 vs 1.26) is pre-existing and P2 only, leaving the score at 5.

No files require special attention for this change.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/agent-ci.yml | Adds `workflow_dispatch` trigger to allow manual runs; the rest of the workflow has a pre-existing Go version mismatch (test uses 1.23, build/lint use 1.26) |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant GH as GitHub Actions
    participant Test as test job
    participant Build as build job
    participant Integration as integration jobs
    participant Lint as lint job

    Dev->>GH: workflow_dispatch (manual trigger) OR push/PR to main
    GH->>Test: Run tests (Go 1.23, ubuntu/macos/windows)
    Test-->>Build: on success
    Build->>Build: Build binaries (Go 1.26, multi-arch)
    Build-->>Integration: artifacts ready
    Build-->>Lint: (parallel)
    Integration->>Integration: integration-linux
    Integration->>Integration: integration-macos
    Integration->>Integration: integration-windows
    Lint->>Lint: golangci-lint (Go 1.26)
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.github/workflows/agent-ci.yml`, line 31-32 ([link](https://github.com/jainal09/envdrift/blob/3537bb37ff3312a3beaff39bcc6b1eba0d2bc7e3/.github/workflows/agent-ci.yml#L31-L32)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Go version inconsistency between test and build/lint jobs**

   The `test` job pins `go: ['1.23']` while `build` and `lint` both use `'1.26'`. This means tests are validated against an older toolchain than the binary that ships. If the code relies on any behaviour change or new standard-library feature introduced in 1.24–1.26, tests would still pass on 1.23 while the built binary behaves differently. Aligning the Go version across all jobs (or adding 1.26 to the test matrix) would close the gap.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["ci: allow manual agent workflow runs"](https://github.com/jainal09/envdrift/commit/3537bb37ff3312a3beaff39bcc6b1eba0d2bc7e3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30779321)</sub>

<!-- /greptile_comment -->