### PR TITLE
feat(vault): add config-free vault-pull command (symmetric to vault-push)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,21 +62,26 @@ pip install "envdrift[vault]"  # All vault providers
 
 ```bash
 envdrift encrypt .env.production
-envdrift vault-push . my-app-key --provider azure --vault-url https://myvault.vault.azure.net/
+envdrift vault-push . my-app-key --env production --provider azure --vault-url https://myvault.vault.azure.net/
 ```
 
-**2. Team members pull instantly:**
+**2. Team members pull instantly (no config needed):**
 
 ```bash
-envdrift pull --provider azure --vault-url https://myvault.vault.azure.net/
+envdrift vault-pull . my-app-key --env production --provider azure --vault-url https://myvault.vault.azure.net/
 ```
 
-**3. Daily workflow:**
+`vault-pull` fetches the key, writes `.env.keys`, and decrypts `.env.production` in one step.
+
+**3. Daily workflow (config-based, needs `[vault.sync]` in `envdrift.toml`):**
 
 ```bash
 envdrift pull   # After git pull - sync keys, decrypt
 envdrift lock   # Before commit - encrypt, verify keys
 ```
+
+> Note: `pull`/`lock` operate on all services defined in your sync config. For a
+> single secret without any TOML config, use `vault-pull`/`vault-push`.
 
 ## Beyond Sync
 

--- a/docs/cli/decrypt.md
+++ b/docs/cli/decrypt.md
@@ -170,6 +170,12 @@ Failure shows WRONG_PRIVATE_KEY and prints repair steps:
 - `envdrift sync --force ...` to restore .env.keys from vault
 - `envdrift encrypt <file>` to re-encrypt with the vault key
 
+!!! note "`--verify-vault` only verifies — it does not fetch the key"
+    This is a **read-only CI check**: it fetches the vault key, tests decryption in
+    a throwaway temp dir, and discards everything (the original file is *not*
+    decrypted and no `.env.keys` is written). To actually fetch a key onto a
+    machine and decrypt for use, see [`vault-pull`](vault-pull.md).
+
 ## Error Handling
 
 ### Missing Private Key

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -26,6 +26,7 @@ uv add envdrift
 | [pull](pull.md)                  | Pull keys from vault and decrypt all env files         |
 | [sync](sync.md)                  | Sync encryption keys from cloud vaults to local files  |
 | [vault-push](vault-push.md)      | Push encryption keys from local files to cloud vaults  |
+| [vault-pull](vault-pull.md)      | Pull a single key from a vault (config-free) + decrypt |
 | [init](init.md)                  | Generate Pydantic Settings from .env files             |
 | [hook](hook.md)                  | Manage pre-commit hook integration                     |
 | [version](version.md)            | Show envdrift version                                  |

--- a/docs/cli/lock.md
+++ b/docs/cli/lock.md
@@ -442,3 +442,4 @@ repos:
 - [encrypt](encrypt.md) - Encrypt a single .env file
 - [decrypt](decrypt.md) - Decrypt a single .env file
 - [vault-push](vault-push.md) - Push keys to vault
+- [vault-pull](vault-pull.md) - Config-free single-secret pull + decrypt

--- a/docs/cli/pull.md
+++ b/docs/cli/pull.md
@@ -253,5 +253,6 @@ When `environment` is not set, it defaults from:
 
 - [sync](sync.md) - Sync keys only (without decryption)
 - [decrypt](decrypt.md) - Decrypt a single .env file
+- [vault-pull](vault-pull.md) - Config-free single-secret pull + decrypt (no sync config required)
 - [vault-push](vault-push.md) - Push keys to vault (opposite of pull)
 - [Vault Sync Guide](../guides/vault-sync.md) - Detailed setup guide

--- a/docs/cli/vault-pull.md
+++ b/docs/cli/vault-pull.md
@@ -185,9 +185,25 @@ Error: Secret 'myapp-key' not found in azure vault
 - **HashiCorp Vault**: `VAULT_TOKEN` environment variable
 - **GCP Secret Manager**: Application Default Credentials
 
+## `vault-pull` vs `decrypt --verify-vault`
+
+Both commands fetch a key from your vault, but they do very different things — don't confuse them:
+
+| | `vault-pull` | `decrypt --verify-vault` |
+| :--- | :--- | :--- |
+| **Purpose** | Onboarding — get the key and use it | CI health-check — does the shared key still work? |
+| **Writes `.env.keys`?** | **Yes** | No |
+| **Decrypts the real file?** | **Yes** (unless `--no-decrypt`) | No — tests in a throwaway temp dir, then discards |
+| **Persists anything?** | Yes | No (prints *"Original file was not decrypted"*) |
+
+Use `vault-pull` to actually fetch a key onto a machine and decrypt. Use
+[`decrypt --verify-vault`](decrypt.md) only to verify, in CI, that the vault's
+shared key can still decrypt an encrypted file — it never writes the key or
+touches the file.
+
 ## See Also
 
 - [vault-push](vault-push.md) - Push a single key to a vault (opposite of vault-pull)
 - [pull](pull.md) - Config-based, multi-service pull + decrypt
-- [decrypt](decrypt.md) - Decrypt an env file using a local key
+- [decrypt](decrypt.md) - Decrypt an env file using a local key (and `--verify-vault` CI check)
 - [Vault Sync Guide](../guides/vault-sync.md) - Detailed vault setup guide

--- a/docs/cli/vault-pull.md
+++ b/docs/cli/vault-pull.md
@@ -1,0 +1,193 @@
+# envdrift vault-pull
+
+Pull a single encryption key from a cloud vault into a local `.env.keys` file.
+This command is specific to dotenvx keys; SOPS users should use their SOPS key management workflows.
+
+## Synopsis
+
+```bash
+envdrift vault-pull [OPTIONS] FOLDER SECRET_NAME
+```
+
+## Description
+
+The `vault-pull` command is the **config-free, single-secret inverse** of
+[`vault-push`](vault-push.md). It fetches one secret from a cloud vault, writes
+the `DOTENV_PRIVATE_KEY_<ENV>` key into `<folder>/.env.keys`, and — by default —
+decrypts the matching `.env.<env>` file so a single command onboards a developer
+with **no TOML configuration required**.
+
+This complements [`envdrift pull`](pull.md), which requires a `[vault.sync]`
+configuration and operates on multiple services. Use `vault-pull` when you just
+need one secret and don't want to maintain a sync config.
+
+Supported vault providers:
+
+- **Azure Key Vault** - Microsoft Azure's secret management service
+- **AWS Secrets Manager** - Amazon Web Services secret storage
+- **HashiCorp Vault** - Open-source secrets management
+- **GCP Secret Manager** - Google Cloud secret storage
+
+## Modes
+
+### Pull key and decrypt (default)
+
+Fetches the secret, writes the key to `.env.keys`, and decrypts `.env.<env>`.
+
+```bash
+envdrift vault-pull ./services/myapp my-secret-name --env production \
+  -p azure --vault-url https://myvault.vault.azure.net/
+```
+
+This fetches `my-secret-name`, writes `DOTENV_PRIVATE_KEY_PRODUCTION` to
+`./services/myapp/.env.keys`, and decrypts `./services/myapp/.env.production`.
+
+### Pull key only (skip decryption)
+
+Use `--no-decrypt` to only write the key without touching the `.env.<env>` file.
+
+```bash
+envdrift vault-pull ./services/myapp my-secret-name --env production --no-decrypt \
+  -p azure --vault-url https://myvault.vault.azure.net/
+```
+
+## Options
+
+### `FOLDER`
+
+Path to the folder where the fetched `.env.keys` file is written (and which contains
+the `.env.<env>` file to decrypt).
+
+### `SECRET_NAME`
+
+Name of the secret to fetch from the vault.
+
+### `--env`, `-e`
+
+**Required.** Environment suffix that names the key written to `.env.keys`
+(e.g., `--env soak` writes `DOTENV_PRIVATE_KEY_SOAK`). It also selects which
+`.env.<env>` file is decrypted unless `--no-decrypt` is used.
+
+The secret value may be stored as either `DOTENV_PRIVATE_KEY_<ENV>=<value>`
+(the format written by `vault-push`) or a bare value — both are handled.
+
+### `--no-decrypt`
+
+Only write the key to `.env.keys`; do not decrypt the `.env.<env>` file.
+
+### `--config`, `-c`
+
+Path to an `envdrift.toml` config file used to read default provider settings.
+
+### `--provider`, `-p`
+
+Vault provider to use. Required unless configured in `envdrift.toml`.
+
+Options: `azure`, `aws`, `hashicorp`, `gcp`
+
+### `--vault-url`
+
+Vault URL. **Required for Azure and HashiCorp** unless configured in `envdrift.toml`.
+
+### `--region`
+
+AWS region for Secrets Manager. Default: `us-east-1`.
+
+### `--project-id`
+
+GCP project ID for Secret Manager. Required for the `gcp` provider unless configured in `envdrift.toml`.
+
+## Configuration
+
+Provider settings can be read from `envdrift.toml`:
+
+```toml
+[vault]
+provider = "azure"
+
+[vault.azure]
+vault_url = "https://my-keyvault.vault.azure.net/"
+
+[vault.aws]
+region = "us-east-1"
+
+[vault.hashicorp]
+url = "https://vault.example.com:8200"
+
+[vault.gcp]
+project_id = "my-gcp-project"
+```
+
+When configured, you can omit the `--provider`, `--vault-url`, and `--project-id` flags.
+
+## Examples
+
+### Azure Key Vault
+
+```bash
+# Pull and decrypt
+envdrift vault-pull ./services/myapp myapp-key --env production \
+  -p azure --vault-url https://myvault.vault.azure.net/
+
+# Using config from envdrift.toml
+envdrift vault-pull ./services/myapp myapp-key --env production
+```
+
+### AWS Secrets Manager
+
+```bash
+envdrift vault-pull ./services/myapp myapp-key --env staging \
+  -p aws --region us-west-2
+```
+
+### HashiCorp Vault
+
+```bash
+envdrift vault-pull ./services/myapp myapp-key --env dev \
+  -p hashicorp --vault-url https://vault.example.com:8200
+```
+
+### GCP Secret Manager
+
+```bash
+envdrift vault-pull ./services/myapp myapp-key --env production \
+  -p gcp --project-id my-gcp-project
+```
+
+## Output
+
+On success:
+
+```text
+Pulled 'myapp-key' -> DOTENV_PRIVATE_KEY_PRODUCTION written to services/myapp/.env.keys
+Decrypted services/myapp/.env.production
+```
+
+On error:
+
+```text
+Error: Secret 'myapp-key' not found in azure vault
+```
+
+## Exit Codes
+
+| Code | Meaning                                              |
+| :--- | :--------------------------------------------------- |
+| 0    | Success (key written, file decrypted if applicable)  |
+| 1    | Error (auth failure, secret not found, decrypt error) |
+
+## Authentication
+
+`vault-pull` uses the same credential chains as `vault-push`:
+
+- **Azure Key Vault**: `DefaultAzureCredential` (env vars, Managed Identity, `az login`)
+- **AWS Secrets Manager**: boto3 credential chain (env vars, `~/.aws/credentials`, IAM role)
+- **HashiCorp Vault**: `VAULT_TOKEN` environment variable
+- **GCP Secret Manager**: Application Default Credentials
+
+## See Also
+
+- [vault-push](vault-push.md) - Push a single key to a vault (opposite of vault-pull)
+- [pull](pull.md) - Config-based, multi-service pull + decrypt
+- [decrypt](decrypt.md) - Decrypt an env file using a local key
+- [Vault Sync Guide](../guides/vault-sync.md) - Detailed vault setup guide

