### PR TITLE
refactor(tests): replace pyrefly suppressions with real types (#257)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -196,7 +196,6 @@ skips = ["B101", "B110"]  # assert usage and try-except-pass are controlled
 project-includes = ["src/**/*.py", "tests/**/*.py"]
 # Lets `from tests.helpers import ...` and `from tests.integration.conftest ...` resolve.
 search-path = ["."]
-# TODO(#257): clean up pre-existing `# pyrefly: ignore` suppressions in tests/.
 
 [dependency-groups]
 dev = [

--- a/tests/integration/test_error_handling.py
+++ b/tests/integration/test_error_handling.py
@@ -657,5 +657,6 @@ class TestMockVaultTimeouts:
 
         assert len(result.services) == 1
         assert result.services[0].action == SyncAction.ERROR
-        # pyrefly: ignore [missing-attribute]
-        assert "timed out" in result.services[0].error.lower()
+        error_message = result.services[0].error
+        assert error_message is not None
+        assert "timed out" in error_message.lower()

--- a/tests/scanner/test_engine.py
+++ b/tests/scanner/test_engine.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import sys
-import types
 from pathlib import Path
+from types import SimpleNamespace
 
 from envdrift.scanner.base import (
     AggregatedScanResult,
@@ -191,16 +191,14 @@ class TestScanEngine:
                 },
             )
 
-        gitleaks_mod = types.ModuleType("envdrift.scanner.gitleaks")
-        # pyrefly: ignore [missing-attribute]
-        gitleaks_mod.GitleaksScanner = make_scanner("GitleaksScanner", "gitleaks", True)
-        truffle_mod = types.ModuleType("envdrift.scanner.trufflehog")
-        # pyrefly: ignore [missing-attribute]
-        truffle_mod.TrufflehogScanner = make_scanner("TrufflehogScanner", "trufflehog", True)
-        detect_mod = types.ModuleType("envdrift.scanner.detect_secrets")
-        # pyrefly: ignore [missing-attribute]
-        detect_mod.DetectSecretsScanner = make_scanner(
-            "DetectSecretsScanner", "detect-secrets", True
+        gitleaks_mod = SimpleNamespace(
+            GitleaksScanner=make_scanner("GitleaksScanner", "gitleaks", True),
+        )
+        truffle_mod = SimpleNamespace(
+            TrufflehogScanner=make_scanner("TrufflehogScanner", "trufflehog", True),
+        )
+        detect_mod = SimpleNamespace(
+            DetectSecretsScanner=make_scanner("DetectSecretsScanner", "detect-secrets", True),
         )
 
         monkeypatch.setitem(sys.modules, "envdrift.scanner.gitleaks", gitleaks_mod)
@@ -254,9 +252,9 @@ class TestScanEngine:
                 },
             )
 
-        gitleaks_mod = types.ModuleType("envdrift.scanner.gitleaks")
-        # pyrefly: ignore [missing-attribute]
-        gitleaks_mod.GitleaksScanner = make_scanner("GitleaksScanner", "gitleaks")
+        gitleaks_mod = SimpleNamespace(
+            GitleaksScanner=make_scanner("GitleaksScanner", "gitleaks"),
+        )
         monkeypatch.setitem(sys.modules, "envdrift.scanner.gitleaks", gitleaks_mod)
 
         config = GuardConfig(
@@ -306,9 +304,9 @@ class TestScanEngine:
                 },
             )
 
