### PR TITLE
ci(lint): exclude auto-generated CHANGELOG.md from markdownlint

### DIFF
--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -15,3 +15,7 @@ site/
 .pytest_cache/
 .ruff_cache/
 .git/
+
+# Ignore generated changelog (release-please emits single-line entries that
+# routinely exceed MD013's line-length limit; the file is bot-managed).
+CHANGELOG.md

--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ docs-serve:
 lint-docs:
 	@echo "Linting markdown files..."
 	npx markdownlint-cli2 "**/*.md" "!**/node_modules/**" "!.venv/**" "!venv/**" "!.git/**" "!dist/**" "!build/**" "!site/**" "!.pytest_cache/**" \
-	 "!.ruff_cache/**" "!.uv-cache/**"
+	 "!.ruff_cache/**" "!.uv-cache/**" "!**/CHANGELOG.md"
 
 # Clean build artifacts
 clean:


### PR DESCRIPTION
## Summary

- Excludes the auto-generated `CHANGELOG.md` from `make lint-docs` so release-please PRs aren't blocked by MD013 (line-length) violations.
- Updates both the Makefile glob (the mechanism that actually drives ignores under markdownlint-cli2 v0.22.1) and `.markdownlintignore` (for any other markdownlint invocation).

## Why now

PR #254 (the 10.10.1 release) has been failing CI on this exact rule. The same fix was pushed directly onto the release-please branch earlier — release-please force-pushed the branch when PR #255 merged and wiped the commit. Landing the fix on `main` is durable: every future release-please regeneration of its branch inherits it.

The trigger is structural — release-please emits each changelog entry as a single line concatenating issue refs, PR refs, and the full commit-SHA URL, which is routinely 250+ chars vs MD013's 150-char limit. It will recur on every release without this fix.

## Test plan

- [x] Locally: `make lint-docs` excludes CHANGELOG.md and lints 59 file(s); the only remaining error is in an untracked dev file (not present in CI).
- [x] Direct test: `git ls-files "*.md" | grep -v CHANGELOG | xargs npx markdownlint-cli2` → 0 errors across 58 tracked files.

Unblocks #254.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR excludes auto-generated `CHANGELOG.md` from markdownlint to unblock release-please PRs that fail MD013 (line-length) because release-please emits entries as single long lines with multiple issue/PR/SHA refs.

- **`Makefile`**: Appends `\"!**/CHANGELOG.md\"` to the `lint-docs` glob exclusion list so `make lint-docs` skips all changelog files.
- **`.markdownlintignore`**: Adds `CHANGELOG.md` (with a clear comment) for any direct markdownlint invocations outside the Makefile target; the gitignore-style pattern correctly matches the file at any directory depth, consistent with the `**/` glob in the Makefile.

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge — it only modifies CI lint configuration to exclude a bot-managed file from a style rule it will always violate.

Both changes are purely additive exclusions in CI tooling config. The Makefile glob pattern !**/CHANGELOG.md and the .markdownlintignore entry CHANGELOG.md are consistent with each other and correctly scoped. No application logic, build output, or test coverage is affected. The fix is narrow and directly addresses the documented root cause.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .markdownlintignore | Adds CHANGELOG.md to the ignore list with an explanatory comment; pattern correctly follows gitignore semantics and will match CHANGELOG.md anywhere in the tree. |
| Makefile | Appends !**/CHANGELOG.md to the markdownlint-cli2 glob exclusion list in the lint-docs target; consistent with the .markdownlintignore change and correctly scoped to all subdirectories. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[make lint-docs] --> B[npx markdownlint-cli2 **/*.md]
    B --> C{Is file excluded?}
    C -->|node_modules, .venv, .git,\ndist, build, site,\n.pytest_cache, .ruff_cache,\n.uv-cache| D[Skip file]
    C -->|CHANGELOG.md\n NEW exclusion| D
    C -->|All other .md files| E[Lint file]
    E --> F{Pass MD013?}
    F -->|Yes| G[OK]
    F -->|No| H[Fail CI]
```

<sub>Reviews (3): Last reviewed commit: ["ci(lint): exclude auto-generated CHANGEL..."](https://github.com/jainal09/envdrift/commit/1802ecf414d344b3ef42874728cfd15febe537b6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32858278)</sub>

<!-- /greptile_comment -->