### PR TITLE
fix(diff): normalize trivially-equivalent values before comparing (#251)

### DIFF
--- a/docs/cli/diff.md
+++ b/docs/cli/diff.md
@@ -78,6 +78,41 @@ Include variables that are identical in both files.
 envdrift diff .env.dev .env.prod --include-unchanged
 ```
 
+### `--normalize`, `--strict`
+
+Normalize values before comparing so trivially-equivalent strings don't show up
+as drift. Enabled by default; pass `--strict` to fall back to raw string compare.
+
+When `--normalize` is in effect, two values are considered equal if:
+
+- they match after stripping leading/trailing whitespace
+  (`DATABASE_URL="foo "` vs `DATABASE_URL=foo`),
+- both look like booleans (`true|false|yes|no|on|off|1|0`, any case) and share
+  the same truthiness (`DEBUG=true` vs `DEBUG=True`), or
+- both look like JSON lists/objects and parse to the same structure, regardless
+  of single- vs double-quote style
+  (`CORS_ORIGINS=["http://x"]` vs `CORS_ORIGINS=['http://x']`).
+
+When `--schema` is also passed, each value is additionally coerced through the
+matching Pydantic field type (`bool`, `int`, `list[str]`, `Literal[...]`, etc.)
+before comparison. Variables not in the schema, or values that fail Pydantic
+validation, fall back to the universal rules above.
+
+```bash
+# Default — normalization on
+envdrift diff .env.dev .env.prod
+
+# Disable normalization for strict raw-string compare
+envdrift diff .env.dev .env.prod --strict
+
+# Schema-aware coercion plus normalization
+envdrift diff .env.dev .env.prod --schema config.settings:Settings
+```
+
+Displayed values are always the original ones from the file — normalization
+only affects the `changed` / `unchanged` classification, never what you see in
+the table or JSON output.
+
 ## Examples
 
 ### Basic Comparison

--- a/docs/cli/diff.md
+++ b/docs/cli/diff.md
@@ -152,31 +152,30 @@ Output:
 
 ```json
 {
-  "env1_path": ".env.development",
-  "env2_path": ".env.production",
-  "has_drift": true,
-  "differences": [
-    {
-      "name": "DEBUG",
-      "diff_type": "changed",
-      "value1": "true",
-      "value2": "false",
-      "is_sensitive": false
-    },
-    {
-      "name": "SENTRY_DSN",
-      "diff_type": "added",
-      "value1": null,
-      "value2": "https://...",
-      "is_sensitive": true
-    }
-  ],
+  "env1": ".env.development",
+  "env2": ".env.production",
   "summary": {
     "added": 1,
     "removed": 1,
     "changed": 2,
-    "unchanged": 5
-  }
+    "has_drift": true
+  },
+  "differences": [
+    {
+      "name": "DEBUG",
+      "type": "changed",
+      "value_env1": "true",
+      "value_env2": "false",
+      "sensitive": false
+    },
+    {
+      "name": "SENTRY_DSN",
+      "type": "added",
+      "value_env1": null,
+      "value_env2": "https://...",
+      "sensitive": true
+    }
+  ]
 }
 ```
 

--- a/src/envdrift/cli_commands/diff.py
+++ b/src/envdrift/cli_commands/diff.py
@@ -34,6 +34,17 @@ def diff(
     include_unchanged: Annotated[
         bool, typer.Option("--include-unchanged", help="Include unchanged variables")
     ] = False,
+    normalize: Annotated[
+        bool,
+        typer.Option(
+            "--normalize/--strict",
+            help=(
+                "Normalize values (whitespace, bool casing, JSON quote style) and "
+                "use --schema types for comparison. Disable with --strict for "
+                "raw string compare."
+            ),
+        ),
+    ] = True,
 ) -> None:
     """
     Compare two .env files and display their differences.
@@ -46,6 +57,7 @@ def diff(
         show_values (bool): If True, do not mask sensitive values in the output.
         format_ (str): Output format, either "table" (default) for human-readable output or "json" for machine-readable output.
         include_unchanged (bool): If True, include variables that are unchanged between the two files in the output.
+        normalize (bool): If True (default), normalize values before comparing — strips leading/trailing whitespace, treats `true/True/TRUE` (and similar bool aliases) as equal, and parses JSON-style lists/dicts so quote-style differences don't read as drift. When a `--schema` is provided, values are also coerced through the corresponding Pydantic type before comparison. Pass `--strict` to disable and fall back to raw string compare.
     """
     # Check files exist
     if not env1.exists():
@@ -82,6 +94,7 @@ def diff(
         schema=schema_meta,
         mask_values=not show_values,
         include_unchanged=include_unchanged,
+        normalize=normalize,
     )
 
     # Output

--- a/src/envdrift/core/diff.py
+++ b/src/envdrift/core/diff.py
@@ -2,12 +2,21 @@
 
 from __future__ import annotations
 
+import ast
+import json
+import re
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
+from typing import Any
+
+from pydantic import TypeAdapter, ValidationError
 
 from envdrift.core.parser import EnvFile
-from envdrift.core.schema import SchemaMetadata
+from envdrift.core.schema import FieldMetadata, SchemaMetadata
+
+_BOOL_RE = re.compile(r"^(true|false|yes|no|on|off|1|0)$", re.IGNORECASE)
+_BOOL_TRUTHY = {"true", "yes", "on", "1"}
 
 
 class DiffType(Enum):
@@ -130,6 +139,7 @@ class DiffEngine:
         schema: SchemaMetadata | None = None,
         mask_values: bool = True,
         include_unchanged: bool = False,
+        normalize: bool = True,
     ) -> DiffResult:
         """
         Compute differences between two environment files and return a structured DiffResult.
@@ -137,9 +147,10 @@ class DiffEngine:
         Parameters:
             env1 (EnvFile): First environment file (left-hand side of comparison).
             env2 (EnvFile): Second environment file (right-hand side of comparison).
-            schema (SchemaMetadata | None): Optional schema used to identify sensitive fields.
+            schema (SchemaMetadata | None): Optional schema used to identify sensitive fields and (when ``normalize`` is True) to coerce values via Pydantic before comparison.
             mask_values (bool): If True, sensitive variable values are replaced with a mask in the result.
             include_unchanged (bool): If True, variables with identical values in both files are included.
+            normalize (bool): If True (default), apply universal normalization (whitespace, bool casing, JSON quote style) and, when ``schema`` is provided, coerce values through the field's Pydantic type before comparison. Set to False for raw string comparison (the ``--strict`` CLI mode).
 
         Returns:
             DiffResult: Aggregated comparison result containing a list of VarDiff entries and summary counts.
@@ -151,6 +162,7 @@ class DiffEngine:
 
         all_vars = env1_vars | env2_vars
         sensitive_fields = set(schema.sensitive_fields) if schema else set()
+        adapter_cache: dict[Any, TypeAdapter[Any]] = {}
 
         for var_name in sorted(all_vars):
             in_env1 = var_name in env1_vars
@@ -171,12 +183,14 @@ class DiffEngine:
                 display_value1 = value1
                 display_value2 = value2
 
+            field_meta = schema.fields.get(var_name) if schema else None
+
             # Determine diff type
             if not in_env1 and in_env2:
                 diff_type = DiffType.ADDED
             elif in_env1 and not in_env2:
                 diff_type = DiffType.REMOVED
-            elif value1 != value2:
+            elif not self._values_equal(value1, value2, field_meta, normalize, adapter_cache):
                 diff_type = DiffType.CHANGED
             else:
                 diff_type = DiffType.UNCHANGED
@@ -196,6 +210,71 @@ class DiffEngine:
             result.differences.append(var_diff)
 
         return result
+
+    def _values_equal(
+        self,
+        value1: str | None,
+        value2: str | None,
+        field_meta: FieldMetadata | None,
+        normalize: bool,
+        adapter_cache: dict[Any, TypeAdapter[Any]],
+    ) -> bool:
+        """Compare two parsed env values, optionally with schema/universal normalization."""
+        if not normalize:
+            return value1 == value2
+
+        if value1 is None or value2 is None:
+            return value1 == value2
+
+        # Layer 2: schema-aware coercion via Pydantic.
+        if field_meta is not None and field_meta.field_type is not None:
+            try:
+                adapter = adapter_cache.get(field_meta.field_type)
+                if adapter is None:
+                    adapter = TypeAdapter(field_meta.field_type)
+                    adapter_cache[field_meta.field_type] = adapter
+                coerced1 = adapter.validate_python(value1)
+                coerced2 = adapter.validate_python(value2)
+            except (ValidationError, TypeError, ValueError):
+                pass
+            else:
+                return coerced1 == coerced2
+
+        # Layer 1: universal normalization.
+        stripped1 = value1.strip()
+        stripped2 = value2.strip()
+        if stripped1 == stripped2:
+            return True
+
+        if _BOOL_RE.match(stripped1) and _BOOL_RE.match(stripped2):
+            return (stripped1.lower() in _BOOL_TRUTHY) == (stripped2.lower() in _BOOL_TRUTHY)
+
+        if self._looks_like_json_collection(stripped1) and self._looks_like_json_collection(
+            stripped2
+        ):
+            parsed1 = self._loose_parse(stripped1)
+            parsed2 = self._loose_parse(stripped2)
+            if parsed1 is not None and parsed2 is not None:
+                return parsed1 == parsed2
+
+        return False
+
+    @staticmethod
+    def _looks_like_json_collection(value: str) -> bool:
+        """True when the value starts with a list/object opener."""
+        return value.startswith(("[", "{"))
+
+    @staticmethod
+    def _loose_parse(value: str) -> Any:
+        """Parse JSON-ish values, accepting both JSON and Python-literal quote styles."""
+        try:
+            return json.loads(value)
+        except ValueError:
+            pass
+        try:
+            return ast.literal_eval(value)
+        except (ValueError, SyntaxError):
+            return None
 
     def to_dict(self, result: DiffResult) -> dict:
         """

--- a/src/envdrift/core/diff.py
+++ b/src/envdrift/core/diff.py
@@ -226,21 +226,36 @@ class DiffEngine:
         if value1 is None or value2 is None:
             return value1 == value2
 
-        # Layer 2: schema-aware coercion via Pydantic.
-        if field_meta is not None and field_meta.field_type is not None:
+        # Schema-aware coercion via Pydantic, when the field's type carries
+        # meaningful semantics (skip `Any` / `None` — those just round-trip the
+        # raw string and would defeat the universal layer below). We use
+        # `validate_strings` rather than `validate_python` because env values
+        # arrive as raw strings: that's the Pydantic v2 API for env-source
+        # inputs and it parses JSON for list/dict/etc. types correctly.
+        # On success-and-equal we short-circuit; otherwise we fall through to
+        # the universal layer so `str` fields still benefit from whitespace
+        # and bool normalization.
+        if (
+            field_meta is not None
+            and field_meta.field_type is not None
+            and field_meta.field_type is not Any
+        ):
             try:
                 adapter = adapter_cache.get(field_meta.field_type)
                 if adapter is None:
                     adapter = TypeAdapter(field_meta.field_type)
                     adapter_cache[field_meta.field_type] = adapter
-                coerced1 = adapter.validate_python(value1)
-                coerced2 = adapter.validate_python(value2)
+                coerced1 = adapter.validate_strings(value1)
+                coerced2 = adapter.validate_strings(value2)
             except (ValidationError, TypeError, ValueError):
                 pass
             else:
-                return coerced1 == coerced2
+                if coerced1 == coerced2:
+                    return True
 
-        # Layer 1: universal normalization.
+        # Universal normalization fallback (also runs for `str` / `Any` /
+        # unknown-field cases): strip, then bool-alias truthiness, then
+        # JSON-or-Python-literal structural equality for list/dict values.
         stripped1 = value1.strip()
         stripped2 = value2.strip()
         if stripped1 == stripped2:
@@ -266,14 +281,19 @@ class DiffEngine:
 
     @staticmethod
     def _loose_parse(value: str) -> Any:
-        """Parse JSON-ish values, accepting both JSON and Python-literal quote styles."""
+        """Parse JSON-ish values, accepting both JSON and Python-literal quote styles.
+
+        Returns ``None`` for anything we can't safely parse — including
+        adversarial inputs that trip the recursion limit or run out of memory,
+        so a malformed `.env` value can never crash the diff.
+        """
         try:
             return json.loads(value)
-        except ValueError:
+        except (ValueError, RecursionError, MemoryError):
             pass
         try:
             return ast.literal_eval(value)
-        except (ValueError, SyntaxError):
+        except (ValueError, SyntaxError, RecursionError, MemoryError):
             return None
 
     def to_dict(self, result: DiffResult) -> dict:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -90,6 +90,52 @@ def test_diff_json_format(tmp_path) -> None:
     assert "differences" in result.stdout
 
 
+def test_diff_env1_missing(tmp_path) -> None:
+    """Diff reports the first file when only env2 exists."""
+    env2 = tmp_path / ".env2"
+    env2.write_text("FOO=bar")
+
+    result = runner.invoke(app, ["diff", str(tmp_path / "missing.env"), str(env2)])
+    assert result.exit_code == 1
+    assert "not found" in result.stdout.lower()
+
+
+def test_diff_normalize_default_collapses_bool_casing(tmp_path) -> None:
+    """Default --normalize hides trivial bool-casing drift."""
+    env1 = tmp_path / ".env1"
+    env1.write_text("DEBUG=true")
+    env2 = tmp_path / ".env2"
+    env2.write_text("DEBUG=True")
+
+    result = runner.invoke(app, ["diff", str(env1), str(env2), "--format", "json"])
+    assert result.exit_code == 0
+    assert '"has_drift": false' in result.stdout
+
+
+def test_diff_strict_flag_disables_normalization(tmp_path) -> None:
+    """`--strict` restores raw string compare so bool casing reads as drift."""
+    env1 = tmp_path / ".env1"
+    env1.write_text("DEBUG=true")
+    env2 = tmp_path / ".env2"
+    env2.write_text("DEBUG=True")
+
+    result = runner.invoke(app, ["diff", str(env1), str(env2), "--strict", "--format", "json"])
+    assert result.exit_code == 0
+    assert '"has_drift": true' in result.stdout
+
+
+def test_diff_schema_load_error_warns_and_continues(tmp_path) -> None:
+    """An unloadable --schema warns but still runs the comparison."""
+    env1 = tmp_path / ".env1"
+    env1.write_text("FOO=bar")
+    env2 = tmp_path / ".env2"
+    env2.write_text("FOO=bar")
+
+    result = runner.invoke(app, ["diff", str(env1), str(env2), "--schema", "does.not.exist:Nope"])
+    assert result.exit_code == 0
+    assert "could not load schema" in result.stdout.lower()
+
+
 def test_encrypt_check_file_not_found(tmp_path) -> None:
     """Test encrypt --check with missing file."""
     result = runner.invoke(app, ["encrypt", str(tmp_path / "nonexistent.env"), "--check"])

--- a/tests/unit/test_diff.py
+++ b/tests/unit/test_diff.py
@@ -298,10 +298,27 @@ class TestDiffSchemaAwareNormalization:
         result = self._diff(
             tmp_path,
             'CORS_ORIGINS=["http://x", "http://y"]\n',
+            'CORS_ORIGINS=["http://x", "http://y"]\n',
+            self._schema(Schema),
+        )
+        # validate_strings parses both JSON strings into list[str] → equal.
+        assert result.changed_count == 0
+
+    def test_list_field_order_difference_still_reports_drift(self, tmp_path):
+        from pydantic_settings import BaseSettings, SettingsConfigDict
+
+        class Schema(BaseSettings):
+            model_config = SettingsConfigDict(extra="ignore")
+            CORS_ORIGINS: list[str]
+
+        result = self._diff(
+            tmp_path,
+            'CORS_ORIGINS=["http://x", "http://y"]\n',
             'CORS_ORIGINS=["http://y", "http://x"]\n',
             self._schema(Schema),
         )
-        # Same elements but Pydantic preserves order for list[str] → still drift.
+        # Pydantic preserves list order; universal-layer JSON fallback also
+        # sees ordered lists. Different order → still drift.
         assert result.changed_count == 1
 
     def test_schema_coercion_falls_back_when_validation_fails(self, tmp_path):
@@ -315,3 +332,46 @@ class TestDiffSchemaAwareNormalization:
         # and ultimately raw string compare. Different strings → CHANGED.
         result = self._diff(tmp_path, "PORT=abc\n", "PORT=def\n", self._schema(Schema))
         assert result.changed_count == 1
+
+    def test_str_field_still_runs_universal_normalization(self, tmp_path):
+        """A `str` field would round-trip through validate_strings unchanged,
+        but the universal layer must still collapse `foo ` vs `foo`."""
+        from pydantic_settings import BaseSettings, SettingsConfigDict
+
+        class Schema(BaseSettings):
+            model_config = SettingsConfigDict(extra="ignore")
+            DATABASE_URL: str
+
+        result = self._diff(
+            tmp_path,
+            'DATABASE_URL="foo "\n',
+            "DATABASE_URL=foo\n",
+            self._schema(Schema),
+        )
+        assert result.changed_count == 0
+
+    def test_str_field_bool_casing_still_normalized(self, tmp_path):
+        """A `str`-typed bool-looking value should still normalize under the
+        universal layer — schema coercion must not short-circuit it."""
+        from pydantic_settings import BaseSettings, SettingsConfigDict
+
+        class Schema(BaseSettings):
+            model_config = SettingsConfigDict(extra="ignore")
+            FLAG: str
+
+        result = self._diff(tmp_path, "FLAG=true\n", "FLAG=True\n", self._schema(Schema))
+        assert result.changed_count == 0
+
+    def test_any_field_skips_schema_coercion(self, tmp_path):
+        """`Any`-typed fields must skip schema coercion entirely (TypeAdapter(Any)
+        is an identity check) so the universal layer can normalize them."""
+        from typing import Any as AnyType
+
+        from pydantic_settings import BaseSettings, SettingsConfigDict
+
+        class Schema(BaseSettings):
+            model_config = SettingsConfigDict(extra="ignore")
+            DEBUG: AnyType = None
+
+        result = self._diff(tmp_path, "DEBUG=true\n", "DEBUG=True\n", self._schema(Schema))
+        assert result.changed_count == 0

--- a/tests/unit/test_diff.py
+++ b/tests/unit/test_diff.py
@@ -169,3 +169,149 @@ class TestDiffEngine:
         assert len(result.get_added()) == result.added_count
         assert len(result.get_removed()) == result.removed_count
         assert len(result.get_changed()) == result.changed_count
+
+
+class TestDiffNormalization:
+    """Normalization-driven equality (issue #251)."""
+
+    @staticmethod
+    def _diff(tmp_path, content1, content2, **kwargs):
+        env1_file = tmp_path / ".env1"
+        env1_file.write_text(content1)
+        env2_file = tmp_path / ".env2"
+        env2_file.write_text(content2)
+        parser = EnvParser()
+        env1 = parser.parse(env1_file)
+        env2 = parser.parse(env2_file)
+        return DiffEngine().diff(env1, env2, mask_values=False, **kwargs)
+
+    def test_inside_quote_whitespace_is_equal(self, tmp_path):
+        """`DATABASE_URL="foo "` vs `DATABASE_URL=foo` no longer reports drift."""
+        result = self._diff(tmp_path, 'DATABASE_URL="foo "\n', "DATABASE_URL=foo\n")
+        assert result.changed_count == 0
+
+    def test_bool_casing_is_equal(self, tmp_path):
+        """`DEBUG=true` vs `DEBUG=True` is unchanged under normalization."""
+        result = self._diff(tmp_path, "DEBUG=true\n", "DEBUG=True\n")
+        assert result.changed_count == 0
+
+    def test_bool_aliases_are_equal(self, tmp_path):
+        """Bool aliases (yes/on/1) collapse under the same canonical truthiness."""
+        result = self._diff(tmp_path, "FEATURE=yes\n", "FEATURE=on\n")
+        assert result.changed_count == 0
+
+    def test_bool_opposites_still_differ(self, tmp_path):
+        """Normalization must not collapse semantically opposite bool values."""
+        result = self._diff(tmp_path, "DEBUG=true\n", "DEBUG=false\n")
+        assert result.changed_count == 1
+
+    def test_json_list_quote_style_is_equal(self, tmp_path):
+        """JSON-equivalent lists with different quote styles compare equal."""
+        result = self._diff(
+            tmp_path,
+            'CORS_ORIGINS=["http://x"]\n',
+            "CORS_ORIGINS=['http://x']\n",
+        )
+        assert result.changed_count == 0
+
+    def test_json_object_quote_style_is_equal(self, tmp_path):
+        """Object/dict equivalents with different quote styles compare equal."""
+        # env1: '{"a": 1}' (JSON-quoted, parser strips outer single quotes).
+        # env2: {'a': 1}  (Python-literal style, no outer quote pair).
+        result = self._diff(
+            tmp_path,
+            "TAGS='{\"a\": 1}'\n",
+            "TAGS={'a': 1}\n",
+        )
+        assert result.changed_count == 0
+
+    def test_case_difference_without_schema_still_reports(self, tmp_path):
+        """Without schema, free-form case differences must remain CHANGED."""
+        result = self._diff(tmp_path, "LOG_LEVEL=warning\n", "LOG_LEVEL=WARNING\n")
+        assert result.changed_count == 1
+
+    def test_strict_mode_disables_normalization(self, tmp_path):
+        """`normalize=False` (the --strict flag) preserves legacy raw compare."""
+        result = self._diff(
+            tmp_path,
+            "DEBUG=true\nCORS=['http://x']\n",
+            'DEBUG=True\nCORS=["http://x"]\n',
+            normalize=False,
+        )
+        assert result.changed_count == 2
+
+    def test_unparseable_collection_falls_back_to_string(self, tmp_path):
+        """If a value looks like a list but won't parse, fall through to raw compare."""
+        result = self._diff(tmp_path, "RAW=[unterminated\n", "RAW=[different\n")
+        assert result.changed_count == 1
+
+
+class TestDiffSchemaAwareNormalization:
+    """Schema-aware coercion via Pydantic when --schema is passed."""
+
+    @staticmethod
+    def _schema(model_cls):
+        from envdrift.core.schema import SchemaLoader
+
+        return SchemaLoader().extract_metadata(model_cls)
+
+    @staticmethod
+    def _diff(tmp_path, content1, content2, schema):
+        env1_file = tmp_path / ".env1"
+        env1_file.write_text(content1)
+        env2_file = tmp_path / ".env2"
+        env2_file.write_text(content2)
+        parser = EnvParser()
+        env1 = parser.parse(env1_file)
+        env2 = parser.parse(env2_file)
+        return DiffEngine().diff(env1, env2, schema=schema, mask_values=False)
+
+    def test_bool_field_coerces_via_schema(self, tmp_path):
+        from pydantic_settings import BaseSettings, SettingsConfigDict
+
+        class Schema(BaseSettings):
+            model_config = SettingsConfigDict(extra="ignore")
+            DEBUG: bool
+
+        result = self._diff(tmp_path, "DEBUG=1\n", "DEBUG=true\n", self._schema(Schema))
+        assert result.changed_count == 0
+
+    def test_int_field_coerces_quoted_vs_unquoted(self, tmp_path):
+        from pydantic_settings import BaseSettings, SettingsConfigDict
+
+        class Schema(BaseSettings):
+            model_config = SettingsConfigDict(extra="ignore")
+            PORT: int
+
+        # Parser already strips outer quotes, so this also exercises that bytes
+        # like "8000 " (inside-quote trailing space) coerce to the same int.
+        result = self._diff(tmp_path, 'PORT="8000 "\n', "PORT=8000\n", self._schema(Schema))
+        assert result.changed_count == 0
+
+    def test_list_field_coerces_json_variants(self, tmp_path):
+        from pydantic_settings import BaseSettings, SettingsConfigDict
+
+        class Schema(BaseSettings):
+            model_config = SettingsConfigDict(extra="ignore")
+            CORS_ORIGINS: list[str]
+
+        result = self._diff(
+            tmp_path,
+            'CORS_ORIGINS=["http://x", "http://y"]\n',
+            'CORS_ORIGINS=["http://y", "http://x"]\n',
+            self._schema(Schema),
+        )
+        # Same elements but Pydantic preserves order for list[str] → still drift.
+        assert result.changed_count == 1
+
+    def test_schema_coercion_falls_back_when_validation_fails(self, tmp_path):
+        from pydantic_settings import BaseSettings, SettingsConfigDict
+
+        class Schema(BaseSettings):
+            model_config = SettingsConfigDict(extra="ignore")
+            PORT: int
+
+        # Neither value coerces to int — must fall through to universal layer
+        # and ultimately raw string compare. Different strings → CHANGED.
+        result = self._diff(tmp_path, "PORT=abc\n", "PORT=def\n", self._schema(Schema))
+        assert result.changed_count == 1


### PR DESCRIPTION
## Summary

- Stops `envdrift diff` from reporting false-positive `CHANGED` rows for values that consumers (Pydantic, dotenv, shell) treat as identical — fixes #251.
- Adds two layered comparison strategies in `DiffEngine.diff()`, both enabled by default:
  - **Universal normalization** — strip surrounding whitespace, collapse bool aliases (`true|True|yes|on|1`…) by canonical truthiness, and parse JSON-ish list/object values so quote-style differences (`["x"]` vs `['x']`) compare equal.
  - **Schema-aware coercion** — when `--schema` is passed, coerce both values through the field's Pydantic type (`bool`, `int`, `list[str]`, `Literal[...]`, …) before comparing. Variables outside the schema or values that fail validation fall back to the universal layer.
- New `--normalize/--strict` flag opts out (`--strict` restores raw string compare).
- Displayed values are untouched — normalization only affects classification, never the values shown in the table or JSON output.

## Test plan

- [x] `uv run pytest tests/unit/test_diff.py tests/test_cli.py` — 46 passed, including 13 new normalization/schema tests and 4 new CLI tests
- [x] Full suite: `uv run pytest` — 1693 passed, 43 skipped, no regressions
- [x] Coverage on touched files: `core/diff.py` 99%, `cli_commands/diff.py` 91% (both ≥80%)
- [x] Lint+format+type: pre-commit hooks pass (`ruff check`, `ruff format`, `pyrefly check`)
- [x] Manual CLI smoke:
  ```bash
  printf 'DEBUG=true\nCORS=["http://x"]\n' > /tmp/a.env
  printf "DEBUG=True\nCORS=['http://x']\n"  > /tmp/b.env
  envdrift diff /tmp/a.env /tmp/b.env             # → no drift
  envdrift diff /tmp/a.env /tmp/b.env --strict    # → drift on both
  ```

Closes #251.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--normalize` (default) and `--strict` flags to `envdrift diff`. Normalization treats formatting variants—whitespace, boolean casing, JSON structure—as equivalent values.

