### PR TITLE
ci: align agent go version

### DIFF
--- a/.github/workflows/agent-ci.yml
+++ b/.github/workflows/agent-ci.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go: ['1.23']
+        go: ['1.26']
 
     steps:
       - name: Checkout code

--- a/.github/workflows/agent-ci.yml
+++ b/.github/workflows/agent-ci.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go: ['1.26']
+        go: ['1.23', '1.26']
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
- align the Agent CI test matrix Go version with the build and lint jobs

## Review finding
- Valid: test used Go 1.23 while build/lint used Go 1.26. Fixed by changing the test matrix to Go 1.26.
- Skipped changing build/lint to Go 1.23 because that is broader than the finding and the existing build/lint jobs already validate with Go 1.26.

## Validation
- git diff --check
- go test -race ./... in envdrift-agent using local Go 1.23
- GitHub Actions will validate the exact Go 1.26 CI setup on this PR

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Go `1.26` to the test matrix alongside `1.23`, so the `test` job now covers both versions and aligns with the fixed `1.26` used in `build` and `lint`. The one minor issue is that the coverage upload condition was not updated: both ubuntu-latest runs now satisfy `matrix.os == 'ubuntu-latest'`, causing duplicate Codecov uploads with identical `name`/`flags`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a one-line CI matrix expansion with only a minor coverage-upload duplication concern.

Only P2 findings are present; the duplicate Codecov upload won't break CI or correctness, so the score remains at 5.

.github/workflows/agent-ci.yml — coverage upload condition should be tightened after expanding the Go matrix.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/agent-ci.yml | Adds Go 1.26 alongside 1.23 in the test matrix to match build/lint jobs; coverage upload condition not updated to guard against duplicate Codecov uploads. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[push / pull_request] --> B[test matrix\nos × go]

    subgraph matrix["Test Matrix (6 jobs)"]
        B --> C1["ubuntu-latest + 1.23"]
        B --> C2["ubuntu-latest + 1.26"]
        B --> C3["macos-latest + 1.23"]
        B --> C4["macos-latest + 1.26"]
        B --> C5["windows-latest + 1.23"]
        B --> C6["windows-latest + 1.26"]
    end

    C1 -->|"os==ubuntu ✓"| U1["Upload coverage ⚠️"]
    C2 -->|"os==ubuntu ✓"| U2["Upload coverage ⚠️"]
    C3 -->|"os!=ubuntu ✗"| SKIP1[Skip]
    C4 -->|"os!=ubuntu ✗"| SKIP2[Skip]
    C5 -->|"os!=ubuntu ✗"| SKIP3[Skip]
    C6 -->|"os!=ubuntu ✗"| SKIP4[Skip]

    U1 -->|"same name+flags"| CC["Codecov\nduplicate uploads"]
    U2 -->|"same name+flags"| CC

    matrix --> BUILD["build job\nGo 1.26 fixed"]
    BUILD --> INT["integration tests\nLinux / macOS / Windows"]
    BUILD --> LINT["lint job\nGo 1.26 fixed"]
```

<sub>Reviews (2): Last reviewed commit: ["ci: align agent go version"](https://github.com/jainal09/envdrift/commit/d9ec8dfdc99e77dc3a2c2acd7e04d8b47cd40884) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30779609)</sub>

<!-- /greptile_comment -->