--- a/docs/cli/vault-push.md
+++ b/docs/cli/vault-push.md
@@ -249,6 +249,8 @@ Uses boto3's credential chain:
 
 ## See Also
 
+- [vault-pull](vault-pull.md) - Config-free single-secret pull (opposite of vault-push)
 - [sync](sync.md) - Pull encryption keys from vaults to local files
+- [pull](pull.md) - Config-based, multi-service pull + decrypt
 - [encrypt](encrypt.md) - Check/perform encryption
 - [Vault Sync Guide](../guides/vault-sync.md) - Detailed vault setup guide

--- a/docs/concepts/how-it-works.md
+++ b/docs/concepts/how-it-works.md
@@ -129,7 +129,8 @@ The `pull` and `lock` commands form a complete workflow:
 | `pull` | Vault → Local | Sync keys, decrypt files for development |
 | `lock` | Local → Repo | Verify keys, encrypt files for commit |
 | `sync` | Vault → Local | Sync keys only (no decrypt) |
-| `vault-push` | Local → Vault | Push new keys to vault |
+| `vault-push` | Local → Vault | Push a single key to vault (config-free) |
+| `vault-pull` | Vault → Local | Pull a single key + decrypt (config-free) |
 
 ## Encryption Detection
 

--- a/docs/concepts/vault-providers.md
+++ b/docs/concepts/vault-providers.md
@@ -58,7 +58,10 @@ folder_path = "."
 envdrift sync --provider azure --vault-url https://my-keyvault.vault.azure.net/
 
 # Push keys to Azure Key Vault
-envdrift vault-push . my-secret-name --provider azure --vault-url https://my-keyvault.vault.azure.net/
+envdrift vault-push . my-secret-name --env production --provider azure --vault-url https://my-keyvault.vault.azure.net/
+
+# Pull a single key back (config-free) and decrypt .env.production
+envdrift vault-pull . my-secret-name --env production --provider azure --vault-url https://my-keyvault.vault.azure.net/
 ```
 
 ### Pros
@@ -120,7 +123,10 @@ folder_path = "."
 envdrift sync --provider aws --region us-east-1
 
 # Push keys
-envdrift vault-push . my-secret-name --provider aws --region us-east-1
+envdrift vault-push . my-secret-name --env production --provider aws --region us-east-1
+
+# Pull a single key back (config-free) and decrypt .env.production
+envdrift vault-pull . my-secret-name --env production --provider aws --region us-east-1
 ```
 
 ### Pros
@@ -182,7 +188,10 @@ export VAULT_TOKEN="hvs.xxx"
 envdrift sync --provider hashicorp --vault-url https://vault.example.com
 
 # Push keys
-envdrift vault-push . myapp/dotenvx-key --provider hashicorp --vault-url https://vault.example.com
+envdrift vault-push . myapp/dotenvx-key --env production --provider hashicorp --vault-url https://vault.example.com
+
+# Pull a single key back (config-free) and decrypt .env.production
+envdrift vault-pull . myapp/dotenvx-key --env production --provider hashicorp --vault-url https://vault.example.com
 ```
 
 ### Pros
@@ -240,7 +249,10 @@ folder_path = "."
 envdrift sync --provider gcp --project-id my-gcp-project
 
 # Push keys
-envdrift vault-push . my-secret-name --provider gcp --project-id my-gcp-project
+envdrift vault-push . my-secret-name --env production --provider gcp --project-id my-gcp-project
+
+# Pull a single key back (config-free) and decrypt .env.production
+envdrift vault-pull . my-secret-name --env production --provider gcp --project-id my-gcp-project
 ```
 
 ### Pros

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -149,11 +149,14 @@ Share encryption keys with your team via a cloud vault:
 
 ```bash
 # Push your key to Azure Key Vault
-envdrift vault-push . my-app-key --provider azure --vault-url https://myvault.vault.azure.net/
+envdrift vault-push . my-app-key --env production --provider azure --vault-url https://myvault.vault.azure.net/
 
-# Team members pull the key
-envdrift pull --provider azure --vault-url https://myvault.vault.azure.net/
+# Team members pull the key (no config needed) - writes .env.keys and decrypts .env.production
+envdrift vault-pull . my-app-key --env production --provider azure --vault-url https://myvault.vault.azure.net/
 ```
+
+> `vault-pull` is the config-free, single-secret counterpart of `vault-push`. For
+> multi-service flows driven by a `[vault.sync]` config, use `envdrift pull`.
 
 ## Pre-commit Hook (Optional)
 

--- a/docs/guides/migrating.md
+++ b/docs/guides/migrating.md
@@ -330,7 +330,10 @@ envdrift validate .env --schema config:Settings
 
 # Phase 2: Encryption (later)
 envdrift encrypt .env.production
-envdrift vault-push . my-key
+envdrift vault-push . my-key --env production
+
+# Team members pull it back (config-free) and decrypt
+envdrift vault-pull . my-key --env production
 ```
 
 ### Keep Existing Loaders

--- a/docs/index.md
+++ b/docs/index.md
@@ -60,19 +60,23 @@ envdrift pull
 envdrift encrypt .env.production
 
 # Push the encryption key to your team's vault
-envdrift vault-push . my-app-key --provider azure --vault-url https://myvault.vault.azure.net/
+envdrift vault-push . my-app-key --env production --provider azure --vault-url https://myvault.vault.azure.net/
 ```
 
-### 2. Team members onboard instantly
+### 2. Team members onboard instantly (no config needed)
 
 ```bash
-# New developer runs one command
-envdrift pull --provider azure --vault-url https://myvault.vault.azure.net/
+# New developer runs one command - fetches the key, writes .env.keys, and decrypts
+envdrift vault-pull . my-app-key --env production --provider azure --vault-url https://myvault.vault.azure.net/
 
 # Done! .env.production is decrypted and ready
 ```
 
