### PR TITLE
chore(deps): bump pyrefly to v1.0 stable (#253)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ docs = ["mkdocs-material>=9.5"]
 # Development dependencies
 dev = [
     "ruff>=0.8.0",
-    "pyrefly>=0.2.0",
+    "pyrefly>=1.0,<2",
     "bandit>=1.7.0",
     "pytest>=8.0",
     "pytest-cov>=4.0",
@@ -191,6 +191,12 @@ exclude_lines = [
 [tool.bandit]
 exclude_dirs = ["tests", ".venv"]
 skips = ["B101", "B110"]  # assert usage and try-except-pass are controlled
+
+[tool.pyrefly]
+project-includes = [
+    "**/*.py*",
+    "**/*.ipynb",
+]
 
 [dependency-groups]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,10 +193,11 @@ exclude_dirs = ["tests", ".venv"]
 skips = ["B101", "B110"]  # assert usage and try-except-pass are controlled
 
 [tool.pyrefly]
-project-includes = [
-    "**/*.py*",
-    "**/*.ipynb",
-]
+# Scope reflects what CI / Makefile / pre-commit actually check today
+# (they pass `src` as a positional argument, which overrides this block,
+# but having it makes pyrefly stop emitting the "No pyrefly.toml found"
+# notice on every run). Broadening to also check `tests/` is tracked in #256.
+project-includes = ["src/**/*.py"]
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
## Summary

- Bumps `pyrefly` floor from `>=0.2.0` → `>=1.0,<2` to pick up the stable v1.0 release.
- Adds a minimal `[tool.pyrefly] project-includes = ["src/**/*.py"]` matching what CI/Makefile/pre-commit actually check today (each passes an explicit `src` positional argument, which overrides any broader `project-includes`). Without a `[tool.pyrefly]` block, pyrefly 1.0 prints a `"No pyrefly.toml found"` notice on every run — having the block silences it.
- Broadening pyrefly's coverage to also check `tests/` (which would surface ~98 pre-existing test-file errors that need baselining) is tracked separately in **#256**.

## What changed vs the original version of this PR

Earlier this PR set `project-includes = ["**/*.py*", "**/*.ipynb"]` and the description claimed "98 vs 107 errors" coverage parity. PR review feedback (Copilot + greptile) correctly pointed out that the broad pattern was bypassed by every automated invocation, so the comparison only reflected manual `pyrefly check` runs, not CI behavior. The config is now scoped to match what actually runs.

## Coverage reality

| | 0.45 (baseline) | 1.0 (this PR) |
|---|---|---|
| `pyrefly check src` (CI/Makefile/pre-commit) | 0 errors | 0 errors |
| `pyrefly check` (no args, manual) | 107 errors (all in `tests/`) | 98 errors (all in `tests/`) — N/A here, see #256 |

Automated coverage is unchanged. The version bump alone is the user-visible change.

## Renovate note

Renovate's `config:recommended` extends `pep621`, so it would have eventually opened a Renovate PR for `0.45 → 1.0` on the next weekend run (labeled `major-version-bump`, no automerge). It would **not** have caught the silent preset-default change — pyrefly 1.0 ships a much narrower `basic` preset when no `[tool.pyrefly]` block exists, which makes manual `pyrefly check` quietly stop checking most files (4 errors instead of 107). The explicit `[tool.pyrefly]` block in this PR prevents that surprise.

## Test plan

- [x] `uv run pyrefly check src` — 0 errors
- [x] `make typecheck` — 0 errors
- [x] `uv run pre-commit run pyrefly-check --all-files` — Passed
- [x] `uv run pytest` — 1697 passed, 43 skipped, no regressions

Closes #253. Follow-up: #256.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps `pyrefly` to the stable v1.0 release (`>=1.0,<2`) and adds a minimal `[tool.pyrefly]` configuration block. A previous iteration of the config used broader patterns (`**/*.py*`, `**/*.ipynb`) that were narrowed and corrected in response to prior review feedback; the committed config scopes to `src/**/*.py` and an inline comment explicitly acknowledges the CI/pre-commit `src`-argument override.

- **Dependency bump**: `pyrefly>=0.2.0` → `>=1.0,<2`; the `<2` upper bound guards against a future breaking major release.
- **Pyrefly config**: Adds `[tool.pyrefly]` with `project-includes = ["src/**/*.py"]`, primarily to suppress the "No pyrefly.toml found" notice; the comment correctly documents that automated checks pass `src` directly and therefore override this block.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a two-line dependency version bump plus a self-documented config block that has no effect on automated checks.

The only code change is a version constraint update and a new [tool.pyrefly] block whose scope and behavior are accurately described in an inline comment. Previous review concerns about notebook glob patterns and config bypass have been resolved in this version of the PR.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| pyproject.toml | Bumps pyrefly from >=0.2.0 to >=1.0,<2 and adds a [tool.pyrefly] config block scoped to src/**/*.py with an inline comment acknowledging that CI/pre-commit explicit src arguments override this block. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(pyrefly): scope project-includes to ..."](https://github.com/jainal09/envdrift/commit/5734c36051fdae51c02a8fdd3465097d472df0e1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32843318)</sub>

<!-- /greptile_comment -->