-        gitleaks_mod = types.ModuleType("envdrift.scanner.gitleaks")
-        # pyrefly: ignore [missing-attribute]
-        gitleaks_mod.GitleaksScanner = make_scanner("GitleaksScanner", "gitleaks")
+        gitleaks_mod = SimpleNamespace(
+            GitleaksScanner=make_scanner("GitleaksScanner", "gitleaks"),
+        )
         monkeypatch.setitem(sys.modules, "envdrift.scanner.gitleaks", gitleaks_mod)
 
         config = GuardConfig(

--- a/tests/scanner/test_gitleaks.py
+++ b/tests/scanner/test_gitleaks.py
@@ -518,9 +518,9 @@ class TestGitleaksScanExecution:
                 mock_run.side_effect = subprocess.TimeoutExpired(cmd="gitleaks", timeout=300)
                 result = mock_scanner.scan([tmp_path])
 
-        # pyrefly: ignore [missing-attribute]
-        assert "timed out" in result.error.lower()
         assert result.success is False
+        assert result.error is not None
+        assert "timed out" in result.error.lower()
 
     def test_scan_with_git_history_flag(self, mock_scanner: GitleaksScanner, tmp_path: Path):
         """Test that scan passes correct args for git history scan."""

--- a/tests/scanner/test_infisical.py
+++ b/tests/scanner/test_infisical.py
@@ -405,9 +405,9 @@ class TestInfisicalScanExecution:
                 mock_run.side_effect = subprocess.TimeoutExpired(cmd="infisical", timeout=300)
                 result = mock_scanner.scan([tmp_path])
 
-        # pyrefly: ignore [missing-attribute]
-        assert "timed out" in result.error.lower()
         assert result.success is False
+        assert result.error is not None
+        assert "timed out" in result.error.lower()
 
     def test_scan_handles_nonzero_exit_code(self, mock_scanner: InfisicalScanner, tmp_path: Path):
         """Test that scan handles non-zero exit code with error."""
@@ -421,7 +421,7 @@ class TestInfisicalScanExecution:
                 result = mock_scanner.scan([tmp_path])
 
         assert result.success is False
-        # pyrefly: ignore [missing-attribute]
+        assert result.error is not None
         assert "command failed" in result.error.lower()
 
     def test_scan_uses_source_flag(self, mock_scanner: InfisicalScanner, tmp_path: Path):

--- a/tests/scanner/test_talisman.py
+++ b/tests/scanner/test_talisman.py
@@ -396,9 +396,9 @@ class TestTalismanScanExecution:
                 mock_run.side_effect = subprocess.TimeoutExpired(cmd="talisman", timeout=300)
                 result = mock_scanner.scan([tmp_path])
 
-        # pyrefly: ignore [missing-attribute]
-        assert "timed out" in result.error.lower()
         assert result.success is False
+        assert result.error is not None
+        assert "timed out" in result.error.lower()
 
     def test_scan_handles_execution_failure(self, mock_scanner: TalismanScanner, tmp_path: Path):
         """Test that scan handles subprocess execution failure without report."""

--- a/tests/scanner/test_trivy.py
+++ b/tests/scanner/test_trivy.py
@@ -367,9 +367,9 @@ class TestTrivyScanExecution:
                 mock_run.side_effect = subprocess.TimeoutExpired(cmd="trivy", timeout=300)
                 result = mock_scanner.scan([tmp_path])
 
-        # pyrefly: ignore [missing-attribute]
-        assert "timed out" in result.error.lower()
         assert result.success is False
+        assert result.error is not None
+        assert "timed out" in result.error.lower()
 
     def test_scan_handles_nonzero_exit_code(self, mock_scanner: TrivyScanner, tmp_path: Path):
         """Test that scan handles non-zero exit code with error."""
@@ -383,7 +383,7 @@ class TestTrivyScanExecution:
                 result = mock_scanner.scan([tmp_path])
 
         assert result.success is False
-        # pyrefly: ignore [missing-attribute]
+        assert result.error is not None
         assert "command failed" in result.error.lower()
 
     def test_scan_handles_nonzero_exit_with_output(

--- a/tests/scanner/test_trufflehog.py
+++ b/tests/scanner/test_trufflehog.py
@@ -545,9 +545,9 @@ class TestTrufflehogScanExecution:
                 mock_run.side_effect = subprocess.TimeoutExpired(cmd="trufflehog", timeout=600)
                 result = mock_scanner.scan([tmp_path])
 
-        # pyrefly: ignore [missing-attribute]
-        assert "timed out" in result.error.lower()
         assert result.success is False
+        assert result.error is not None
+        assert "timed out" in result.error.lower()
 
     def test_scan_uses_filesystem_mode(self, mock_scanner: TrufflehogScanner, tmp_path: Path):
         """Test that scan uses filesystem mode by default."""

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -94,7 +94,7 @@ class TestSyncHelpers:
         warnings: list[str] = []
         monkeypatch.setattr(sync_module, "print_warning", lambda msg: warnings.append(msg))
 
-        assert sync_module._normalize_max_workers(cast(int, "bad")) is None
+        assert sync_module._normalize_max_workers(cast(Any, "bad")) is None
         assert sync_module._normalize_max_workers(True) is None
 
         assert any("Invalid max_workers value" in msg for msg in warnings)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -6,6 +6,7 @@ import tomllib
 from pathlib import Path
 from textwrap import dedent
 from types import SimpleNamespace
+from typing import Any, cast
 
 from typer.testing import CliRunner
 
@@ -93,8 +94,7 @@ class TestSyncHelpers:
         warnings: list[str] = []
         monkeypatch.setattr(sync_module, "print_warning", lambda msg: warnings.append(msg))
 
-        # pyrefly: ignore [bad-argument-type]
-        assert sync_module._normalize_max_workers("bad") is None
+        assert sync_module._normalize_max_workers(cast(int, "bad")) is None
         assert sync_module._normalize_max_workers(True) is None
 
         assert any("Invalid max_workers value" in msg for msg in warnings)
@@ -1146,7 +1146,7 @@ class TestVaultVerification:
         env_file.write_text("SECRET=encrypted")
 
         secret_value = SimpleNamespace(value="DOTENV_PRIVATE_KEY_PRODUCTION=vault-key")
-        captured: dict[str, object] = {}
+        captured: dict[str, Any] = {}
 
         class DummyVault:
             def ensure_authenticated(self) -> None:
@@ -1181,7 +1181,6 @@ class TestVaultVerification:
 
         assert result is True
         assert captured["provider"] == "gcp"
-        # pyrefly: ignore [bad-index]
         assert captured["kwargs"]["project_id"] == "my-gcp-project"
 
     def test_verify_vault_gcp_failure_includes_project_id(self, monkeypatch, tmp_path: Path):
@@ -1271,7 +1270,13 @@ class TestVaultVerification:
                 """
                 return True
 
-            def decrypt(self, env_path, env_keys_file=None, env=None, cwd=None):
+            def decrypt(
+                self,
+                env_path: Path,
+                env_keys_file: object = None,
+                env: dict[str, str] | None = None,
+                cwd: object = None,
+            ) -> None:
                 """
                 Test stub that simulates a decrypt call by recording the production private key and working directory and asserting the env file exists.
 
@@ -1284,7 +1289,7 @@ class TestVaultVerification:
                 Raises:
                     AssertionError: If `env_path` does not exist.
                 """
-                # pyrefly: ignore [missing-attribute]
+                assert env is not None
                 captured["env_var"] = env.get("DOTENV_PRIVATE_KEY_PRODUCTION")
                 captured["cwd"] = cwd
                 assert env_path.exists()
@@ -1518,7 +1523,7 @@ class TestSyncCommand:
         )
 
         monkeypatch.chdir(tmp_path)
-        captured: dict[str, object] = {}
+        captured: dict[str, Any] = {}
 
         monkeypatch.setattr(
             "envdrift.vault.get_vault_client",
@@ -1540,13 +1545,9 @@ class TestSyncCommand:
 
         assert result.exit_code == 0
         sync_config = captured["config"]
-        # pyrefly: ignore [missing-attribute]
         assert sync_config.default_vault_name == "main"
-        # pyrefly: ignore [missing-attribute]
         assert sync_config.env_keys_filename == ".env.keys"
-        # pyrefly: ignore [missing-attribute]
         assert sync_config.mappings[0].secret_name == "dotenv-key"
-        # pyrefly: ignore [missing-attribute]
         assert sync_config.mappings[0].folder_path == Path("services/api")
 
     def test_sync_config_file_toml_supplies_defaults(self, monkeypatch, tmp_path: Path):
@@ -1574,7 +1575,7 @@ class TestSyncCommand:
             )
         )
 
-        captured: dict[str, object] = {}
+        captured: dict[str, Any] = {}
 
         def fake_get_vault_client(provider, **kwargs):
             captured["provider"] = provider
@@ -1598,14 +1599,10 @@ class TestSyncCommand:
 
         assert result.exit_code == 0
         assert captured["provider"] == "aws"
-        # pyrefly: ignore [bad-index]
         assert captured["kwargs"]["region"] == "eu-west-2"
         sync_config = captured["config"]
-        # pyrefly: ignore [missing-attribute]
         assert sync_config.env_keys_filename == "keys.env"
-        # pyrefly: ignore [missing-attribute]
         assert sync_config.default_vault_name == "aws-vault"
-        # pyrefly: ignore [missing-attribute]
         assert sync_config.mappings[0].vault_name == "aws-vault"
 
     def test_sync_falls_back_to_sync_config_when_load_config_fails(
@@ -1639,7 +1636,7 @@ class TestSyncCommand:
         monkeypatch.setattr("envdrift.output.rich.print_service_sync_status", lambda *_, **__: None)
         monkeypatch.setattr("envdrift.output.rich.print_sync_result", lambda *_, **__: None)
 
-        captured: dict[str, object] = {}
+        captured: dict[str, Any] = {}
 
         class DummyEngine:
             def __init__(self, config, vault_client, mode, prompt_callback, progress_callback):
@@ -1662,7 +1659,6 @@ class TestSyncCommand:
         )
 
         assert result.exit_code == 0
-        # pyrefly: ignore [missing-attribute]
         assert captured["config"].default_vault_name == "fallback"
 
     def test_sync_missing_config_file_errors(self, tmp_path: Path):
@@ -1721,7 +1717,7 @@ class TestSyncCommand:
         )
 
         monkeypatch.chdir(tmp_path)
-        captured: dict[str, object] = {}
+        captured: dict[str, Any] = {}
 
         def fake_get_vault_client(provider, **kwargs):
             captured["provider"] = provider
@@ -1745,9 +1741,7 @@ class TestSyncCommand:
 
         assert result.exit_code == 0
         assert captured["provider"] == "hashicorp"
-        # pyrefly: ignore [bad-index]
         assert captured["kwargs"]["url"] == "http://localhost:8200"
-        # pyrefly: ignore [missing-attribute]
         assert captured["config"].default_vault_name == "hc"
 
     def test_sync_autodiscovery_gcp_defaults(self, monkeypatch, tmp_path: Path):
@@ -1773,7 +1767,7 @@ class TestSyncCommand:
         )
 
         monkeypatch.chdir(tmp_path)
-        captured: dict[str, object] = {}
+        captured: dict[str, Any] = {}
 
         def fake_get_vault_client(provider, **kwargs):
             captured["provider"] = provider
@@ -1797,9 +1791,7 @@ class TestSyncCommand:
 
         assert result.exit_code == 0
         assert captured["provider"] == "gcp"
-        # pyrefly: ignore [bad-index]
         assert captured["kwargs"]["project_id"] == "my-gcp-project"
-        # pyrefly: ignore [missing-attribute]
         assert captured["config"].default_vault_name == "gcp"
 
     def test_sync_invalid_toml_config_errors(self, monkeypatch, tmp_path: Path):
@@ -3035,8 +3027,8 @@ class TestLockCommand:
 
         # Mark content as already encrypted
         dummy = _mock_encryption_backend(monkeypatch)
-        # pyrefly: ignore [missing-attribute]
-        dummy.is_encrypted = lambda content: "encrypted:" in content
+        # has_encrypted_header is the API method called by production code (is_encrypted was a typo).
+        dummy.has_encrypted_header = lambda content: "encrypted:" in content  # type: ignore[method-assign]
 
         result = runner.invoke(app, ["lock", "-c", str(config_file), "--force", "--all"])
 
@@ -3830,7 +3822,7 @@ class TestVaultPushCommand:
         )
 
         monkeypatch.chdir(tmp_path)
-        captured: dict[str, object] = {}
+        captured: dict[str, Any] = {}
 
         class MockVaultClient:
             def authenticate(self):
@@ -3859,7 +3851,6 @@ class TestVaultPushCommand:
 
         assert result.exit_code == 0
         assert captured["provider"] == "gcp"
-        # pyrefly: ignore [bad-index]
         assert captured["kwargs"]["project_id"] == "my-gcp-project"
 
     def test_vault_push_all_uses_auto_install(self, monkeypatch, tmp_path: Path):
@@ -3903,7 +3894,7 @@ class TestVaultPushCommand:
             + "\n"
         )
 
-        captured: dict[str, object] = {}
+        captured: dict[str, Any] = {}
 
         dummy_backend = DummyEncryptionBackend()
 

--- a/tests/unit/test_encryption_helpers.py
+++ b/tests/unit/test_encryption_helpers.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 from textwrap import dedent
+from typing import Any, cast
 
 from envdrift.cli_commands.encryption_helpers import (
     build_sops_encrypt_kwargs,
@@ -12,6 +13,7 @@ from envdrift.cli_commands.encryption_helpers import (
 )
 from envdrift.config import EncryptionConfig
 from envdrift.encryption import EncryptionProvider
+from envdrift.encryption.base import EncryptionBackend
 from tests.helpers import DummyEncryptionBackend
 
 
@@ -30,7 +32,7 @@ def test_resolve_encryption_backend_dotenvx_auto_install(tmp_path, monkeypatch):
         ).lstrip()
     )
 
-    captured: dict[str, object] = {}
+    captured: dict[str, Any] = {}
 
     def fake_get_backend(provider, **config):
         captured["provider"] = provider
@@ -47,7 +49,6 @@ def test_resolve_encryption_backend_dotenvx_auto_install(tmp_path, monkeypatch):
     assert backend.name == "dotenvx"
     assert provider == EncryptionProvider.DOTENVX
     assert encryption_config is not None
-    # pyrefly: ignore [bad-index]
     assert captured["config"]["auto_install"] is True
 
 
@@ -68,7 +69,7 @@ def test_resolve_encryption_backend_sops_config(tmp_path, monkeypatch):
         ).lstrip()
     )
 
-    captured: dict[str, object] = {}
+    captured: dict[str, Any] = {}
 
     def fake_get_backend(provider, **config):
         captured["provider"] = provider
@@ -83,11 +84,8 @@ def test_resolve_encryption_backend_sops_config(tmp_path, monkeypatch):
     resolve_encryption_backend(config_file)
 
     assert captured["provider"] == EncryptionProvider.SOPS
-    # pyrefly: ignore [bad-index]
     assert captured["config"]["auto_install"] is True
-    # pyrefly: ignore [bad-index]
     assert captured["config"]["config_file"] == ".sops.yaml"
-    # pyrefly: ignore [bad-index]
     assert captured["config"]["age_key_file"] == ".agekey"
 
 
@@ -122,10 +120,12 @@ def test_build_sops_encrypt_kwargs():
 
 def test_is_encrypted_content_checks_dotenvx_marker():
     """is_encrypted_content should catch dotenvx value markers."""
-    backend = DummyEncryptionBackend(name="dotenvx", has_encrypted_header=lambda _c: False)
+    backend = cast(
+        EncryptionBackend,
+        DummyEncryptionBackend(name="dotenvx", has_encrypted_header=lambda _c: False),
+    )
     content = "API_KEY=encrypted:abc123"
 
-    # pyrefly: ignore [bad-argument-type]
     assert is_encrypted_content(EncryptionProvider.DOTENVX, backend, content) is True
 
 
@@ -136,9 +136,12 @@ def test_is_encrypted_content_dotenvx_header_but_plaintext_values():
     (from a previous partial merge) but the actual values are still plaintext.
     The function should NOT treat this as "already encrypted".
     """
-    backend = DummyEncryptionBackend(
-        name="dotenvx",
-        has_encrypted_header=lambda _c: True,  # Header IS present
+    backend = cast(
+        EncryptionBackend,
+        DummyEncryptionBackend(
+            name="dotenvx",
+            has_encrypted_header=lambda _c: True,  # Header IS present
+        ),
     )
     # Content has header but values are plaintext (no "encrypted:" prefix)
     content = """\
@@ -153,15 +156,17 @@ API_KEY=plaintext_secret_value
 DATABASE_PASSWORD=another_plaintext_value
 """
     # Should return False because there are no "encrypted:" values
-    # pyrefly: ignore [bad-argument-type]
     assert is_encrypted_content(EncryptionProvider.DOTENVX, backend, content) is False
 
 
 def test_is_encrypted_content_dotenvx_header_with_encrypted_values():
     """is_encrypted_content should return True when DOTENVX has header AND encrypted values."""
-    backend = DummyEncryptionBackend(
-        name="dotenvx",
-        has_encrypted_header=lambda _c: True,
+    backend = cast(
+        EncryptionBackend,
+        DummyEncryptionBackend(
+            name="dotenvx",
+            has_encrypted_header=lambda _c: True,
+        ),
     )
     content = """\
 #/-------------------[DOTENV_PUBLIC_KEY]--------------------/
@@ -170,24 +175,27 @@ DOTENV_PUBLIC_KEY_SECRET="034c65f520ec607225d1344fdbace9c31b06c1c8095f413c9cc50a
 API_KEY=encrypted:BJxUJmUB/UdA5MEUSduzwIrW20EM9mQegxI0t5/Urj83ZEKcbPok4ntuCgE6o6aXmRNdbn
 DATABASE_PASSWORD=encrypted:BDMo6jyFdvRLdd2nkCk6l/7yPmULsTQtXuIIP4j7vrZewJ4bMVXIiEHHGWKBHHS0Mz5a
 """
-    # pyrefly: ignore [bad-argument-type]
     assert is_encrypted_content(EncryptionProvider.DOTENVX, backend, content) is True
 
 
 def test_is_encrypted_content_sops_uses_header():
     """For SOPS provider, is_encrypted_content should use has_encrypted_header."""
     # SOPS with header = encrypted
-    backend_with_header = DummyEncryptionBackend(
-        name="sops",
-        has_encrypted_header=lambda _c: True,
+    backend_with_header = cast(
+        EncryptionBackend,
+        DummyEncryptionBackend(
+            name="sops",
+            has_encrypted_header=lambda _c: True,
+        ),
     )
-    # pyrefly: ignore [bad-argument-type]
     assert is_encrypted_content(EncryptionProvider.SOPS, backend_with_header, "any") is True
 
     # SOPS without header = not encrypted
-    backend_no_header = DummyEncryptionBackend(
-        name="sops",
-        has_encrypted_header=lambda _c: False,
+    backend_no_header = cast(
+        EncryptionBackend,
+        DummyEncryptionBackend(
+            name="sops",
+            has_encrypted_header=lambda _c: False,
+        ),
     )
-    # pyrefly: ignore [bad-argument-type]
     assert is_encrypted_content(EncryptionProvider.SOPS, backend_no_header, "any") is False

--- a/tests/unit/test_guard_cli.py
+++ b/tests/unit/test_guard_cli.py
@@ -18,6 +18,7 @@ from envdrift.config import (
     GuardConfig as FileGuardConfig,
 )
 from envdrift.scanner.base import AggregatedScanResult, FindingSeverity, ScanFinding
+from envdrift.scanner.engine import GuardConfig as EngineGuardConfig
 
 runner = CliRunner()
 
@@ -45,7 +46,7 @@ def _make_finding(severity: FindingSeverity) -> ScanFinding:
 
 
 def _patch_guard_dependencies(monkeypatch, config: EnvdriftConfig, result: AggregatedScanResult):
-    created_configs: list[object] = []
+    created_configs: list[EngineGuardConfig] = []
     info_calls: list[bool] = []
 
     class DummyScanner:
@@ -53,7 +54,7 @@ def _patch_guard_dependencies(monkeypatch, config: EnvdriftConfig, result: Aggre
             self.name = name
 
     class DummyEngine:
-        def __init__(self, guard_config):
+        def __init__(self, guard_config: EngineGuardConfig):
             created_configs.append(guard_config)
             self.scanners = [DummyScanner("native")]
 
@@ -134,17 +135,11 @@ def test_guard_uses_config_scanners(tmp_path: Path, monkeypatch):
     assert result.exit_code == 0
 
     guard_config = created_configs[0]
-    # pyrefly: ignore [missing-attribute]
     assert guard_config.use_gitleaks is True
-    # pyrefly: ignore [missing-attribute]
     assert guard_config.use_trufflehog is True
-    # pyrefly: ignore [missing-attribute]
     assert guard_config.use_detect_secrets is True
-    # pyrefly: ignore [missing-attribute]
     assert guard_config.include_git_history is True
-    # pyrefly: ignore [missing-attribute]
     assert guard_config.check_entropy is True
-    # pyrefly: ignore [missing-attribute]
     assert guard_config.ignore_paths == ["vendor/**"]
 
 
@@ -178,7 +173,6 @@ def test_guard_config_can_disable_gitleaks(tmp_path: Path, monkeypatch):
     assert result.exit_code == 0
 
     guard_config = created_configs[0]
-    # pyrefly: ignore [missing-attribute]
     assert guard_config.use_gitleaks is False
 
 
@@ -202,11 +196,8 @@ def test_guard_cli_overrides_config_scanners(tmp_path: Path, monkeypatch):
     assert result.exit_code == 0
 
     guard_config = created_configs[0]
-    # pyrefly: ignore [missing-attribute]
     assert guard_config.use_gitleaks is False
-    # pyrefly: ignore [missing-attribute]
     assert guard_config.use_trufflehog is False
-    # pyrefly: ignore [missing-attribute]
     assert guard_config.use_detect_secrets is False
 
 
@@ -219,7 +210,6 @@ def test_guard_cli_enables_gitleaks_when_config_disables(tmp_path: Path, monkeyp
     assert result.exit_code == 0
 
     guard_config = created_configs[0]
-    # pyrefly: ignore [missing-attribute]
     assert guard_config.use_gitleaks is True
 
 
@@ -234,11 +224,8 @@ def test_guard_native_only_disables_external_scanners(tmp_path: Path, monkeypatc
     assert result.exit_code == 0
 
     guard_config = created_configs[0]
-    # pyrefly: ignore [missing-attribute]
     assert guard_config.use_gitleaks is False
-    # pyrefly: ignore [missing-attribute]
     assert guard_config.use_trufflehog is False
-    # pyrefly: ignore [missing-attribute]
     assert guard_config.use_detect_secrets is False
 
 
@@ -251,9 +238,7 @@ def test_guard_history_and_entropy_flags_override_config(tmp_path: Path, monkeyp
     assert result.exit_code == 0
 
     guard_config = created_configs[0]
-    # pyrefly: ignore [missing-attribute]
     assert guard_config.include_git_history is True
-    # pyrefly: ignore [missing-attribute]
     assert guard_config.check_entropy is True
 
 
@@ -489,7 +474,6 @@ def test_guard_history_flag(tmp_path: Path, monkeypatch):
     result = runner.invoke(app, ["guard", str(tmp_path), "--history"])
     assert result.exit_code == 0
     assert created_configs
-    # pyrefly: ignore [missing-attribute]
     assert created_configs[0].include_git_history is True
 
 
@@ -571,10 +555,8 @@ def test_guard_with_partial_encryption_config(tmp_path: Path, monkeypatch):
     assert result.exit_code == 0
     assert created_configs
     # Verify clear_file was passed to guard config
-    # pyrefly: ignore [missing-attribute]
     assert created_configs[0].allowed_clear_files == [".env.production.clear"]
     # Verify combined_file was passed to guard config
-    # pyrefly: ignore [missing-attribute]
     assert created_configs[0].combined_files == [".env.production"]
 
 
@@ -586,7 +568,6 @@ def test_guard_skip_clear_flag(tmp_path: Path, monkeypatch):
     result = runner.invoke(app, ["guard", str(tmp_path), "--skip-clear"])
     assert result.exit_code == 0
     assert created_configs
-    # pyrefly: ignore [missing-attribute]
     assert created_configs[0].skip_clear_files is True
 
 
@@ -598,7 +579,6 @@ def test_guard_no_skip_clear_flag(tmp_path: Path, monkeypatch):
     result = runner.invoke(app, ["guard", str(tmp_path), "--no-skip-clear"])
     assert result.exit_code == 0
     assert created_configs
-    # pyrefly: ignore [missing-attribute]
     assert created_configs[0].skip_clear_files is False
 
 
@@ -610,7 +590,6 @@ def test_guard_skip_clear_from_config(tmp_path: Path, monkeypatch):
     result = runner.invoke(app, ["guard", str(tmp_path)])
     assert result.exit_code == 0
     assert created_configs
-    # pyrefly: ignore [missing-attribute]
     assert created_configs[0].skip_clear_files is True
 
 
@@ -624,7 +603,6 @@ def test_guard_skip_clear_cli_overrides_config(tmp_path: Path, monkeypatch):
     result = runner.invoke(app, ["guard", str(tmp_path), "--skip-clear"])
     assert result.exit_code == 0
     assert created_configs
-    # pyrefly: ignore [missing-attribute]
     assert created_configs[0].skip_clear_files is True
 
 
@@ -636,7 +614,6 @@ def test_guard_skip_clear_default_is_false(tmp_path: Path, monkeypatch):
     result = runner.invoke(app, ["guard", str(tmp_path)])
     assert result.exit_code == 0
     assert created_configs
-    # pyrefly: ignore [missing-attribute]
     assert created_configs[0].skip_clear_files is False
 
 
@@ -655,7 +632,6 @@ def test_guard_ignore_rules_from_config(tmp_path: Path, monkeypatch):
     result = runner.invoke(app, ["guard", str(tmp_path)])
     assert result.exit_code == 0
     assert created_configs
-    # pyrefly: ignore [missing-attribute]
     assert created_configs[0].ignore_rules == {
         "ftp-password": ["**/*.json"],
         "django-secret-key": ["**/test_settings.py"],
@@ -670,7 +646,6 @@ def test_guard_kingfisher_flag(tmp_path: Path, monkeypatch):
     result = runner.invoke(app, ["guard", str(tmp_path), "--kingfisher"])
     assert result.exit_code == 0
     assert created_configs
-    # pyrefly: ignore [missing-attribute]
     assert created_configs[0].use_kingfisher is True
 
 
@@ -682,7 +657,6 @@ def test_guard_no_kingfisher_flag(tmp_path: Path, monkeypatch):
     result = runner.invoke(app, ["guard", str(tmp_path), "--no-kingfisher"])
     assert result.exit_code == 0
     assert created_configs
-    # pyrefly: ignore [missing-attribute]
     assert created_configs[0].use_kingfisher is False
 
 
@@ -694,7 +668,6 @@ def test_guard_skip_duplicate_flag(tmp_path: Path, monkeypatch):
     result = runner.invoke(app, ["guard", str(tmp_path), "--skip-duplicate"])
     assert result.exit_code == 0
     assert created_configs
-    # pyrefly: ignore [missing-attribute]
     assert created_configs[0].skip_duplicate is True
 
 
@@ -706,7 +679,6 @@ def test_guard_no_skip_duplicate_flag(tmp_path: Path, monkeypatch):
     result = runner.invoke(app, ["guard", str(tmp_path), "--no-skip-duplicate"])
     assert result.exit_code == 0
     assert created_configs
-    # pyrefly: ignore [missing-attribute]
     assert created_configs[0].skip_duplicate is False
 
 
@@ -718,7 +690,6 @@ def test_guard_skip_duplicate_from_config(tmp_path: Path, monkeypatch):
     result = runner.invoke(app, ["guard", str(tmp_path)])
     assert result.exit_code == 0
     assert created_configs
-    # pyrefly: ignore [missing-attribute]
     assert created_configs[0].skip_duplicate is True
 
 
@@ -730,7 +701,6 @@ def test_guard_skip_gitignored_flag(tmp_path: Path, monkeypatch):
     result = runner.invoke(app, ["guard", str(tmp_path), "--skip-gitignored"])
     assert result.exit_code == 0
     assert created_configs
-    # pyrefly: ignore [missing-attribute]
     assert created_configs[0].skip_gitignored is True
 
 
@@ -742,7 +712,6 @@ def test_guard_no_skip_gitignored_flag(tmp_path: Path, monkeypatch):
     result = runner.invoke(app, ["guard", str(tmp_path), "--no-skip-gitignored"])
     assert result.exit_code == 0
     assert created_configs
-    # pyrefly: ignore [missing-attribute]
     assert created_configs[0].skip_gitignored is False
 
 
@@ -754,7 +723,6 @@ def test_guard_skip_gitignored_from_config(tmp_path: Path, monkeypatch):
     result = runner.invoke(app, ["guard", str(tmp_path)])
     assert result.exit_code == 0
     assert created_configs
-    # pyrefly: ignore [missing-attribute]
     assert created_configs[0].skip_gitignored is True
 
 
@@ -766,5 +734,4 @@ def test_guard_skip_gitignored_default_is_false(tmp_path: Path, monkeypatch):
     result = runner.invoke(app, ["guard", str(tmp_path)])
     assert result.exit_code == 0
     assert created_configs
-    # pyrefly: ignore [missing-attribute]
     assert created_configs[0].skip_gitignored is False

--- a/tests/unit/test_install_cli.py
+++ b/tests/unit/test_install_cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import urllib.error
+from email.message import Message
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -231,8 +232,7 @@ class TestInstallAgentCommand:
                     url="",
                     code=404,
                     msg="Not Found",
-                    # pyrefly: ignore [bad-argument-type]
-                    hdrs={},
+                    hdrs=Message(),
                     fp=None,
                 ),
             ),

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -208,9 +208,9 @@ BAR=plaintext
         parser = EnvParser()
         result = parser.parse(env_file)
 
-        assert result.get("FOO") is not None
-        # pyrefly: ignore [missing-attribute]
-        assert result.get("FOO").value == "bar"
+        foo_var = result.get("FOO")
+        assert foo_var is not None
+        assert foo_var.value == "bar"
         assert result.get("NONEXISTENT") is None
 
     def test_env_file_contains(self, tmp_path):

--- a/tests/unit/test_precommit.py
+++ b/tests/unit/test_precommit.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import cast
 
 import pytest
 import yaml
@@ -47,16 +48,16 @@ class TestHookEntry:
 
     def test_validate_hook_entry(self):
         """Test envdrift-validate hook entry."""
-        validate_hook = next(h for h in HOOK_ENTRY["hooks"] if h["id"] == "envdrift-validate")
+        hooks = cast(list[dict[str, str]], HOOK_ENTRY["hooks"])
+        validate_hook = next(h for h in hooks if h["id"] == "envdrift-validate")
         assert validate_hook["language"] == "system"
-        # pyrefly: ignore [not-iterable]
         assert "validate" in validate_hook["entry"]
 
     def test_encryption_hook_entry(self):
         """Test envdrift-encryption hook entry."""
-        encrypt_hook = next(h for h in HOOK_ENTRY["hooks"] if h["id"] == "envdrift-encryption")
+        hooks = cast(list[dict[str, str]], HOOK_ENTRY["hooks"])
+        encrypt_hook = next(h for h in hooks if h["id"] == "envdrift-encryption")
         assert encrypt_hook["language"] == "system"
-        # pyrefly: ignore [not-iterable]
         assert "encrypt" in encrypt_hook["entry"]
 
 

--- a/tests/unit/test_precommit.py
+++ b/tests/unit/test_precommit.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import cast
+from typing import Any, cast
 
 import pytest
 import yaml
@@ -48,14 +48,14 @@ class TestHookEntry:
 
     def test_validate_hook_entry(self):
         """Test envdrift-validate hook entry."""
-        hooks = cast(list[dict[str, str]], HOOK_ENTRY["hooks"])
+        hooks = cast(list[dict[str, Any]], HOOK_ENTRY["hooks"])
         validate_hook = next(h for h in hooks if h["id"] == "envdrift-validate")
         assert validate_hook["language"] == "system"
         assert "validate" in validate_hook["entry"]
 
     def test_encryption_hook_entry(self):
         """Test envdrift-encryption hook entry."""
-        hooks = cast(list[dict[str, str]], HOOK_ENTRY["hooks"])
+        hooks = cast(list[dict[str, Any]], HOOK_ENTRY["hooks"])
         encrypt_hook = next(h for h in hooks if h["id"] == "envdrift-encryption")
         assert encrypt_hook["language"] == "system"
         assert "encrypt" in encrypt_hook["entry"]

--- a/tests/unit/test_rich_output.py
+++ b/tests/unit/test_rich_output.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from types import SimpleNamespace
+from typing import cast
 from unittest.mock import patch
 
 from envdrift.core.diff import DiffResult, DiffType, VarDiff
@@ -23,7 +24,7 @@ from envdrift.output.rich import (
     print_validation_result,
     print_warning,
 )
-from envdrift.sync.result import DecryptionTestResult, SyncAction
+from envdrift.sync.result import DecryptionTestResult, ServiceSyncResult, SyncAction, SyncResult
 
 
 class TestPrintFunctions:
@@ -231,8 +232,7 @@ class TestSyncOutput:
             schema_valid=False,
         )
         with patch.object(console, "print") as mock_print:
-            # pyrefly: ignore [bad-argument-type]
-            print_service_sync_status(result)
+            print_service_sync_status(cast(ServiceSyncResult, result))
         joined = " ".join(str(c.args[0]) for c in mock_print.call_args_list)
         assert "updated" in joined or "~" in joined
         assert "Error" in joined
@@ -253,8 +253,7 @@ class TestSyncOutput:
             decryption_failed=1,
         )
         with patch.object(console, "print") as mock_print:
-            # pyrefly: ignore [bad-argument-type]
-            print_sync_result(sync_result)
+            print_sync_result(cast(SyncResult, sync_result))
         joined = " ".join(" ".join(map(str, c.args)) for c in mock_print.call_args_list)
         assert "errors" in joined.lower()
         assert "Sync completed with errors" in joined

--- a/tests/unit/test_schema_loader.py
+++ b/tests/unit/test_schema_loader.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 from textwrap import dedent
 from types import SimpleNamespace
+from typing import cast
 
 import pytest
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from envdrift.core.schema import FieldMetadata, SchemaLoader, SchemaLoadError, SchemaMetadata
 
@@ -112,8 +113,9 @@ def test_extract_metadata_with_config_object_and_typing():
         items: list[str] = []
 
     loader = SchemaLoader()
-    # pyrefly: ignore [bad-assignment]
-    Settings.model_config = SimpleNamespace(extra="forbid")
+    # Deliberately attach a non-ConfigDict value to exercise the loader's fallback path
+    # when model_config doesn't conform to the standard mapping shape.
+    Settings.model_config = cast(SettingsConfigDict, SimpleNamespace(extra="forbid"))
     schema = loader.extract_metadata(Settings)
 
     assert schema.extra_policy == "forbid"

--- a/tests/unit/test_vault_gcp.py
+++ b/tests/unit/test_vault_gcp.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import base64
 import importlib
 import sys
-import types
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -45,45 +44,28 @@ class DummyDefaultCredentialsError(Exception):
 @pytest.fixture
 def mock_gcp():
     """Mock GCP SDK modules."""
-    exceptions_mod = types.ModuleType("google.api_core.exceptions")
-    # pyrefly: ignore [missing-attribute]
-    exceptions_mod.GoogleAPICallError = DummyGoogleAPICallError
-    # pyrefly: ignore [missing-attribute]
-    exceptions_mod.PermissionDenied = DummyPermissionDeniedError
-    # pyrefly: ignore [missing-attribute]
-    exceptions_mod.Unauthenticated = DummyUnauthenticatedError
-    # pyrefly: ignore [missing-attribute]
-    exceptions_mod.NotFound = DummyNotFoundError
-    # pyrefly: ignore [missing-attribute]
-    exceptions_mod.AlreadyExists = DummyAlreadyExistsError
+    exceptions_mod = SimpleNamespace(
+        GoogleAPICallError=DummyGoogleAPICallError,
+        PermissionDenied=DummyPermissionDeniedError,
+        Unauthenticated=DummyUnauthenticatedError,
+        NotFound=DummyNotFoundError,
+        AlreadyExists=DummyAlreadyExistsError,
+    )
+    api_core_mod = SimpleNamespace(exceptions=exceptions_mod)
 
-    api_core_mod = types.ModuleType("google.api_core")
-    # pyrefly: ignore [missing-attribute]
-    api_core_mod.exceptions = exceptions_mod
+    auth_exceptions_mod = SimpleNamespace(
+        DefaultCredentialsError=DummyDefaultCredentialsError,
+    )
+    auth_mod = SimpleNamespace(exceptions=auth_exceptions_mod)
 
-    auth_exceptions_mod = types.ModuleType("google.auth.exceptions")
-    # pyrefly: ignore [missing-attribute]
-    auth_exceptions_mod.DefaultCredentialsError = DummyDefaultCredentialsError
+    secretmanager_mod = SimpleNamespace(SecretManagerServiceClient=MagicMock())
+    cloud_mod = SimpleNamespace(secretmanager=secretmanager_mod)
 
-    auth_mod = types.ModuleType("google.auth")
-    # pyrefly: ignore [missing-attribute]
-    auth_mod.exceptions = auth_exceptions_mod
-
-    secretmanager_mod = types.ModuleType("google.cloud.secretmanager")
-    # pyrefly: ignore [missing-attribute]
-    secretmanager_mod.SecretManagerServiceClient = MagicMock()
-
-    cloud_mod = types.ModuleType("google.cloud")
-    # pyrefly: ignore [missing-attribute]
-    cloud_mod.secretmanager = secretmanager_mod
-
-    google_mod = types.ModuleType("google")
-    # pyrefly: ignore [missing-attribute]
-    google_mod.api_core = api_core_mod
-    # pyrefly: ignore [missing-attribute]
-    google_mod.auth = auth_mod
-    # pyrefly: ignore [missing-attribute]
-    google_mod.cloud = cloud_mod
+    google_mod = SimpleNamespace(
+        api_core=api_core_mod,
+        auth=auth_mod,
+        cloud=cloud_mod,
+    )
 
     with patch.dict(
         sys.modules,

--- a/tests/unit/test_vault_hashicorp.py
+++ b/tests/unit/test_vault_hashicorp.py
@@ -6,7 +6,7 @@ by testing the code paths and exception handling.
 
 from __future__ import annotations
 
-from types import ModuleType
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -17,19 +17,15 @@ from envdrift.vault.base import AuthenticationError, SecretNotFoundError, VaultE
 @pytest.fixture(autouse=True, scope="module")
 def mock_hvac_module():
     """Provide a stub hvac module so tests don't require the real dependency."""
-    hvac_module = ModuleType("hvac")
-    hvac_exceptions = ModuleType("hvac.exceptions")
-
-    # pyrefly: ignore [missing-attribute]
-    hvac_exceptions.Forbidden = type("Forbidden", (Exception,), {})
-    # pyrefly: ignore [missing-attribute]
-    hvac_exceptions.InvalidPath = type("InvalidPath", (Exception,), {})
-    # pyrefly: ignore [missing-attribute]
-    hvac_exceptions.Unauthorized = type("Unauthorized", (Exception,), {})
-    # pyrefly: ignore [missing-attribute]
-    hvac_module.exceptions = hvac_exceptions
-    # pyrefly: ignore [missing-attribute]
-    hvac_module.Client = MagicMock()
+    hvac_exceptions = SimpleNamespace(
+        Forbidden=type("Forbidden", (Exception,), {}),
+        InvalidPath=type("InvalidPath", (Exception,), {}),
+        Unauthorized=type("Unauthorized", (Exception,), {}),
+    )
+    hvac_module = SimpleNamespace(
+        exceptions=hvac_exceptions,
+        Client=MagicMock(),
+    )
 
     with patch.dict(
         "sys.modules",


### PR DESCRIPTION
## Summary

Replace every `# pyrefly: ignore` comment in `tests/` (100 total) with real type annotations, narrowing assertions, or `cast()` calls. Each removed suppression is a real type error caught going forward.

**Before:** 100 `# pyrefly: ignore` comments across 17 test files (added in #258 via `pyrefly suppress`).
**After:** 0 in `tests/`. 3 unrelated pre-existing suppressions remain elsewhere — outside the scope of this issue.

Closes #257.

## Patterns applied

- **`SimpleNamespace` for stub SDK modules** in place of `types.ModuleType(...) + setattr` — `test_vault_gcp`, `test_vault_hashicorp`, `test_engine`.
- **Concrete config type imports + variable annotations** so `created_configs` is typed `list[EngineGuardConfig]` instead of `list[object]` — `test_guard_cli`, `test_cli`.
- **`dict[str, Any]`** for test capture dicts so nested indexing typechecks — `test_cli`, `test_encryption_helpers`.
- **`assert ... is not None`** to narrow `str | None` before `.lower()` in scanner timeout/error tests — `test_trivy`, `test_infisical`, `test_trufflehog`, `test_talisman`, `test_gitleaks`, `test_parser`, `test_error_handling`.
- **`cast(EncryptionBackend, ...)` / `cast(ServiceSyncResult, ...)`** for intentional duck-typed test doubles — `test_encryption_helpers`, `test_rich_output`, `test_schema_loader`.
- **Real `email.message.Message()`** instead of `{}` for `HTTPError(hdrs=...)` — `test_install_cli`.

## Production-code-adjacent test bugs surfaced by type-checking

No `src/` changes, but two real test bugs were caught and fixed:

1. **`tests/unit/test_cli.py:3030`** — a test was assigning `dummy.is_encrypted = lambda ...`, but the encryption backend API uses `has_encrypted_header`. The patched lambda was dead code; the test now patches the real method (and therefore actually exercises what its comment claims).
2. **`tests/unit/test_vault_hashicorp.py`** — same root-cause fix as the Copilot autofix (#258) that already landed on `main`. No-op against the merged baseline; rolled into the broader refactor commit.

## Remaining suppressions

None in `tests/`. `pyrefly check` reports 3 suppressed lines, all pre-existing and outside the scope of #257.

## Test plan

- [x] `uv run pyrefly check` — 0 errors, 3 suppressed (unchanged baseline)
- [x] `make typecheck` — passes
- [x] `uv run pre-commit run pyrefly-check --all-files` — passes
- [x] `uv run pre-commit run --files <changed>` — ruff lint + format + pyrefly all pass
- [x] `uv run pytest -m "not integration"` — 1595 passed, 2 skipped, 0 regressions
- [ ] CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Reorganized assertions in error-handling and timeout tests to verify success state before error content across multiple test modules.
  * Enhanced type safety in test fixtures through explicit casting and imports.
  * Refactored test infrastructure to use SimpleNamespace instead of ModuleType for mocking.
  * Removed linter suppressions throughout test suite.

* **Chores**
  * Removed obsolete project cleanup task reference.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jainal09/envdrift/pull/260?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes all 100 `# pyrefly: ignore` suppressions from `tests/` (added in #258) by replacing them with proper type annotations, narrowing assertions, `cast()` calls, and corrected stub patterns. One real test bug was also fixed as a side-effect of the type work.

- **Type narrowing in scanner tests**: Added `assert result.error is not None` guards before `.lower()` calls, with assertion order corrected to check `success is False` first across all scanner test files.
- **`SimpleNamespace` stubs**: Replaced `types.ModuleType(...) + setattr` patterns with `SimpleNamespace(...)` in `test_engine`, `test_vault_gcp`, and `test_vault_hashicorp`.
- **Real bug fix in `test_cli.py`**: Changed `dummy.is_encrypted = lambda ...` to `dummy.has_encrypted_header = lambda ...` — the patched lambda was previously dead code since production code calls `has_encrypted_header`, not `is_encrypted`.

<h3>Confidence Score: 5/5</h3>

All changes are confined to test files and a minor pyproject.toml comment removal; no production code is touched.

Every change is a mechanical type-annotation improvement to test code: replacing broad types with precise alternatives, adding `is not None` narrowing assertions, and swapping `ModuleType + setattr` stubs with `SimpleNamespace`. The one behavioural change — patching `has_encrypted_header` instead of the non-existent `is_encrypted` — corrects a test that was previously exercising nothing. The PR reports 1595 tests passing with 0 regressions.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| tests/unit/test_cli.py | Changed multiple `captured: dict[str, object]` to `dict[str, Any]`, removed redundant pyrefly suppressions, and fixed a real bug where `is_encrypted` was patched instead of the actual `has_encrypted_header` method. |
| tests/unit/test_encryption_helpers.py | Replaced pyrefly suppressions with `cast(EncryptionBackend, DummyEncryptionBackend(...))` calls; structural gap between the two types is a pre-existing concern noted in prior review. |
| tests/unit/test_vault_gcp.py | Replaced verbose `types.ModuleType + setattr` pattern (17 lines) with concise `SimpleNamespace(...)` for GCP SDK stubs; functionally equivalent for test purposes. |
| tests/unit/test_vault_hashicorp.py | Same `ModuleType to SimpleNamespace` refactor as in test_vault_gcp; removes 8 pyrefly suppressions cleanly. |
| tests/unit/test_guard_cli.py | Changed `created_configs: list[object]` to `list[EngineGuardConfig]` and typed the `DummyEngine.__init__` parameter; removes all 20 pyrefly suppressions on attribute access. |
| tests/scanner/test_engine.py | Replaced `types.ModuleType` stubs with `SimpleNamespace` for scanner module mocks; no behaviour change. |
| tests/unit/test_install_cli.py | Replaced `hdrs={}` with `hdrs=Message()` for `urllib.error.HTTPError`; the real `Message` object satisfies the expected type signature. |
| tests/unit/test_schema_loader.py | Imports `SettingsConfigDict` and uses `cast()` to deliberately assign a non-conforming `SimpleNamespace` to `model_config` while keeping the type checker happy. |
| tests/unit/test_precommit.py | Added `cast(list[dict[str, Any]], HOOK_ENTRY["hooks"])` to satisfy pyrefly's `not-iterable` check; no logic change. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[pyrefly: ignore suppression] --> B{Pattern type?}
    B --> C[missing-attribute on ModuleType]
    B --> D[missing-attribute on result.error]
    B --> E[bad-argument-type on cast target]
    B --> F[bad-index on dict access]
    B --> G[missing-attribute on object-typed var]

    C --> C1["SimpleNamespace(...)\ntest_vault_gcp, test_vault_hashicorp\ntest_engine"]
    D --> D1["assert x is not None\n+ reorder assertions\nscanner tests, test_error_handling"]
    E --> E1["cast(EncryptionBackend, ...)\ncast(ServiceSyncResult, ...)\ntest_encryption_helpers, test_rich_output"]
    F --> F1["dict[str, Any] annotation\ntest_cli, test_encryption_helpers"]
    G --> G1["list[EngineGuardConfig] annotation\ntest_guard_cli"]

    D1 --> H[Bug fix: is_encrypted to has_encrypted_header in test_cli.py]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `tests/unit/test_encryption_helpers.py`, line 454-457 ([link](https://github.com/jainal09/envdrift/blob/1d780323520ad701e543c5d996ec7c778dbd580e/tests/unit/test_encryption_helpers.py#L454-L457)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=8" align="top"></a> **`DummyEncryptionBackend` cast hides a structural gap with `EncryptionBackend`**

   `DummyEncryptionBackend` does not formally subclass `EncryptionBackend` and is missing the `encrypted_value_prefix`, `get_version`, and `detect_encryption_status` abstract members. The five `cast(EncryptionBackend, ...)` calls silence pyrefly, but if any of those missing methods were ever called by the functions under test, the tests would fail at runtime with `AttributeError` rather than a type error. Making `DummyEncryptionBackend` a proper subclass of `EncryptionBackend` (or a `Protocol`) would make these casts unnecessary and catch structural drift at check time.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["refactor(tests): address Copilot review ..."](https://github.com/jainal09/envdrift/commit/9b38f02ad9e25b8e5cff0c237445296eac479885) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32862067)</sub>

<!-- /greptile_comment -->