-### 3. Keep environments in sync
+### 3. Keep environments in sync (config-based)
+
+`pull` and `lock` operate on the services defined in your `[vault.sync]` config
+(`envdrift.toml`/`pyproject.toml`). For a single secret without any TOML config,
+use `vault-pull`/`vault-push` instead.
 
 ```bash
 # Before committing changes

--- a/docs/support/faq.md
+++ b/docs/support/faq.md
@@ -63,10 +63,15 @@ See [Encryption Backends](../concepts/encryption-backends.md) for a detailed com
 
 Use vault sync:
 
-1. Push your keys to a cloud vault: `envdrift vault-push`
-2. Team members pull keys: `envdrift sync` or `envdrift pull`
+1. Push your keys to a cloud vault: `envdrift vault-push . my-key --env production`
+2. Team members pull keys:
+   - For a single secret with no config: `envdrift vault-pull . my-key --env production`
+   - For multi-service flows driven by a `[vault.sync]` config: `envdrift sync` or `envdrift pull`
 
 This way, keys are stored securely in the cloud and synced on demand.
+
+> `sync` and `pull` require a `[vault.sync]` configuration in `envdrift.toml`/`pyproject.toml`.
+> `vault-pull` is config-free and handles a single secret.
 
 ### Can I encrypt only some variables?
 

--- a/docs/support/troubleshooting.md
+++ b/docs/support/troubleshooting.md
@@ -260,7 +260,8 @@ Error: Secret 'myapp-key' not found in vault
 
 1. Check the secret name matches exactly (case-sensitive)
 2. Verify the secret exists: check vault UI or CLI
-3. Push the secret first: `envdrift vault-push . myapp-key`
+3. Push the secret first: `envdrift vault-push . myapp-key --env production`
+4. To pull a single secret back without a sync config, use `envdrift vault-pull . myapp-key --env production`
 
 ## Pre-commit Hook Issues
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,6 +52,7 @@ nav:
       - lock: cli/lock.md
       - sync: cli/sync.md
       - vault-push: cli/vault-push.md
+      - vault-pull: cli/vault-pull.md
       - encrypt: cli/encrypt.md
       - decrypt: cli/decrypt.md
       - push: cli/push.md

--- a/src/envdrift/cli.py
+++ b/src/envdrift/cli.py
@@ -18,7 +18,7 @@ from envdrift.cli_commands.partial import pull_cmd as pull_partial_cmd
 from envdrift.cli_commands.partial import push as push_cmd
 from envdrift.cli_commands.sync import lock, pull, sync
 from envdrift.cli_commands.validate import validate
-from envdrift.cli_commands.vault import vault_push
+from envdrift.cli_commands.vault import vault_pull, vault_push
 from envdrift.cli_commands.version import version as version_cmd
 
 
@@ -64,6 +64,7 @@ app.command()(sync)
 app.command()(pull)
 app.command()(lock)
 app.command("vault-push")(vault_push)
+app.command("vault-pull")(vault_pull)
 app.command()(version_cmd)
 
 # Partial encryption commands

--- a/src/envdrift/cli_commands/vault.py
+++ b/src/envdrift/cli_commands/vault.py
@@ -506,7 +506,7 @@ def vault_pull(
         ),
     ] = False,
 ) -> None:
-    """
+    r"""
     Pull a single encryption key from a cloud vault into a local .env.keys file.
 
     This is the config-free inverse of `envdrift vault-push` (single-service mode):
@@ -523,7 +523,7 @@ def vault_pull(
        envdrift vault-pull ./services/soak soak-machine --env soak --no-decrypt -p azure --vault-url https://myvault.vault.azure.net/
 
     Provider/URL/region/project-id may be omitted when they are configured in the
-    `[vault]` section of an envdrift.toml/pyproject.toml.
+    `\[vault]` section of an envdrift.toml/pyproject.toml.
 
     Examples:
         # Azure
@@ -597,16 +597,22 @@ def vault_pull(
 
     env_file = folder / f".env.{env}"
     if not env_file.exists():
-        console.print(f"[dim]No {env_file} to decrypt (use --no-decrypt to silence)[/dim]")
+        console.print(f"[dim]Key written; no {env_file} found to decrypt.[/dim]")
         return
 
     from envdrift.cli_commands.encryption_helpers import resolve_encryption_backend
     from envdrift.encryption import EncryptionBackendError, EncryptionNotFoundError
 
-    # NOTE: resolve_encryption_backend only honours `config` when it has a
-    # `.toml` suffix; a config path without that suffix is silently ignored here
-    # (falls back to auto-discovery), even though the vault settings above did
-    # load it. Pass an envdrift.toml/pyproject.toml so both stay consistent.
+    # resolve_encryption_backend only honours `config` when it has a `.toml`
+    # suffix; a config path without that suffix is silently ignored here (falls
+    # back to auto-discovery) even though the vault settings above did load it.
+    # Warn so the inconsistency isn't silent.
+    if config is not None and config.suffix.lower() != ".toml":
+        print_warning(
+            f"--config {config} has no .toml suffix; it is used for vault settings "
+            f"but ignored when selecting the encryption backend (auto-detected instead)."
+        )
+
     try:
         encryption_backend, _, _ = resolve_encryption_backend(config)
     except ValueError as e:

--- a/src/envdrift/cli_commands/vault.py
+++ b/src/envdrift/cli_commands/vault.py
@@ -23,7 +23,13 @@ def vault_push(
     env: Annotated[
         str | None,
         typer.Option(
-            "--env", "-e", help="Environment suffix (e.g., 'soak' for DOTENV_PRIVATE_KEY_SOAK)"
+            "--env",
+            "-e",
+            help=(
+                "Required (single-service mode): environment suffix that selects which "
+                "DOTENV_PRIVATE_KEY_<ENV> key is read from .env.keys "
+                "(e.g., 'soak' -> DOTENV_PRIVATE_KEY_SOAK)"
+            ),
         ),
     ] = None,
     direct: Annotated[
@@ -399,3 +405,220 @@ def vault_push(
     except VaultError as e:
         print_error(f"Failed to push secret: {e}")
         raise typer.Exit(code=1) from None
+
+
+def vault_pull(
+    folder: Annotated[
+        Path,
+        typer.Argument(help="Service folder to write the fetched .env.keys file into"),
+    ],
+    secret_name: Annotated[
+        str,
+        typer.Argument(help="Name of the secret in the vault"),
+    ],
+    env: Annotated[
+        str,
+        typer.Option(
+            "--env",
+            "-e",
+            help=(
+                "Required: environment suffix that names the key written to .env.keys "
+                "(e.g., 'soak' -> DOTENV_PRIVATE_KEY_SOAK). Also selects which "
+                ".env.<env> file is decrypted unless --no-decrypt is used."
+            ),
+        ),
+    ],
+    config: Annotated[
+        Path | None,
+        typer.Option("--config", "-c", help="Path to envdrift.toml config file"),
+    ] = None,
+    provider: Annotated[
+        str | None,
+        typer.Option("--provider", "-p", help="Vault provider: azure, aws, hashicorp, gcp"),
+    ] = None,
+    vault_url: Annotated[
+        str | None,
+        typer.Option("--vault-url", help="Vault URL (Azure Key Vault or HashiCorp Vault)"),
+    ] = None,
+    region: Annotated[
+        str | None,
+        typer.Option("--region", help="AWS region (default: us-east-1)"),
+    ] = None,
+    project_id: Annotated[
+        str | None,
+        typer.Option("--project-id", help="GCP project ID (Secret Manager)"),
+    ] = None,
+    no_decrypt: Annotated[
+        bool,
+        typer.Option(
+            "--no-decrypt",
+            help="Only write the key to .env.keys; do not decrypt the .env.<env> file",
+        ),
+    ] = False,
+) -> None:
+    """
+    Pull a single encryption key from a cloud vault into a local .env.keys file.
+
+    This is the config-free inverse of `envdrift vault-push` (single-service mode):
+    it fetches one secret, writes the DOTENV_PRIVATE_KEY_<ENV> key into
+    `<folder>/.env.keys`, and (by default) decrypts the matching `.env.<env>` file
+    so a single command onboards a developer with no TOML required.
+
+    Modes:
+
+    1. Pull key and decrypt (default):
+       envdrift vault-pull ./services/soak soak-machine --env soak -p azure --vault-url https://myvault.vault.azure.net/
+
+    2. Pull key only (skip decryption):
+       envdrift vault-pull ./services/soak soak-machine --env soak --no-decrypt -p azure --vault-url https://myvault.vault.azure.net/
+
+    Provider/URL/region/project-id may be omitted when they are configured in the
+    `[vault]` section of an envdrift.toml/pyproject.toml.
+
+    Examples:
+        # Azure
+        envdrift vault-pull . my-app-key --env production -p azure --vault-url https://myvault.vault.azure.net/
+
+        # AWS
+        envdrift vault-pull . my-app-key --env production -p aws --region us-east-1
+
+        # GCP
+        envdrift vault-pull . my-app-key --env production -p gcp --project-id my-gcp-project
+
+        # HashiCorp
+        envdrift vault-pull . my-app-key --env production -p hashicorp --vault-url https://vault.example.com:8200
+    """
+    import contextlib
+    import tomllib
+
+    from envdrift.config import ConfigNotFoundError, find_config, load_config
+    from envdrift.sync.operations import EnvKeysFile
+    from envdrift.vault import VaultError, get_vault_client
+    from envdrift.vault.base import SecretNotFoundError
+
+    # Load config defaults (same fallback as vault-push single-service mode)
+    envdrift_config = None
+    if config:
+        with contextlib.suppress(ConfigNotFoundError, tomllib.TOMLDecodeError):
+            envdrift_config = load_config(config)
+    else:
+        config_path = find_config()
+        if config_path:
+            with contextlib.suppress(ConfigNotFoundError, tomllib.TOMLDecodeError):
+                envdrift_config = load_config(config_path)
+
+    vault_config = getattr(envdrift_config, "vault", None)
+
+    # Determine effective provider
+    effective_provider = provider or getattr(vault_config, "provider", None)
+    if not effective_provider:
+        print_error("Vault provider required. Use --provider or configure in envdrift.toml")
+        raise typer.Exit(code=1)
+
+    # Determine effective vault URL
+    effective_vault_url = vault_url
+    if effective_vault_url is None and vault_config:
+        if effective_provider == "azure":
+            effective_vault_url = getattr(vault_config, "azure_vault_url", None)
+        elif effective_provider == "hashicorp":
+            effective_vault_url = getattr(vault_config, "hashicorp_url", None)
+
+    # Determine effective region
+    effective_region = region
+    if effective_region is None and vault_config:
+        effective_region = getattr(vault_config, "aws_region", None)
+
+    effective_project_id = project_id
+    if effective_project_id is None and vault_config:
+        effective_project_id = getattr(vault_config, "gcp_project_id", None)
+
+    # Validate provider-specific requirements
+    if effective_provider in ("azure", "hashicorp") and not effective_vault_url:
+        print_error(f"--vault-url required for {effective_provider}")
+        raise typer.Exit(code=1)
+    if effective_provider == "gcp" and not effective_project_id:
+        print_error("--project-id required for gcp")
+        raise typer.Exit(code=1)
+
+    # Create vault client
+    try:
+        vault_client_config = {}
+        if effective_provider == "azure":
+            vault_client_config["vault_url"] = effective_vault_url
+        elif effective_provider == "aws":
+            vault_client_config["region"] = effective_region or "us-east-1"
+        elif effective_provider == "hashicorp":
+            vault_client_config["url"] = effective_vault_url
+        elif effective_provider == "gcp":
+            vault_client_config["project_id"] = effective_project_id
+
+        client = get_vault_client(effective_provider, **vault_client_config)
+        client.authenticate()
+    except ImportError as e:
+        print_error(str(e))
+        raise typer.Exit(code=1) from None
+    except VaultError as e:
+        print_error(f"Vault authentication failed: {e}")
+        raise typer.Exit(code=1) from None
+
+    # Fetch the secret
+    try:
+        secret = client.get_secret(secret_name)
+    except SecretNotFoundError:
+        print_error(f"Secret '{secret_name}' not found in {effective_provider} vault")
+        raise typer.Exit(code=1) from None
+    except VaultError as e:
+        print_error(f"Failed to fetch secret: {e}")
+        raise typer.Exit(code=1) from None
+
+    key_name = f"DOTENV_PRIVATE_KEY_{env.upper()}"
+
+    # Parse the stored value. vault-push stores it as "DOTENV_PRIVATE_KEY_<ENV>=<value>",
+    # but accept a bare value too (no KEY_NAME= prefix).
+    raw_value = secret.value
+    if "=" in raw_value and raw_value.startswith("DOTENV_PRIVATE_KEY_"):
+        key_value = raw_value.split("=", 1)[1]
+    else:
+        key_value = raw_value
+
+    # Write the key into <folder>/.env.keys
+    env_keys_path = folder / ".env.keys"
+    env_keys = EnvKeysFile(env_keys_path)
+    env_keys.write_key(key_name, key_value, environment=env)
+
+    print_success(f"Pulled '{secret_name}' -> {key_name} written to {env_keys_path}")
+
+    # Optionally decrypt the matching .env.<env> file (true one-command onboarding)
+    if no_decrypt:
+        return
+
+    env_file = folder / f".env.{env}"
+    if not env_file.exists():
+        console.print(f"[dim]No {env_file} to decrypt (use --no-decrypt to silence)[/dim]")
+        return
+
+    from envdrift.cli_commands.encryption_helpers import resolve_encryption_backend
+    from envdrift.encryption import EncryptionBackendError, EncryptionNotFoundError
+
+    try:
+        encryption_backend, _, _ = resolve_encryption_backend(config)
+    except ValueError as e:
+        print_error(f"Unsupported encryption backend: {e}")
+        raise typer.Exit(code=1) from None
+
+    if not encryption_backend.is_installed():
+        print_error(f"{encryption_backend.name} is not installed")
+        console.print(encryption_backend.install_instructions())
+        raise typer.Exit(code=1)
+
+    try:
+        result = encryption_backend.decrypt(env_file.resolve())
+    except (EncryptionNotFoundError, EncryptionBackendError) as e:
+        print_error(f"Failed to decrypt {env_file}: {e}")
+        raise typer.Exit(code=1) from None
+
+    if not result.success:
+        print_error(f"Failed to decrypt {env_file}: {result.message}")
+        raise typer.Exit(code=1)
+
+    print_success(f"Decrypted {env_file}")

--- a/src/envdrift/cli_commands/vault.py
+++ b/src/envdrift/cli_commands/vault.py
@@ -11,6 +11,111 @@ from envdrift.env_files import detect_env_file
 from envdrift.output.rich import console, print_error, print_success, print_warning
 
 
+def _resolve_vault_settings(
+    config: Path | None,
+    provider: str | None,
+    vault_url: str | None,
+    region: str | None,
+    project_id: str | None,
+) -> tuple[str, str | None, str | None, str | None]:
+    """Resolve the effective vault provider/url/region/project-id.
+
+    Merges explicit CLI flags with the ``[vault]`` section of an
+    ``envdrift.toml``/``pyproject.toml`` (flags win). Exits the CLI with a
+    user-facing error when the provider is missing or a provider-specific
+    requirement is unmet (azure/hashicorp need ``--vault-url``; gcp needs
+    ``--project-id``).
+
+    Shared by ``vault-push`` (single-service mode) and ``vault-pull`` so the two
+    commands stay byte-for-byte consistent.
+    """
+    import contextlib
+    import tomllib
+
+    from envdrift.config import ConfigNotFoundError, find_config, load_config
+
+    envdrift_config = None
+    if config:
+        with contextlib.suppress(ConfigNotFoundError, tomllib.TOMLDecodeError):
+            envdrift_config = load_config(config)
+    else:
+        config_path = find_config()
+        if config_path:
+            with contextlib.suppress(ConfigNotFoundError, tomllib.TOMLDecodeError):
+                envdrift_config = load_config(config_path)
+
+    vault_config = getattr(envdrift_config, "vault", None)
+
+    effective_provider = provider or getattr(vault_config, "provider", None)
+    if not effective_provider:
+        print_error("Vault provider required. Use --provider or configure in envdrift.toml")
+        raise typer.Exit(code=1)
+
+    effective_vault_url = vault_url
+    if effective_vault_url is None and vault_config:
+        if effective_provider == "azure":
+            effective_vault_url = getattr(vault_config, "azure_vault_url", None)
+        elif effective_provider == "hashicorp":
+            effective_vault_url = getattr(vault_config, "hashicorp_url", None)
+
+    effective_region = region
+    if effective_region is None and vault_config:
+        effective_region = getattr(vault_config, "aws_region", None)
+
+    effective_project_id = project_id
+    if effective_project_id is None and vault_config:
+        effective_project_id = getattr(vault_config, "gcp_project_id", None)
+
+    if effective_provider in ("azure", "hashicorp") and not effective_vault_url:
+        print_error(f"--vault-url required for {effective_provider}")
+        raise typer.Exit(code=1)
+    if effective_provider == "gcp" and not effective_project_id:
+        print_error("--project-id required for gcp")
+        raise typer.Exit(code=1)
+
+    return effective_provider, effective_vault_url, effective_region, effective_project_id
+
+
+def _build_authenticated_client(
+    provider: str,
+    vault_url: str | None,
+    region: str | None,
+    project_id: str | None,
+):
+    """Create and authenticate a vault client for the given effective settings.
+
+    Exits the CLI with a user-facing error on a missing optional dependency
+    (``ImportError``), an unsupported provider or bad configuration
+    (``ValueError``), or an authentication failure (``VaultError``).
+    """
+    from envdrift.vault import VaultError, get_vault_client
+
+    try:
+        vault_client_config: dict[str, str | None] = {}
+        if provider == "azure":
+            vault_client_config["vault_url"] = vault_url
+        elif provider == "aws":
+            vault_client_config["region"] = region or "us-east-1"
+        elif provider == "hashicorp":
+            vault_client_config["url"] = vault_url
+        elif provider == "gcp":
+            vault_client_config["project_id"] = project_id
+
+        client = get_vault_client(provider, **vault_client_config)
+        client.authenticate()
+    except ImportError as e:
+        print_error(str(e))
+        raise typer.Exit(code=1) from None
+    except ValueError as e:
+        print_error(f"Invalid vault configuration: {e}")
+        raise typer.Exit(code=1) from None
+    except VaultError as e:
+        print_error(f"Vault authentication failed: {e}")
+        raise typer.Exit(code=1) from None
+
+    return client
+
+
 def vault_push(
     folder: Annotated[
         Path | None,
@@ -107,12 +212,8 @@ def vault_push(
         # Push all without encrypting (when files are already encrypted)
         envdrift vault-push --all --skip-encrypt
     """
-    import contextlib
-    import tomllib
-
-    from envdrift.config import ConfigNotFoundError, find_config, load_config
     from envdrift.sync.operations import EnvKeysFile
-    from envdrift.vault import VaultError, get_vault_client
+    from envdrift.vault import VaultError
     from envdrift.vault.base import SecretNotFoundError
 
     # Validate --skip-encrypt is only used with --all
@@ -298,49 +399,14 @@ def vault_push(
             raise typer.Exit(code=1)
         return
 
-    # Normal/Direct mode preamble
-    envdrift_config = None
-    if config:
-        with contextlib.suppress(ConfigNotFoundError, tomllib.TOMLDecodeError):
-            envdrift_config = load_config(config)
-    else:
-        config_path = find_config()
-        if config_path:
-            with contextlib.suppress(ConfigNotFoundError, tomllib.TOMLDecodeError):
-                envdrift_config = load_config(config_path)
-
-    vault_config = getattr(envdrift_config, "vault", None)
-
-    # Determine effective provider
-    effective_provider = provider or getattr(vault_config, "provider", None)
-    if not effective_provider:
-        print_error("Vault provider required. Use --provider or configure in envdrift.toml")
-        raise typer.Exit(code=1)
-
-    # Determine effective vault URL
-    effective_vault_url = vault_url
-    if effective_vault_url is None and vault_config:
-        if effective_provider == "azure":
-            effective_vault_url = getattr(vault_config, "azure_vault_url", None)
-        elif effective_provider == "hashicorp":
-            effective_vault_url = getattr(vault_config, "hashicorp_url", None)
-
-    # Determine effective region
-    effective_region = region
-    if effective_region is None and vault_config:
-        effective_region = getattr(vault_config, "aws_region", None)
-
-    effective_project_id = project_id
-    if effective_project_id is None and vault_config:
-        effective_project_id = getattr(vault_config, "gcp_project_id", None)
-
-    # Validate provider-specific requirements
-    if effective_provider in ("azure", "hashicorp") and not effective_vault_url:
-        print_error(f"--vault-url required for {effective_provider}")
-        raise typer.Exit(code=1)
-    if effective_provider == "gcp" and not effective_project_id:
-        print_error("--project-id required for gcp")
-        raise typer.Exit(code=1)
+    # Normal/Direct mode preamble: resolve effective provider settings (shared
+    # with vault-pull).
+    (
+        effective_provider,
+        effective_vault_url,
+        effective_region,
+        effective_project_id,
+    ) = _resolve_vault_settings(config, provider, vault_url, region, project_id)
 
     # Handle direct mode
     if direct:
@@ -375,26 +441,10 @@ def vault_push(
         actual_secret_name = secret_name
         actual_value = f"{key_name}={key_value}"
 
-    # Create vault client
-    try:
-        vault_client_config = {}
-        if effective_provider == "azure":
-            vault_client_config["vault_url"] = effective_vault_url
-        elif effective_provider == "aws":
-            vault_client_config["region"] = effective_region or "us-east-1"
-        elif effective_provider == "hashicorp":
-            vault_client_config["url"] = effective_vault_url
-        elif effective_provider == "gcp":
-            vault_client_config["project_id"] = effective_project_id
-
-        client = get_vault_client(effective_provider, **vault_client_config)
-        client.authenticate()
-    except ImportError as e:
-        print_error(str(e))
-        raise typer.Exit(code=1) from None
-    except VaultError as e:
-        print_error(f"Vault authentication failed: {e}")
-        raise typer.Exit(code=1) from None
+    # Create vault client (shared with vault-pull)
+    client = _build_authenticated_client(
+        effective_provider, effective_vault_url, effective_region, effective_project_id
+    )
 
     # Push the secret
     try:
@@ -488,78 +538,21 @@ def vault_pull(
         # HashiCorp
         envdrift vault-pull . my-app-key --env production -p hashicorp --vault-url https://vault.example.com:8200
     """
-    import contextlib
-    import tomllib
-
-    from envdrift.config import ConfigNotFoundError, find_config, load_config
     from envdrift.sync.operations import EnvKeysFile
-    from envdrift.vault import VaultError, get_vault_client
+    from envdrift.vault import VaultError
     from envdrift.vault.base import SecretNotFoundError
 
-    # Load config defaults (same fallback as vault-push single-service mode)
-    envdrift_config = None
-    if config:
-        with contextlib.suppress(ConfigNotFoundError, tomllib.TOMLDecodeError):
-            envdrift_config = load_config(config)
-    else:
-        config_path = find_config()
-        if config_path:
-            with contextlib.suppress(ConfigNotFoundError, tomllib.TOMLDecodeError):
-                envdrift_config = load_config(config_path)
-
-    vault_config = getattr(envdrift_config, "vault", None)
-
-    # Determine effective provider
-    effective_provider = provider or getattr(vault_config, "provider", None)
-    if not effective_provider:
-        print_error("Vault provider required. Use --provider or configure in envdrift.toml")
-        raise typer.Exit(code=1)
-
-    # Determine effective vault URL
-    effective_vault_url = vault_url
-    if effective_vault_url is None and vault_config:
-        if effective_provider == "azure":
-            effective_vault_url = getattr(vault_config, "azure_vault_url", None)
-        elif effective_provider == "hashicorp":
-            effective_vault_url = getattr(vault_config, "hashicorp_url", None)
-
-    # Determine effective region
-    effective_region = region
-    if effective_region is None and vault_config:
-        effective_region = getattr(vault_config, "aws_region", None)
-
-    effective_project_id = project_id
-    if effective_project_id is None and vault_config:
-        effective_project_id = getattr(vault_config, "gcp_project_id", None)
-
-    # Validate provider-specific requirements
-    if effective_provider in ("azure", "hashicorp") and not effective_vault_url:
-        print_error(f"--vault-url required for {effective_provider}")
-        raise typer.Exit(code=1)
-    if effective_provider == "gcp" and not effective_project_id:
-        print_error("--project-id required for gcp")
-        raise typer.Exit(code=1)
-
-    # Create vault client
-    try:
-        vault_client_config = {}
-        if effective_provider == "azure":
-            vault_client_config["vault_url"] = effective_vault_url
-        elif effective_provider == "aws":
-            vault_client_config["region"] = effective_region or "us-east-1"
-        elif effective_provider == "hashicorp":
-            vault_client_config["url"] = effective_vault_url
-        elif effective_provider == "gcp":
-            vault_client_config["project_id"] = effective_project_id
-
-        client = get_vault_client(effective_provider, **vault_client_config)
-        client.authenticate()
-    except ImportError as e:
-        print_error(str(e))
-        raise typer.Exit(code=1) from None
-    except VaultError as e:
-        print_error(f"Vault authentication failed: {e}")
-        raise typer.Exit(code=1) from None
+    # Resolve effective provider settings + build an authenticated client
+    # (shared with vault-push single-service mode).
+    (
+        effective_provider,
+        effective_vault_url,
+        effective_region,
+        effective_project_id,
+    ) = _resolve_vault_settings(config, provider, vault_url, region, project_id)
+    client = _build_authenticated_client(
+        effective_provider, effective_vault_url, effective_region, effective_project_id
+    )
 
     # Fetch the secret
     try:
@@ -577,7 +570,17 @@ def vault_pull(
     # but accept a bare value too (no KEY_NAME= prefix).
     raw_value = secret.value
     if "=" in raw_value and raw_value.startswith("DOTENV_PRIVATE_KEY_"):
-        key_value = raw_value.split("=", 1)[1]
+        stored_key_name, key_value = raw_value.split("=", 1)
+        # Fail fast on env-prefix mismatch: e.g. pulling --env production a secret
+        # that was pushed --env staging would otherwise silently store the staging
+        # key under the production name and fail later with an opaque crypto error.
+        if stored_key_name != key_name:
+            print_error(
+                f"Secret holds '{stored_key_name}' but --env {env} expects '{key_name}'. "
+                f"Re-run with --env matching the environment the secret was pushed for "
+                f"(or push the secret under the correct environment)."
+            )
+            raise typer.Exit(code=1)
     else:
         key_value = raw_value
 
@@ -600,6 +603,10 @@ def vault_pull(
     from envdrift.cli_commands.encryption_helpers import resolve_encryption_backend
     from envdrift.encryption import EncryptionBackendError, EncryptionNotFoundError
 
+    # NOTE: resolve_encryption_backend only honours `config` when it has a
+    # `.toml` suffix; a config path without that suffix is silently ignored here
+    # (falls back to auto-discovery), even though the vault settings above did
+    # load it. Pass an envdrift.toml/pyproject.toml so both stay consistent.
     try:
         encryption_backend, _, _ = resolve_encryption_backend(config)
     except ValueError as e:
@@ -612,7 +619,9 @@ def vault_pull(
         raise typer.Exit(code=1)
 
     try:
-        result = encryption_backend.decrypt(env_file.resolve())
+        # Point the backend at the .env.keys we just wrote so decryption works
+        # even when FOLDER is not the current working directory (monorepo usage).
+        result = encryption_backend.decrypt(env_file.resolve(), keys_file=env_keys_path.resolve())
     except (EncryptionNotFoundError, EncryptionBackendError) as e:
         print_error(f"Failed to decrypt {env_file}: {e}")
         raise typer.Exit(code=1) from None

--- a/tests/integration/test_azure_integration.py
+++ b/tests/integration/test_azure_integration.py
@@ -328,3 +328,72 @@ vault_key_path = "test-pushed-secret"
                 f"{endpoint}/secrets/test-pushed-secret",
                 params={"api-version": "7.4"},
             )
+
+
+class TestAzureVaultPull:
+    """Test CLI vault-pull commands with Azure Key Vault."""
+
+    def test_azure_vault_pull_round_trip(
+        self,
+        lowkey_vault_endpoint: str,
+        azure_test_env: dict,
+        lowkey_vault_client,
+        work_dir: Path,
+        integration_pythonpath: str,
+    ):
+        """Seed a secret directly, then fetch it back via `envdrift vault-pull`."""
+        session, endpoint = lowkey_vault_client
+        secret_name = "test-pull-secret"
+        stored_value = "DOTENV_PRIVATE_KEY_PRODUCTION=pulledkey123"
+
+        # Seed the secret directly via the vault REST API
+        put = session.put(
+            f"{endpoint}/secrets/{secret_name}",
+            json={"value": stored_value},
+            headers={"Content-Type": "application/json"},
+            params={"api-version": "7.4"},
+        )
+        if put.status_code not in (200, 201):
+            pytest.skip(f"Lowkey Vault returned {put.status_code} on seed")
+
+        try:
+            env = azure_test_env.copy()
+            env["PYTHONPATH"] = integration_pythonpath
+            env["CURL_CA_BUNDLE"] = ""
+            env["REQUESTS_CA_BUNDLE"] = ""
+
+            # --no-decrypt: we only want to assert the key was written back
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "envdrift",
+                    "vault-pull",
+                    str(work_dir),
+                    secret_name,
+                    "--env",
+                    "production",
+                    "--no-decrypt",
+                    "-p",
+                    "azure",
+                    "--vault-url",
+                    lowkey_vault_endpoint,
+                ],
+                cwd=work_dir,
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+
+            # May fail on auth in the emulator, but must not crash
+            assert result.returncode in (0, 1), result.stderr
+            if result.returncode == 0:
+                keys_content = (work_dir / ".env.keys").read_text()
+                assert "DOTENV_PRIVATE_KEY_PRODUCTION=pulledkey123" in keys_content
+        finally:
+            with contextlib.suppress(Exception):
+                session.delete(
+                    f"{endpoint}/secrets/{secret_name}",
+                    params={"api-version": "7.4"},
+                )

--- a/tests/integration/test_azure_integration.py
+++ b/tests/integration/test_azure_integration.py
@@ -340,6 +340,7 @@ class TestAzureVaultPull:
         lowkey_vault_client,
         work_dir: Path,
         integration_pythonpath: str,
+        envdrift_cmd: list[str],
     ):
         """Seed a secret directly, then fetch it back via `envdrift vault-pull`."""
         session, endpoint = lowkey_vault_client
@@ -362,12 +363,12 @@ class TestAzureVaultPull:
             env["CURL_CA_BUNDLE"] = ""
             env["REQUESTS_CA_BUNDLE"] = ""
 
-            # --no-decrypt: we only want to assert the key was written back
+            # Use the real console-script entrypoint (there is no envdrift.__main__,
+            # so `python -m envdrift` would exit before dispatching). --no-decrypt:
+            # we only assert the key is written back.
             result = subprocess.run(
                 [
-                    sys.executable,
-                    "-m",
-                    "envdrift",
+                    *envdrift_cmd,
                     "vault-pull",
                     str(work_dir),
                     secret_name,
@@ -386,11 +387,24 @@ class TestAzureVaultPull:
                 timeout=30,
             )
 
-            # May fail on auth in the emulator, but must not crash
-            assert result.returncode in (0, 1), result.stderr
+            combined = result.stdout + result.stderr
+            # The CLI must actually dispatch — a missing entrypoint / import error
+            # would make this test vacuous, so fail loudly on those.
+            assert "No module named" not in combined, combined
+            assert "is a package and cannot be directly executed" not in combined, combined
+
             if result.returncode == 0:
+                # Real success: the seeded key was fetched and written.
                 keys_content = (work_dir / ".env.keys").read_text()
                 assert "DOTENV_PRIVATE_KEY_PRODUCTION=pulledkey123" in keys_content
+            else:
+                # DefaultAzureCredential can't authenticate against Lowkey Vault in
+                # CI; skip visibly rather than passing vacuously. Still confirms the
+                # command ran far enough to attempt the vault call.
+                assert "vault" in combined.lower() or "credential" in combined.lower(), combined
+                pytest.skip(
+                    f"vault-pull could not authenticate against Lowkey Vault: {combined[:200]}"
+                )
         finally:
             with contextlib.suppress(Exception):
                 session.delete(

--- a/tests/unit/test_cli_vault_pull.py
+++ b/tests/unit/test_cli_vault_pull.py
@@ -1,0 +1,675 @@
+"""Tests for vault-pull command (config-free single-secret pull)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+from envdrift.cli import app
+from envdrift.encryption import EncryptionProvider
+from envdrift.encryption.base import EncryptionBackendError, EncryptionResult
+from envdrift.vault.base import SecretNotFoundError, SecretValue, VaultError
+from tests.helpers import DummyEncryptionBackend
+
+runner = CliRunner()
+
+
+def _make_client(value: str) -> MagicMock:
+    client = MagicMock()
+    client.get_secret.return_value = SecretValue(name="my-secret", value=value)
+    return client
+
+
+class TestVaultPullSingleSecret:
+    """Tests for the single-secret config-free vault-pull command."""
+
+    @patch("envdrift.cli_commands.encryption_helpers.resolve_encryption_backend")
+    @patch("envdrift.vault.get_vault_client")
+    def test_pull_success_writes_key_and_decrypts(
+        self,
+        mock_get_client,
+        mock_resolve_backend,
+        tmp_path,
+    ):
+        """Happy path: writes DOTENV_PRIVATE_KEY_<ENV> to .env.keys and decrypts."""
+        mock_get_client.return_value = _make_client("DOTENV_PRIVATE_KEY_PRODUCTION=abc123secret")
+        backend = DummyEncryptionBackend()
+        mock_resolve_backend.return_value = (backend, EncryptionProvider.DOTENVX, None)
+
+        # An encrypted env file exists so decrypt runs
+        env_file = tmp_path / ".env.production"
+        env_file.write_text("SECRET=encrypted:xyz")
+
+        result = runner.invoke(
+            app,
+            [
+                "vault-pull",
+                str(tmp_path),
+                "my-secret",
+                "--env",
+                "production",
+                "-p",
+                "azure",
+                "--vault-url",
+                "https://myvault.vault.azure.net/",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        keys_content = (tmp_path / ".env.keys").read_text()
+        assert "DOTENV_PRIVATE_KEY_PRODUCTION=abc123secret" in keys_content
+        # decrypt was called on the env file
+        assert backend.decrypt_calls == [env_file.resolve()]
+        assert "Decrypted" in result.output
+
+    @patch("envdrift.cli_commands.encryption_helpers.resolve_encryption_backend")
+    @patch("envdrift.vault.get_vault_client")
+    def test_pull_value_without_prefix(
+        self,
+        mock_get_client,
+        mock_resolve_backend,
+        tmp_path,
+    ):
+        """Secret value with no KEY_NAME= prefix is treated as the bare key value."""
+        mock_get_client.return_value = _make_client("barevalue999")
+        backend = DummyEncryptionBackend()
+        mock_resolve_backend.return_value = (backend, EncryptionProvider.DOTENVX, None)
+
+        result = runner.invoke(
+            app,
+            [
+                "vault-pull",
+                str(tmp_path),
+                "my-secret",
+                "--env",
+                "staging",
+                "--no-decrypt",
+                "-p",
+                "azure",
+                "--vault-url",
+                "https://myvault.vault.azure.net/",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        keys_content = (tmp_path / ".env.keys").read_text()
+        assert "DOTENV_PRIVATE_KEY_STAGING=barevalue999" in keys_content
+
+    @patch("envdrift.vault.get_vault_client")
+    def test_pull_no_decrypt_skips_decryption(
+        self,
+        mock_get_client,
+        tmp_path,
+    ):
+        """--no-decrypt writes the key but does not attempt decryption."""
+        mock_get_client.return_value = _make_client("DOTENV_PRIVATE_KEY_PRODUCTION=abc123")
+        # Even with an env file present, decrypt should not run
+        (tmp_path / ".env.production").write_text("SECRET=encrypted:xyz")
+
+        result = runner.invoke(
+            app,
+            [
+                "vault-pull",
+                str(tmp_path),
+                "my-secret",
+                "--env",
+                "production",
+                "--no-decrypt",
+                "-p",
+                "azure",
+                "--vault-url",
+                "https://myvault.vault.azure.net/",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "Decrypted" not in result.output
+        assert "DOTENV_PRIVATE_KEY_PRODUCTION=abc123" in (tmp_path / ".env.keys").read_text()
+
+    @patch("envdrift.vault.get_vault_client")
+    def test_pull_no_env_file_to_decrypt(
+        self,
+        mock_get_client,
+        tmp_path,
+    ):
+        """When no .env.<env> file exists, key is written and decrypt is skipped gracefully."""
+        mock_get_client.return_value = _make_client("DOTENV_PRIVATE_KEY_PRODUCTION=abc123")
+
+        result = runner.invoke(
+            app,
+            [
+                "vault-pull",
+                str(tmp_path),
+                "my-secret",
+                "--env",
+                "production",
+                "-p",
+                "azure",
+                "--vault-url",
+                "https://myvault.vault.azure.net/",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "No" in result.output and "to decrypt" in result.output
+        assert "DOTENV_PRIVATE_KEY_PRODUCTION=abc123" in (tmp_path / ".env.keys").read_text()
+
+    def test_pull_missing_env_flag(self, tmp_path):
+        """--env is required; omitting it fails."""
+        result = runner.invoke(
+            app,
+            [
+                "vault-pull",
+                str(tmp_path),
+                "my-secret",
+                "-p",
+                "azure",
+                "--vault-url",
+                "https://myvault.vault.azure.net/",
+            ],
+        )
+        assert result.exit_code != 0
+
+    @patch("envdrift.vault.get_vault_client")
+    def test_pull_secret_not_found(
+        self,
+        mock_get_client,
+        tmp_path,
+    ):
+        """SecretNotFoundError exits with code 1."""
+        client = MagicMock()
+        client.get_secret.side_effect = SecretNotFoundError("missing")
+        mock_get_client.return_value = client
+
+        result = runner.invoke(
+            app,
+            [
+                "vault-pull",
+                str(tmp_path),
+                "my-secret",
+                "--env",
+                "production",
+                "-p",
+                "azure",
+                "--vault-url",
+                "https://myvault.vault.azure.net/",
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert "not found" in result.output.lower()
+
+    @patch("envdrift.vault.get_vault_client")
+    def test_pull_vault_error_on_fetch(
+        self,
+        mock_get_client,
+        tmp_path,
+    ):
+        """VaultError during fetch exits with code 1."""
+        client = MagicMock()
+        client.get_secret.side_effect = VaultError("boom")
+        mock_get_client.return_value = client
+
+        result = runner.invoke(
+            app,
+            [
+                "vault-pull",
+                str(tmp_path),
+                "my-secret",
+                "--env",
+                "production",
+                "-p",
+                "azure",
+                "--vault-url",
+                "https://myvault.vault.azure.net/",
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert "Failed to fetch secret" in result.output
+
+    def test_pull_azure_requires_vault_url(self, tmp_path):
+        """Azure provider without --vault-url fails validation."""
+        result = runner.invoke(
+            app,
+            [
+                "vault-pull",
+                str(tmp_path),
+                "my-secret",
+                "--env",
+                "production",
+                "-p",
+                "azure",
+            ],
+        )
+        assert result.exit_code == 1
+        assert "vault-url required" in result.output.lower()
+
+    def test_pull_gcp_requires_project_id(self, tmp_path):
+        """GCP provider without --project-id fails validation."""
+        result = runner.invoke(
+            app,
+            [
+                "vault-pull",
+                str(tmp_path),
+                "my-secret",
+                "--env",
+                "production",
+                "-p",
+                "gcp",
+            ],
+        )
+        assert result.exit_code == 1
+        assert "project-id required" in result.output.lower()
+
+    def test_pull_missing_provider(self, tmp_path):
+        """No provider and no config fails."""
+        with patch("envdrift.config.find_config", return_value=None):
+            result = runner.invoke(
+                app,
+                [
+                    "vault-pull",
+                    str(tmp_path),
+                    "my-secret",
+                    "--env",
+                    "production",
+                ],
+            )
+        assert result.exit_code == 1
+        assert "provider required" in result.output.lower()
+
+    @patch("envdrift.vault.get_vault_client")
+    def test_pull_auth_failure(
+        self,
+        mock_get_client,
+        tmp_path,
+    ):
+        """Authentication failure exits with code 1."""
+        client = MagicMock()
+        client.authenticate.side_effect = VaultError("auth failed")
+        mock_get_client.return_value = client
+
+        result = runner.invoke(
+            app,
+            [
+                "vault-pull",
+                str(tmp_path),
+                "my-secret",
+                "--env",
+                "production",
+                "-p",
+                "azure",
+                "--vault-url",
+                "https://myvault.vault.azure.net/",
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert "authentication failed" in result.output.lower()
+
+    @patch("envdrift.cli_commands.encryption_helpers.resolve_encryption_backend")
+    @patch("envdrift.vault.get_vault_client")
+    def test_pull_decrypt_backend_not_installed(
+        self,
+        mock_get_client,
+        mock_resolve_backend,
+        tmp_path,
+    ):
+        """If the encryption backend is not installed, exit with code 1."""
+        mock_get_client.return_value = _make_client("DOTENV_PRIVATE_KEY_PRODUCTION=abc123")
+        mock_resolve_backend.return_value = (
+            DummyEncryptionBackend(installed=False),
+            EncryptionProvider.DOTENVX,
+            None,
+        )
+        (tmp_path / ".env.production").write_text("SECRET=encrypted:xyz")
+
+        result = runner.invoke(
+            app,
+            [
+                "vault-pull",
+                str(tmp_path),
+                "my-secret",
+                "--env",
+                "production",
+                "-p",
+                "azure",
+                "--vault-url",
+                "https://myvault.vault.azure.net/",
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert "not installed" in result.output.lower()
+
+    @patch("envdrift.cli_commands.encryption_helpers.resolve_encryption_backend")
+    @patch("envdrift.vault.get_vault_client")
+    def test_pull_decrypt_failure(
+        self,
+        mock_get_client,
+        mock_resolve_backend,
+        tmp_path,
+    ):
+        """A failed decrypt result exits with code 1."""
+        mock_get_client.return_value = _make_client("DOTENV_PRIVATE_KEY_PRODUCTION=abc123")
+        backend = DummyEncryptionBackend()
+
+        def fail_decrypt(env_file, **kwargs):
+            return EncryptionResult(success=False, message="bad key", file_path=env_file)
+
+        backend.decrypt = fail_decrypt  # type: ignore[method-assign]
+        mock_resolve_backend.return_value = (backend, EncryptionProvider.DOTENVX, None)
+        (tmp_path / ".env.production").write_text("SECRET=encrypted:xyz")
+
+        result = runner.invoke(
+            app,
+            [
+                "vault-pull",
+                str(tmp_path),
+                "my-secret",
+                "--env",
+                "production",
+                "-p",
+                "azure",
+                "--vault-url",
+                "https://myvault.vault.azure.net/",
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert "failed to decrypt" in result.output.lower()
+
+    @patch("envdrift.cli_commands.encryption_helpers.resolve_encryption_backend")
+    @patch("envdrift.vault.get_vault_client")
+    def test_pull_decrypt_raises_backend_error(
+        self,
+        mock_get_client,
+        mock_resolve_backend,
+        tmp_path,
+    ):
+        """An EncryptionBackendError during decrypt exits with code 1."""
+        mock_get_client.return_value = _make_client("DOTENV_PRIVATE_KEY_PRODUCTION=abc123")
+        backend = DummyEncryptionBackend(
+            decrypt_side_effect=EncryptionBackendError("decrypt blew up")
+        )
+        mock_resolve_backend.return_value = (backend, EncryptionProvider.DOTENVX, None)
+        (tmp_path / ".env.production").write_text("SECRET=encrypted:xyz")
+
+        result = runner.invoke(
+            app,
+            [
+                "vault-pull",
+                str(tmp_path),
+                "my-secret",
+                "--env",
+                "production",
+                "-p",
+                "azure",
+                "--vault-url",
+                "https://myvault.vault.azure.net/",
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert "failed to decrypt" in result.output.lower()
+
+    @patch("envdrift.vault.get_vault_client")
+    def test_pull_aws_provider(
+        self,
+        mock_get_client,
+        tmp_path,
+    ):
+        """AWS provider works with --region and no vault-url."""
+        mock_get_client.return_value = _make_client("DOTENV_PRIVATE_KEY_PRODUCTION=awssecret")
+
+        result = runner.invoke(
+            app,
+            [
+                "vault-pull",
+                str(tmp_path),
+                "my-secret",
+                "--env",
+                "production",
+                "--no-decrypt",
+                "-p",
+                "aws",
+                "--region",
+                "us-west-2",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        mock_get_client.assert_called_once_with("aws", region="us-west-2")
+        assert "DOTENV_PRIVATE_KEY_PRODUCTION=awssecret" in (tmp_path / ".env.keys").read_text()
+
+    @patch("envdrift.vault.get_vault_client")
+    def test_pull_hashicorp_provider(
+        self,
+        mock_get_client,
+        tmp_path,
+    ):
+        """HashiCorp provider passes url through to the client."""
+        mock_get_client.return_value = _make_client("DOTENV_PRIVATE_KEY_PRODUCTION=hcvalue")
+
+        result = runner.invoke(
+            app,
+            [
+                "vault-pull",
+                str(tmp_path),
+                "my-secret",
+                "--env",
+                "production",
+                "--no-decrypt",
+                "-p",
+                "hashicorp",
+                "--vault-url",
+                "https://vault.example.com:8200",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        mock_get_client.assert_called_once_with("hashicorp", url="https://vault.example.com:8200")
+
+    @patch("envdrift.vault.get_vault_client")
+    def test_pull_gcp_provider(
+        self,
+        mock_get_client,
+        tmp_path,
+    ):
+        """GCP provider passes project_id through to the client."""
+        mock_get_client.return_value = _make_client("DOTENV_PRIVATE_KEY_PRODUCTION=gcpvalue")
+
+        result = runner.invoke(
+            app,
+            [
+                "vault-pull",
+                str(tmp_path),
+                "my-secret",
+                "--env",
+                "production",
+                "--no-decrypt",
+                "-p",
+                "gcp",
+                "--project-id",
+                "my-project",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        mock_get_client.assert_called_once_with("gcp", project_id="my-project")
+
+    @patch("envdrift.cli_commands.encryption_helpers.resolve_encryption_backend")
+    @patch("envdrift.vault.get_vault_client")
+    def test_pull_unsupported_backend(
+        self,
+        mock_get_client,
+        mock_resolve_backend,
+        tmp_path,
+    ):
+        """A ValueError from backend resolution exits with code 1."""
+        mock_get_client.return_value = _make_client("DOTENV_PRIVATE_KEY_PRODUCTION=abc123")
+        mock_resolve_backend.side_effect = ValueError("nope")
+        (tmp_path / ".env.production").write_text("SECRET=encrypted:xyz")
+
+        result = runner.invoke(
+            app,
+            [
+                "vault-pull",
+                str(tmp_path),
+                "my-secret",
+                "--env",
+                "production",
+                "-p",
+                "azure",
+                "--vault-url",
+                "https://myvault.vault.azure.net/",
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert "unsupported encryption backend" in result.output.lower()
+
+    @patch("envdrift.vault.get_vault_client")
+    def test_pull_uses_config_defaults(
+        self,
+        mock_get_client,
+        tmp_path,
+    ):
+        """When --provider/--vault-url are omitted, values come from envdrift.toml [vault]."""
+        mock_get_client.return_value = _make_client("DOTENV_PRIVATE_KEY_PRODUCTION=cfgvalue")
+
+        config_file = tmp_path / "envdrift.toml"
+        config_file.write_text(
+            '[vault]\nprovider = "azure"\n\n[vault.azure]\nvault_url = "https://cfg.vault.azure.net/"\n'
+        )
+
+        result = runner.invoke(
+            app,
+            [
+                "vault-pull",
+                str(tmp_path),
+                "my-secret",
+                "--env",
+                "production",
+                "--no-decrypt",
+                "-c",
+                str(config_file),
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        mock_get_client.assert_called_once_with("azure", vault_url="https://cfg.vault.azure.net/")
+
+    @patch("envdrift.vault.get_vault_client")
+    def test_pull_import_error(
+        self,
+        mock_get_client,
+        tmp_path,
+    ):
+        """ImportError (missing SDK extras) exits with code 1."""
+        mock_get_client.side_effect = ImportError("Azure vault support requires extras")
+
+        result = runner.invoke(
+            app,
+            [
+                "vault-pull",
+                str(tmp_path),
+                "my-secret",
+                "--env",
+                "production",
+                "-p",
+                "azure",
+                "--vault-url",
+                "https://myvault.vault.azure.net/",
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert "Azure vault support" in result.output
+
+
+class _InMemoryVault:
+    """A tiny in-memory vault used to exercise a push -> pull round-trip."""
+
+    def __init__(self) -> None:
+        self.store: dict[str, str] = {}
+
+    def authenticate(self) -> None:
+        return None
+
+    def set_secret(self, name: str, value: str) -> SecretValue:
+        self.store[name] = value
+        return SecretValue(name=name, value=value, version="1")
+
+    def get_secret(self, name: str) -> SecretValue:
+        if name not in self.store:
+            raise SecretNotFoundError(name)
+        return SecretValue(name=name, value=self.store[name])
+
+
+class TestVaultPushPullRoundTrip:
+    """vault-push then vault-pull should reproduce the original key."""
+
+    @patch("envdrift.cli_commands.encryption_helpers.resolve_encryption_backend")
+    @patch("envdrift.vault.get_vault_client")
+    def test_push_then_pull_roundtrip(
+        self,
+        mock_get_client,
+        mock_resolve_backend,
+        tmp_path,
+    ):
+        """A key pushed from one folder is recovered identically by vault-pull."""
+        vault = _InMemoryVault()
+        mock_get_client.return_value = vault
+        mock_resolve_backend.return_value = (
+            DummyEncryptionBackend(),
+            EncryptionProvider.DOTENVX,
+            None,
+        )
+
+        # Source folder with a real key in .env.keys
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / ".env.keys").write_text("DOTENV_PRIVATE_KEY_PRODUCTION=roundtripsecret\n")
+
+        push = runner.invoke(
+            app,
+            [
+                "vault-push",
+                str(src),
+                "shared-key",
+                "--env",
+                "production",
+                "-p",
+                "azure",
+                "--vault-url",
+                "https://myvault.vault.azure.net/",
+            ],
+        )
+        assert push.exit_code == 0, push.output
+        assert vault.store["shared-key"] == ("DOTENV_PRIVATE_KEY_PRODUCTION=roundtripsecret")
+
+        # Destination folder receives the key via vault-pull
+        dst = tmp_path / "dst"
+        dst.mkdir()
+
+        pull = runner.invoke(
+            app,
+            [
+                "vault-pull",
+                str(dst),
+                "shared-key",
+                "--env",
+                "production",
+                "--no-decrypt",
+                "-p",
+                "azure",
+                "--vault-url",
+                "https://myvault.vault.azure.net/",
+            ],
+        )
+        assert pull.exit_code == 0, pull.output
+
+        recovered = (dst / ".env.keys").read_text()
+        assert "DOTENV_PRIVATE_KEY_PRODUCTION=roundtripsecret" in recovered

--- a/tests/unit/test_cli_vault_pull.py
+++ b/tests/unit/test_cli_vault_pull.py
@@ -152,7 +152,7 @@ class TestVaultPullSingleSecret:
         )
 
         assert result.exit_code == 0, result.output
-        assert "No" in result.output and "to decrypt" in result.output
+        assert "found to decrypt" in result.output
         assert "DOTENV_PRIVATE_KEY_PRODUCTION=abc123" in (tmp_path / ".env.keys").read_text()
 
     def test_pull_missing_env_flag(self, tmp_path):
@@ -742,11 +742,10 @@ class TestVaultPullReviewFixes:
         assert backend.decrypt_kwargs, "decrypt was not called"
         assert backend.decrypt_kwargs[0]["keys_file"] == (folder / ".env.keys").resolve()
 
-    @patch("envdrift.vault.get_vault_client")
-    def test_pull_invalid_provider_exits_cleanly(self, mock_get_client, tmp_path):
-        """An unsupported provider (ValueError from get_vault_client) exits cleanly, no traceback."""
-        mock_get_client.side_effect = ValueError("unsupported provider 'nope'")
-
+    def test_pull_invalid_provider_exits_cleanly(self, tmp_path):
+        """An unsupported provider raises ValueError in get_vault_client; the CLI exits cleanly."""
+        # `bogus` is not azure/hashicorp/gcp, so it reaches get_vault_client, where
+        # VaultProvider("bogus") raises a real ValueError — no mock needed.
         result = runner.invoke(
             app,
             [
@@ -756,9 +755,7 @@ class TestVaultPullReviewFixes:
                 "--env",
                 "production",
                 "-p",
-                "azure",
-                "--vault-url",
-                "https://myvault.vault.azure.net/",
+                "bogus",
             ],
         )
 

--- a/tests/unit/test_cli_vault_pull.py
+++ b/tests/unit/test_cli_vault_pull.py
@@ -673,3 +673,96 @@ class TestVaultPushPullRoundTrip:
 
         recovered = (dst / ".env.keys").read_text()
         assert "DOTENV_PRIVATE_KEY_PRODUCTION=roundtripsecret" in recovered
+
+
+class TestVaultPullReviewFixes:
+    """Regression tests for issues raised in PR review."""
+
+    @patch("envdrift.vault.get_vault_client")
+    def test_pull_fails_fast_on_env_prefix_mismatch(self, mock_get_client, tmp_path):
+        """Pulling --env production a secret pushed --env staging fails fast, writes nothing."""
+        mock_get_client.return_value = _make_client("DOTENV_PRIVATE_KEY_STAGING=abc123")
+
+        result = runner.invoke(
+            app,
+            [
+                "vault-pull",
+                str(tmp_path),
+                "my-secret",
+                "--env",
+                "production",
+                "--no-decrypt",
+                "-p",
+                "azure",
+                "--vault-url",
+                "https://myvault.vault.azure.net/",
+            ],
+        )
+
+        assert result.exit_code == 1, result.output
+        # The error names both the stored prefix and the requested env.
+        assert "DOTENV_PRIVATE_KEY_STAGING" in result.output
+        assert "production" in result.output.lower()
+        # No mismatched key is written.
+        assert not (tmp_path / ".env.keys").exists()
+
+    @patch("envdrift.cli_commands.encryption_helpers.resolve_encryption_backend")
+    @patch("envdrift.vault.get_vault_client")
+    def test_pull_passes_keys_file_to_decrypt(
+        self,
+        mock_get_client,
+        mock_resolve_backend,
+        tmp_path,
+    ):
+        """Decrypt is pointed at the .env.keys we just wrote (monorepo / folder != cwd)."""
+        mock_get_client.return_value = _make_client("DOTENV_PRIVATE_KEY_PRODUCTION=abc123")
+        backend = DummyEncryptionBackend()
+        mock_resolve_backend.return_value = (backend, EncryptionProvider.DOTENVX, None)
+
+        folder = tmp_path / "services" / "myapp"
+        folder.mkdir(parents=True)
+        (folder / ".env.production").write_text("SECRET=encrypted:xyz")
+
+        result = runner.invoke(
+            app,
+            [
+                "vault-pull",
+                str(folder),
+                "my-secret",
+                "--env",
+                "production",
+                "-p",
+                "azure",
+                "--vault-url",
+                "https://myvault.vault.azure.net/",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert backend.decrypt_kwargs, "decrypt was not called"
+        assert backend.decrypt_kwargs[0]["keys_file"] == (folder / ".env.keys").resolve()
+
+    @patch("envdrift.vault.get_vault_client")
+    def test_pull_invalid_provider_exits_cleanly(self, mock_get_client, tmp_path):
+        """An unsupported provider (ValueError from get_vault_client) exits cleanly, no traceback."""
+        mock_get_client.side_effect = ValueError("unsupported provider 'nope'")
+
+        result = runner.invoke(
+            app,
+            [
+                "vault-pull",
+                str(tmp_path),
+                "my-secret",
+                "--env",
+                "production",
+                "-p",
+                "azure",
+                "--vault-url",
+                "https://myvault.vault.azure.net/",
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert "Invalid vault configuration" in result.output
+        # No unhandled exception leaked through.
+        assert result.exception is None or isinstance(result.exception, SystemExit)

--- a/tests/unit/test_cli_vault_push.py
+++ b/tests/unit/test_cli_vault_push.py
@@ -886,8 +886,15 @@ class TestVaultPushSingleService:
         assert result.exit_code == 1
         assert "failed to push secret" in result.output.lower()
 
-    def test_force_without_all_warns(self, tmp_path):
-        """--force without --all shows a warning."""
+    @patch("envdrift.vault.get_vault_client")
+    def test_force_without_all_warns_but_continues(self, mock_get_client, tmp_path):
+        """--force without --all is informational: it warns but the push still succeeds."""
+        client = MagicMock()
+        client.set_secret.return_value = SecretValue(name="secret-name", value="x", version="1")
+        mock_get_client.return_value = client
+
+        (tmp_path / ".env.keys").write_text("DOTENV_PRIVATE_KEY_PROD=prodvalue123\n")
+
         result = runner.invoke(
             app,
             [
@@ -903,7 +910,14 @@ class TestVaultPushSingleService:
                 "https://vault.vault.azure.net",
             ],
         )
+        # Warning is shown...
         assert "--force is only applicable with --all mode" in result.output
+        # ...but execution continues and the secret is pushed successfully.
+        assert result.exit_code == 0, result.output
+        client.set_secret.assert_called_once_with(
+            "secret-name", "DOTENV_PRIVATE_KEY_PROD=prodvalue123"
+        )
+        assert "Pushed secret" in result.output
 
 
 class TestVaultPushSkipEncrypt:

--- a/tests/unit/test_cli_vault_push.py
+++ b/tests/unit/test_cli_vault_push.py
@@ -689,6 +689,224 @@ class TestVaultPushAll:
             "my-secret", "DOTENV_PRIVATE_KEY_STAGING=stagingkey"
         )
 
+
+class TestVaultPushSingleService:
+    """Tests for vault-push single-service and direct (config-free) modes."""
+
+    @patch("envdrift.vault.get_vault_client")
+    def test_push_single_service_success(self, mock_get_client, tmp_path):
+        """Single-service mode reads DOTENV_PRIVATE_KEY_<ENV> and pushes KEY=value."""
+        client = MagicMock()
+        client.set_secret.return_value = SecretValue(name="my-secret", value="x", version="1")
+        mock_get_client.return_value = client
+
+        (tmp_path / ".env.keys").write_text("DOTENV_PRIVATE_KEY_SOAK=soakvalue123\n")
+
+        result = runner.invoke(
+            app,
+            [
+                "vault-push",
+                str(tmp_path),
+                "my-secret",
+                "--env",
+                "soak",
+                "-p",
+                "azure",
+                "--vault-url",
+                "https://myvault.vault.azure.net/",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        client.set_secret.assert_called_once_with(
+            "my-secret", "DOTENV_PRIVATE_KEY_SOAK=soakvalue123"
+        )
+        assert "Pushed secret" in result.output
+        assert "Version: 1" in result.output
+
+    @patch("envdrift.vault.get_vault_client")
+    def test_push_direct_mode(self, mock_get_client, tmp_path):
+        """Direct mode pushes a literal value under the given secret name."""
+        client = MagicMock()
+        client.set_secret.return_value = SecretValue(name="s", value="x", version=None)
+        mock_get_client.return_value = client
+
+        result = runner.invoke(
+            app,
+            [
+                "vault-push",
+                "--direct",
+                "soak-machine",
+                "DOTENV_PRIVATE_KEY_SOAK=abc",
+                "-p",
+                "azure",
+                "--vault-url",
+                "https://myvault.vault.azure.net/",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        client.set_secret.assert_called_once_with("soak-machine", "DOTENV_PRIVATE_KEY_SOAK=abc")
+
+    def test_push_single_missing_env(self, tmp_path):
+        """Single-service mode requires --env."""
+        (tmp_path / ".env.keys").write_text("DOTENV_PRIVATE_KEY_SOAK=v\n")
+        result = runner.invoke(
+            app,
+            [
+                "vault-push",
+                str(tmp_path),
+                "my-secret",
+                "-p",
+                "azure",
+                "--vault-url",
+                "https://myvault.vault.azure.net/",
+            ],
+        )
+        assert result.exit_code == 1
+        assert "Required" in result.output
+
+    def test_push_single_missing_keys_file(self, tmp_path):
+        """Missing .env.keys file fails."""
+        result = runner.invoke(
+            app,
+            [
+                "vault-push",
+                str(tmp_path),
+                "my-secret",
+                "--env",
+                "soak",
+                "-p",
+                "azure",
+                "--vault-url",
+                "https://myvault.vault.azure.net/",
+            ],
+        )
+        assert result.exit_code == 1
+        assert "not found" in result.output.lower()
+
+    def test_push_single_key_not_in_file(self, tmp_path):
+        """Key missing from .env.keys fails."""
+        (tmp_path / ".env.keys").write_text("DOTENV_PRIVATE_KEY_OTHER=v\n")
+        result = runner.invoke(
+            app,
+            [
+                "vault-push",
+                str(tmp_path),
+                "my-secret",
+                "--env",
+                "soak",
+                "-p",
+                "azure",
+                "--vault-url",
+                "https://myvault.vault.azure.net/",
+            ],
+        )
+        assert result.exit_code == 1
+        assert "not found" in result.output.lower()
+
+    def test_push_single_azure_requires_vault_url(self, tmp_path):
+        """Azure provider without --vault-url fails."""
+        (tmp_path / ".env.keys").write_text("DOTENV_PRIVATE_KEY_SOAK=v\n")
+        result = runner.invoke(
+            app,
+            ["vault-push", str(tmp_path), "my-secret", "--env", "soak", "-p", "azure"],
+        )
+        assert result.exit_code == 1
+        assert "vault-url required" in result.output.lower()
+
+    def test_push_single_gcp_requires_project_id(self, tmp_path):
+        """GCP provider without --project-id fails."""
+        (tmp_path / ".env.keys").write_text("DOTENV_PRIVATE_KEY_SOAK=v\n")
+        result = runner.invoke(
+            app,
+            ["vault-push", str(tmp_path), "my-secret", "--env", "soak", "-p", "gcp"],
+        )
+        assert result.exit_code == 1
+        assert "project-id required" in result.output.lower()
+
+    def test_push_single_missing_provider(self, tmp_path):
+        """No provider and no config fails."""
+        (tmp_path / ".env.keys").write_text("DOTENV_PRIVATE_KEY_SOAK=v\n")
+        with patch("envdrift.config.find_config", return_value=None):
+            result = runner.invoke(
+                app,
+                ["vault-push", str(tmp_path), "my-secret", "--env", "soak"],
+            )
+        assert result.exit_code == 1
+        assert "provider required" in result.output.lower()
+
+    @patch("envdrift.vault.get_vault_client")
+    def test_push_single_auth_failure(self, mock_get_client, tmp_path):
+        """Auth failure exits with code 1."""
+        client = MagicMock()
+        client.authenticate.side_effect = VaultError("auth failed")
+        mock_get_client.return_value = client
+        (tmp_path / ".env.keys").write_text("DOTENV_PRIVATE_KEY_SOAK=v\n")
+
+        result = runner.invoke(
+            app,
+            [
+                "vault-push",
+                str(tmp_path),
+                "my-secret",
+                "--env",
+                "soak",
+                "-p",
+                "azure",
+                "--vault-url",
+                "https://myvault.vault.azure.net/",
+            ],
+        )
+        assert result.exit_code == 1
+        assert "authentication failed" in result.output.lower()
+
+    @patch("envdrift.vault.get_vault_client")
+    def test_push_single_set_secret_error(self, mock_get_client, tmp_path):
+        """A VaultError on set_secret exits with code 1."""
+        client = MagicMock()
+        client.set_secret.side_effect = VaultError("write denied")
+        mock_get_client.return_value = client
+        (tmp_path / ".env.keys").write_text("DOTENV_PRIVATE_KEY_SOAK=v\n")
+
+        result = runner.invoke(
+            app,
+            [
+                "vault-push",
+                str(tmp_path),
+                "my-secret",
+                "--env",
+                "soak",
+                "-p",
+                "azure",
+                "--vault-url",
+                "https://myvault.vault.azure.net/",
+            ],
+        )
+        assert result.exit_code == 1
+        assert "failed to push secret" in result.output.lower()
+
+    def test_force_without_all_warns(self, tmp_path):
+        """--force without --all shows a warning."""
+        result = runner.invoke(
+            app,
+            [
+                "vault-push",
+                "--force",
+                str(tmp_path),
+                "secret-name",
+                "--env",
+                "prod",
+                "-p",
+                "azure",
+                "--vault-url",
+                "https://vault.vault.azure.net",
+            ],
+        )
+        assert "--force is only applicable with --all mode" in result.output
+
+
+class TestVaultPushSkipEncrypt:
     def test_skip_encrypt_without_all_warns(self, tmp_path):
         """Test --skip-encrypt without --all shows warning."""
         result = runner.invoke(


### PR DESCRIPTION
## The bug: vault-push/vault-pull asymmetry

`envdrift vault-push <folder> <secret> --env <env> --provider azure --vault-url <url>` has a **config-free single-secret mode** — it reads `DOTENV_PRIVATE_KEY_<ENV>` from `<folder>/.env.keys` and stores it as `DOTENV_PRIVATE_KEY_<ENV>=<value>`.

But the **pull side was asymmetric and broken**: both `envdrift pull` and `envdrift sync` require a `[vault.sync]` config in `envdrift.toml`. There was **no config-free single-secret pull**, and no `vault-pull` command at all.

This made the README root Quick Start **fail end-to-end** when copy-pasted:
- Step 1 `vault-push . my-app-key --provider azure --vault-url ...` was missing the required `--env`.
- Step 2 `envdrift pull --provider azure --vault-url ...` failed with `[ERROR] No sync configuration found` because there is no toml.

## The fix

### New `vault-pull` command (the exact inverse of vault-push single-service mode)

```bash
envdrift vault-pull <folder> <secret-name> --env <env> \
  --provider azure --vault-url <url> [--no-decrypt]