* **Documentation**
  * Updated documentation for new normalization options in the `diff` command.

* **Tests**
  * Expanded test coverage for normalization behaviors and CLI edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jainal09/envdrift/pull/252?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a two-layer value normalization strategy to `envdrift diff` that suppresses false-positive `CHANGED` rows for values consumers treat as equivalent. A new `--normalize/--strict` CLI flag (normalize on by default) controls the feature.

- **Universal normalization** strips surrounding whitespace, collapses bool aliases (`true/True/yes/on/1` → same truthiness) and parses JSON-ish list/dict values with single- or double-quote styles via a `json.loads` → `ast.literal_eval` fallback chain.
- **Schema-aware coercion** (when `--schema` is provided) runs `TypeAdapter(field_type).validate_strings()` first; on success it short-circuits; on failure or inequality it falls through to the universal layer, ensuring `str`-typed fields still benefit from whitespace and bool normalization.
- The `adapter_cache` dict avoids recreating `TypeAdapter` instances on every variable, and `_loose_parse` guards against `RecursionError`/`MemoryError` from adversarial `.env` inputs.

<h3>Confidence Score: 5/5</h3>

Safe to merge; normalization is opt-out via --strict, display values are untouched, and the schema coercion path correctly uses validate_strings for env-source inputs.

The normalization logic is well-layered: schema coercion falls through to the universal layer on failure rather than masking drift, and the universal layer's bool/JSON checks are guarded by explicit pattern matches. The one edge case — a non-bool schema field whose coercion fails but whose valid value shares a bool-alias truthiness with an invalid sibling (e.g., PORT=0 vs PORT=false) — only fires for already-invalid env values that would fail Pydantic validation at runtime, making real-world impact negligible.

src/envdrift/core/diff.py — specifically the interaction between the schema-coercion fallthrough and the universal bool-alias check at lines 264–265.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/envdrift/core/diff.py | Core diff engine gains _values_equal, _looks_like_json_collection, and _loose_parse helpers; the main diff loop now delegates value comparison to this method via normalize + adapter_cache. One subtle false-negative edge case exists in the boolean-alias universal layer for non-bool schema fields. |
| src/envdrift/cli_commands/diff.py | Adds --normalize/--strict Typer boolean flag (default True) and threads it through to DiffEngine.diff(). No issues found. |
| tests/unit/test_diff.py | Adds two new test classes covering universal normalization and schema-aware coercion paths; tests are well-scoped and cover key edge cases including strict mode, unparseable values, and Any-typed fields. |
| tests/test_cli.py | Adds four new CLI-level tests covering missing-file error, default normalize, --strict flag, and schema-load-error graceful degradation. All are well-targeted. |
| docs/cli/diff.md | Adds --normalize/--strict documentation and updates the JSON output example to match the current serialization format (previously outdated). No issues. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["_values_equal(v1, v2, field_meta, normalize, cache)"] --> B{normalize?}
    B -- No --> C["return v1 == v2 (raw)"]
    B -- Yes --> D{either None?}
    D -- Yes --> E["return v1 == v2"]
    D -- No --> F{field_meta set and type != Any?}
    F -- Yes --> G["TypeAdapter.validate_strings(v1, v2)"]
    G --> H{coercion succeeded?}
    H -- "No / Exception" --> I["Universal layer"]
    H -- "Yes, equal" --> J["return True"]
    H -- "Yes, not equal" --> I
    F -- No --> I
    I --> K{stripped1 == stripped2?}
    K -- Yes --> L["return True"]
    K -- No --> M{both match bool regex?}
    M -- Yes --> N["return same_truthiness(v1, v2)"]
    M -- No --> O{both start with list or dict opener?}
    O -- No --> P["return False"]
    O -- Yes --> Q["_loose_parse via JSON then ast.literal_eval"]
    Q --> R{both parsed successfully?}
    R -- Yes --> S["return parsed1 == parsed2"]
    R -- No --> P
```

<sub>Reviews (2): Last reviewed commit: ["fix(diff): address PR review — use valid..."](https://github.com/jainal09/envdrift/commit/508dbd93b3928c2678c599638f2e6654182e1eee) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32833841)</sub>

<!-- /greptile_comment -->