```

- Args mirror `vault-push`: positional `folder` + `secret_name`, plus `--env/-e` (required), `--provider/-p`, `--vault-url`, `--region`, `--project-id`, `--config/-c`. Same provider-specific validation and the same `[vault]` config fallback.
- Fetches the secret, parses the stored `DOTENV_PRIVATE_KEY_<ENV>=<value>` (also accepts a bare value with no `KEY=` prefix), and writes the key into `<folder>/.env.keys` via `EnvKeysFile.write_key` (preserving the dotenvx header).
- **Auto-decrypts** the matching `.env.<env>` file by default for true one-command onboarding (reuses the same `resolve_encryption_backend` path that `pull` uses); opt out with `--no-decrypt`. This is what makes the README Quick Start a genuine two-liner.

### Help-text fix

The `vault-push --env` help previously only described the mechanism. It now states the flag is required and that it selects which `DOTENV_PRIVATE_KEY_*` key is used. The same improved wording is applied to `vault-pull --env`.

### Docs (every occurrence fixed so flows run when copy-pasted)

- `README.md` Quick Start — added `--env`, switched step 2 to `vault-pull`, annotated that `pull`/`lock` need the sync config.
- `docs/index.md`, `docs/getting-started/quickstart.md` — same fixes.
- `docs/concepts/vault-providers.md` — added `--env` and a symmetric `vault-pull` example for azure/aws/hashicorp/gcp.
- `docs/concepts/how-it-works.md` — command table.
- `docs/guides/migrating.md`, `docs/support/troubleshooting.md`, `docs/support/faq.md` — added `--env`, referenced `vault-pull`.
- New `docs/cli/vault-pull.md` reference page; updated `docs/cli/index.md` table; cross-linked "See also" in `vault-push.md`, `pull.md`, `lock.md`; added `vault-pull` to `mkdocs.yml` nav.

### Tests

- New `tests/unit/test_cli_vault_pull.py`: success + decrypt, both value-parsing branches, `--no-decrypt`, no env file, missing `--env`, secret-not-found, vault/auth/import errors, provider validation (azure/gcp/hashicorp/aws), config defaults, backend-not-installed, decrypt failure/exception, and a push→pull round-trip via an in-memory vault.
- Added single-service + direct-mode coverage for `vault-push` (previously untested).
- `vault.py` line coverage is **87%**; full unit suite (**1117 tests**) green.

## Quality gates

- `ruff check`, `ruff format`, `pyrefly check`, `bandit` — all pass (pre-commit run clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `vault-pull` CLI command to retrieve a single secret from vault providers without configuration files.

* **Documentation**
  * Updated quickstart, guides, FAQ, and troubleshooting with expanded vault workflow examples.
  * Added comprehensive CLI reference for `vault-pull` with multi-provider examples.
  * Clarified `--env` flag usage and when to use config-free vault commands versus configuration-based workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `vault-pull` command that is the config-free, single-secret inverse of `vault-push`, completing a symmetric push/pull workflow. It also refactors the shared provider-resolution and client-creation logic from `vault_push` into two private helpers (`_resolve_vault_settings`, `_build_authenticated_client`) that both commands now share, and fixes docs/quick-start examples that were missing the required `--env` flag.

- **New `vault-pull` CLI command** (`src/envdrift/cli_commands/vault.py`): fetches one secret from a vault, writes `DOTENV_PRIVATE_KEY_<ENV>` to `<folder>/.env.keys`, and optionally auto-decrypts `.env.<env>`; validates env-prefix mismatch before writing; warns on non-`.toml` config suffix for encryption-backend selection.
- **Refactored shared helpers**: `_resolve_vault_settings` and `_build_authenticated_client` extracted from the previous `vault_push` inline code, now also catching `ValueError` from `get_vault_client` (a gap in the old code).
- **Extensive tests** added (`tests/unit/test_cli_vault_pull.py`, additions to `test_cli_vault_push.py`, `tests/integration/test_azure_integration.py`): success path, bare-value parsing, `--no-decrypt`, no env file, missing `--env`, secret-not-found, auth/vault/import errors, provider validation, config defaults, backend-not-installed, and push→pull round-trip.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the new vault-pull command is well-structured, addresses the push/pull asymmetry cleanly, and the previously raised env-prefix mismatch and .toml suffix issues have both been fixed.

The implementation is the straightforward inverse of the existing vault-push single-service mode, reuses well-tested helper paths, and ships with comprehensive unit tests (all major code paths covered) plus an integration test. Both review findings from the previous round (env-prefix mismatch writing wrong key, and the .toml suffix inconsistency) are now addressed with a fail-fast error and an explicit warning respectively. No new logic gaps were found.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/envdrift/cli_commands/vault.py | Core change: adds vault_pull command, extracts _resolve_vault_settings / _build_authenticated_client helpers; logic is correct, env-prefix mismatch guard present, .toml suffix warning added. |
| tests/unit/test_cli_vault_pull.py | 765-line new test file covering all major code paths including success, bare-value parsing, --no-decrypt, missing --env, secret-not-found, auth/import errors, all four providers, config defaults, and push-pull round-trip. |
| tests/unit/test_cli_vault_push.py | Adds 238 lines of previously-missing single-service and direct-mode coverage for vault-push. |
| src/envdrift/cli.py | Imports and registers the new vault_pull command under the name vault-pull; minimal two-line change. |
| tests/integration/test_azure_integration.py | Adds an Azure integration round-trip test for vault-pull. |
| docs/cli/vault-pull.md | New reference page documenting vault-pull with synopsis, options, all four providers, exit codes, and authentication details. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant CLI as envdrift CLI
    participant R as _resolve_vault_settings
    participant B as _build_authenticated_client
    participant V as Vault Provider
    participant K as env.keys file
    participant E as Encryption Backend

    Dev->>CLI: vault-pull folder secret --env prod --provider azure --vault-url ...
    CLI->>R: config, provider, vault_url, region, project_id
    R-->>CLI: effective_provider, effective_vault_url
    CLI->>B: effective_provider, effective_vault_url
    B->>V: get_vault_client + authenticate
    V-->>B: authenticated client
    B-->>CLI: client
    CLI->>V: client.get_secret(secret_name)
    V-->>CLI: secret value
    Note over CLI: Validate env-prefix match then extract key_value
    CLI->>K: write_key DOTENV_PRIVATE_KEY_ENV
    K-->>CLI: key written
    alt default mode and env file exists
        CLI->>E: resolve_encryption_backend
        E-->>CLI: backend
        CLI->>E: backend.decrypt env file
        E-->>CLI: success
        CLI-->>Dev: Pulled and Decrypted
    else no-decrypt or no env file
        CLI-->>Dev: Key written only
    end
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/envdrift/cli_commands/vault.py`, line 695-701 ([link](https://github.com/jainal09/envdrift/blob/67d4d2fa6f20bdac915fee8d9406e51afb6a4bab/src/envdrift/cli_commands/vault.py#L695-L701)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Misleading "use --no-decrypt to silence" hint**

   The message `(use --no-decrypt to silence)` implies this is a cosmetic/verbose message. In reality, `--no-decrypt` completely opts out of the decrypt step rather than merely suppressing a single line of output — a user following this hint would stop getting decryption on every subsequent `vault-pull` invocation. A more accurate phrasing would be `(use --no-decrypt to skip the decrypt step entirely)` or simply drop the hint, since the message is already informative on its own.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["fix(vault): address round-2 review on va..."](https://github.com/jainal09/envdrift/commit/a04a4bb71aa98f287c81aa406fa99ff2b0aa9da4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35230516)</sub>

<!-- /greptile_comment -->