### PR TITLE
docs(sops): add dedicated SOPS backend guide + fix backend docs

### DIFF
--- a/docs/cli/lock.md
+++ b/docs/cli/lock.md
@@ -12,7 +12,11 @@ envdrift lock [OPTIONS]
 
 The `lock` command is the opposite of `pull`. While `pull` syncs keys and decrypts files for
 development, `lock` verifies keys and encrypts files before committing.
-This workflow is specific to dotenvx and does not apply to SOPS.
+
+The **key-sync/verify** part of this workflow is dotenvx-only. The encrypt step
+itself uses your configured backend, so `lock` *can* drive SOPS encryption when a
+`[vault.sync]` section is present — but the recommended SOPS path is plain
+`envdrift encrypt`. See the [SOPS Backend Guide](../guides/sops.md#using-pull-and-lock-with-sops).
 
 This command ensures your environment files are properly encrypted before committing. It can:
 

--- a/docs/cli/pull.md
+++ b/docs/cli/pull.md
@@ -1,7 +1,11 @@
 # envdrift pull
 
 Pull keys from vault and decrypt all env files (one-command developer setup).
-This workflow is specific to dotenvx and does not apply to SOPS.
+
+The **key-sync** part of this workflow is dotenvx-only. The decrypt step uses your
+configured backend, so `pull --skip-sync` *can* decrypt SOPS files when a
+`[vault.sync]` section is present — but the recommended SOPS path is plain
+`envdrift decrypt`. See the [SOPS Backend Guide](../guides/sops.md#using-pull-and-lock-with-sops).
 
 ## Synopsis
 

--- a/docs/concepts/encryption-backends.md
+++ b/docs/concepts/encryption-backends.md
@@ -153,7 +153,9 @@ envdrift decrypt .env.production
 
 ## Configuration
 
-Set a default backend in `envdrift.toml`:
+Set a default backend in `envdrift.toml`. Backend-specific options live in the
+`[encryption.dotenvx]` and `[encryption.sops]` subsections (flat `sops_*` keys
+under `[encryption]` are ignored by the parser):
 
 ```toml
 [encryption]
@@ -161,14 +163,20 @@ Set a default backend in `envdrift.toml`:
 backend = "dotenvx"
 
 # dotenvx settings
-dotenvx_auto_install = true
+[encryption.dotenvx]
+auto_install = true
 
 # SOPS settings
-sops_auto_install = true
-sops_config_file = ".sops.yaml"
-sops_age_key_file = "~/.config/sops/age/keys.txt"
-sops_age_recipients = "age1abc..."
+[encryption.sops]
+auto_install = true
+config_file = ".sops.yaml"
+age_key_file = "~/.config/sops/age/keys.txt"
+age_recipients = "age1abc..."
+# azure_kv = "https://my-vault.vault.azure.net/keys/my-key/<version>"
 ```
+
+For a full SOPS setup (including the Azure Key Vault walkthrough and how `lock`/`pull`
+behave with SOPS), see the [SOPS Backend Guide](../guides/sops.md).
 
 ## Migration Between Backends
 

--- a/docs/guides/env-file-sync.md
+++ b/docs/guides/env-file-sync.md
@@ -20,10 +20,11 @@ secret.
     **SOPS users don't use Vault Sync** — and don't need to. SOPS has no portable
     `.env.keys` private key; it delegates decryption to your KMS/age/PGP, which is
     *already* a key-distribution system that controls who can decrypt. You still get
-    the rest of envdrift with SOPS — `envdrift encrypt`/`decrypt --backend sops`, and
-    the `pull`/`lock` workflow encrypt and decrypt SOPS files — you just grant
-    decryption access through SOPS's own key management instead of pushing a key to a
-    vault.
+    the rest of envdrift with SOPS — `envdrift encrypt`/`decrypt --backend sops` are
+    the recommended path, and `lock`/`pull` can drive SOPS too (they need a
+    `[vault.sync]` section, and `pull` needs `--skip-sync`). You just grant decryption
+    access through SOPS's own key management instead of pushing a key to a vault. See
+    the [SOPS Backend Guide](sops.md) for the full setup.
 
 ## Overview
 

--- a/docs/guides/sops.md
+++ b/docs/guides/sops.md
@@ -106,9 +106,16 @@ API_KEY=ENC[AES256_GCM,data:...,iv:...,tag:...,type:str]
 sops_version=3.11.0
 ```
 
-`encrypt`/`decrypt` accept these SOPS flags (overriding config):
-`--backend`, `--sops-config`, `--age`, `--age-key-file`, `--kms`, `--gcp-kms`,
-`--azure-kv`. See [`encrypt`](../cli/encrypt.md) and [`decrypt`](../cli/decrypt.md).
+Flags differ by direction (both override config):
+
+- **`encrypt`** — `--backend`, `--sops-config`, `--age`, `--age-key-file`, `--kms`,
+  `--gcp-kms`, `--azure-kv`. The key-recipient flags (`--age`/`--kms`/`--gcp-kms`/
+  `--azure-kv`) choose *who can decrypt* and are encryption-only.
+- **`decrypt`** — `--backend`, `--sops-config`, `--age-key-file`. Decryption needs no
+  key-recipient flags: SOPS reads the recipients from the file's metadata and unwraps
+  the data key using your credentials (`az login`, KMS access, or the age key).
+
+See [`encrypt`](../cli/encrypt.md) and [`decrypt`](../cli/decrypt.md).
 
 ## Azure Key Vault walkthrough (verified end-to-end)
 
@@ -191,19 +198,22 @@ Partly — and this trips people up, so here is the precise behavior.
 `pull` and `lock` are part of the **Vault Sync family**. They do two things:
 
 1. A **key-sync step** (fetch/verify the dotenvx `.env.keys` private key from a
-   vault) — this is **dotenvx-only**.
+   vault) — this is **dotenvx-only**. `pull` runs it by default; `lock` runs it only
+   with `--verify-vault` or `--sync-keys`.
 2. An **encrypt/decrypt step** that uses whichever backend your config resolves to —
    this **does** support SOPS.
 
 Consequences for SOPS:
 
 - `lock` and `pull` **refuse to start without a `[vault.sync]` section** (and a
-  `[vault]` provider block with a `vault_url`) — they derive their file work-list
-  and build a vault client up front, regardless of backend. A pure-SOPS project
-  has none of that.
-- Plain `envdrift pull` runs the key-sync step, which looks for a dotenvx secret and
-  **fails** for SOPS. You must use `envdrift pull --skip-sync` to skip straight to
-  decryption.
+  `[vault]` provider block) — they derive their file work-list and build a vault
+  client up front, regardless of backend. The provider block needs that provider's
+  own required field: `vault_url` for Azure/HashiCorp, `region` for AWS (defaulted),
+  `project_id` for GCP. A pure-SOPS project has none of this.
+- `lock` does **not** hit Vault Sync by default (it only encrypts), so `lock --force`
+  works for SOPS once the config above exists. Plain `envdrift pull`, however, runs
+  the key-sync step, looks for a dotenvx secret, and **fails** for SOPS — use
+  `envdrift pull --skip-sync` to go straight to decryption.
 
 **Recommendation:** for SOPS, use `envdrift encrypt` / `envdrift decrypt`. They need
 no vault scaffolding and are the intended SOPS workflow. Only reach for `lock`/`pull`

--- a/docs/guides/sops.md
+++ b/docs/guides/sops.md
@@ -1,0 +1,247 @@
+# SOPS Backend Guide
+
+envdrift supports two encryption backends: **dotenvx** (default) and **SOPS**.
+This guide is the end-to-end reference for the **SOPS** path — how it differs from
+dotenvx, why SOPS users don't use envdrift's Vault Sync, and exactly how to set it
+up against a cloud KMS (with a full Azure Key Vault walkthrough).
+
+If you're choosing between backends first, read
+[Encryption Backends](../concepts/encryption-backends.md). If you want the shared
+encrypt/decrypt mechanics, see [Encryption](encryption.md).
+
+## The core difference: who distributes the decrypt key
+
+This is the single most important thing to understand, because it changes which
+commands you use.
+
+| | dotenvx | SOPS |
+|:--|:--|:--|
+| **Decrypt key lives in** | a portable `.env.keys` file (`DOTENV_PRIVATE_KEY_<ENV>`) | your KMS / age / PGP — there is **no** `.env.keys` |
+| **How teammates get decrypt access** | envdrift **Vault Sync** pushes the key to a cloud vault and pulls it back | you grant access in **KMS/age/PGP itself** (e.g. an Azure RBAC role on the key) |
+| **Team commands** | `sync`, `pull`, `vault-push`, `vault-pull`, `decrypt --verify-vault` | not needed — use `encrypt` / `decrypt` |
+
+dotenvx has one secret artifact (`.env.keys`) that must reach every teammate, so
+envdrift gives you Vault Sync to distribute it. SOPS has **no** such portable
+secret: it wraps each file's data key with your KMS/age/PGP key, and *that* system
+already decides who can decrypt. So with SOPS you never push a key anywhere — you
+add a teammate to the KMS key (or hand them an age key) and they can decrypt
+immediately.
+
+!!! info "SOPS does not use Vault Sync — and doesn't need to"
+    The entire Vault Sync family (`vault-push`, `vault-pull`, `sync`, and
+    `decrypt --verify-vault`) is built around the dotenvx `.env.keys` artifact and
+    is dotenvx-only. `decrypt --verify-vault` explicitly rejects non-dotenvx
+    backends. SOPS access control lives in your KMS/age/PGP, not in an envdrift
+    vault mapping.
+
+## Two ways to use vault clouds — don't confuse them
+
+The word "vault" means two different things here:
+
+1. **envdrift Vault Sync** — pushes/pulls the dotenvx `.env.keys` private key using
+   your cloud vault's **secrets** API (e.g. Azure Key Vault *secrets*). dotenvx only.
+2. **A cloud KMS as the SOPS key** — SOPS wraps the file's data key with a cloud
+   **key** (e.g. Azure Key Vault *keys*, AWS KMS, GCP KMS). This is SOPS-native.
+
+So SOPS absolutely uses cloud vaults — just through the **keys** API via SOPS's own
+config, not through envdrift's key-pushing commands. The permission sets are
+different: dotenvx Vault Sync needs **Secrets** Get/List; SOPS + Azure Key Vault
+needs **Keys** crypto permissions (see below).
+
+## Install
+
+```bash
+pip install envdrift          # SOPS support needs no extra envdrift extras
+```
+
+You also need the `sops` binary on PATH. Either install it yourself
+(`brew install sops`, or see the [SOPS releases](https://github.com/getsops/sops/releases))
+or let envdrift fetch it by setting `auto_install = true` (below).
+
+## Configuration
+
+Set SOPS as the backend in `envdrift.toml` (or `[tool.envdrift]` in
+`pyproject.toml`). All SOPS options live under the **`[encryption.sops]`**
+subsection:
+
+```toml
+[encryption]
+backend = "sops"
+
+[encryption.sops]
+auto_install = false              # set true to let envdrift download the sops binary
+config_file = ".sops.yaml"        # optional: path to a SOPS policy file
+age_recipients = "age1example..." # age public key(s) for encryption
+age_key_file = "keys.txt"         # age private key for local decryption (sets SOPS_AGE_KEY_FILE)
+# kms_arn  = "arn:aws:kms:us-east-1:123456789:key/abc-123"
+# gcp_kms  = "projects/p/locations/global/keyRings/r/cryptoKeys/k"
+# azure_kv = "https://my-vault.vault.azure.net/keys/my-key/<version>"
+```
+
+!!! warning "Use the `[encryption.sops]` subsection — not flat keys"
+    Options are read from the `[encryption.sops]` table (`config_file`,
+    `age_recipients`, `azure_kv`, …). Flat keys like `sops_config_file` under
+    `[encryption]` are **ignored** by the parser.
+
+## The simple path: `encrypt` / `decrypt`
+
+For SOPS this is all you need — no vault mappings, no extra config sections.
+
+```bash
+# Encrypt in place (backend + key resolved from envdrift.toml)
+envdrift encrypt .env.production
+
+# Or pick the backend/key explicitly, ignoring config
+envdrift encrypt .env.production --backend sops --age age1example...
+
+# Decrypt in place (backend auto-detected from the file's SOPS metadata)
+envdrift decrypt .env.production
+```
+
+SOPS encrypts values while keeping keys readable and appends its own metadata:
+
+```bash
+DATABASE_URL=ENC[AES256_GCM,data:...,iv:...,tag:...,type:str]
+API_KEY=ENC[AES256_GCM,data:...,iv:...,tag:...,type:str]
+sops_version=3.11.0
+```
+
+`encrypt`/`decrypt` accept these SOPS flags (overriding config):
+`--backend`, `--sops-config`, `--age`, `--age-key-file`, `--kms`, `--gcp-kms`,
+`--azure-kv`. See [`encrypt`](../cli/encrypt.md) and [`decrypt`](../cli/decrypt.md).
+
+## Azure Key Vault walkthrough (verified end-to-end)
+
+This sets up SOPS to wrap your data keys with an Azure Key Vault **key**. envdrift
+authenticates to Azure via SOPS, which uses the standard Azure credential chain
+(`az login`, env vars, or managed identity).
+
+### 1. Permissions — Key Vault **keys**, not secrets
+
+SOPS uses the vault's **keys** API. This is a different RBAC role than dotenvx Vault
+Sync (which uses **secrets**). On the vault, grant:
+
+| Task | Built-in role |
+|:--|:--|
+| Create the key (one-time) | **Key Vault Crypto Officer** |
+| Encrypt / decrypt files (everyone) | **Key Vault Crypto User** |
+
+```bash
+# Replace <user-or-principal> and the scope with your vault's resource ID
+SCOPE=$(az keyvault show --name my-vault --query id -o tsv)
+
+az role assignment create --assignee "<user-or-principal>" \
+  --role "Key Vault Crypto Officer" --scope "$SCOPE"   # to create keys
+az role assignment create --assignee "<user-or-principal>" \
+  --role "Key Vault Crypto User"   --scope "$SCOPE"   # to encrypt/decrypt
+```
+
+RBAC changes take ~30–60s to propagate. If you only hold *Key Vault Secrets
+Officer* (the dotenvx Vault Sync role), `az keyvault key create` will fail with
+`Forbidden (ForbiddenByRbac)` — that's the secrets-vs-keys distinction in action.
+
+### 2. Create the key
+
+```bash
+az keyvault key create --vault-name my-vault --name sops-key \
+  --kty RSA --size 2048 --query "key.kid" -o tsv
+# -> https://my-vault.vault.azure.net/keys/sops-key/<version>
+```
+
+### 3. Point envdrift at it
+
+```toml
+[encryption]
+backend = "sops"
+
+[encryption.sops]
+azure_kv = "https://my-vault.vault.azure.net/keys/sops-key/<version>"
+```
+
+### 4. Encrypt and decrypt
+
+```bash
+envdrift encrypt .env.production       # wraps the data key with your Azure key
+envdrift decrypt .env.production       # calls Azure to unwrap, restores plaintext
+```
+
+The encrypted file records which key was used, so decryption needs no extra config —
+only `az login` (or any Azure credential with *Key Vault Crypto User* on the key):
+
+```bash
+sops_azure_kv__list_0__map_vault_url=https://my-vault.vault.azure.net
+sops_azure_kv__list_0__map_name=sops-key
+sops_azure_kv__list_0__map_version=<version>
+```
+
+### Granting a teammate decrypt access
+
+No key push. Give them **Key Vault Crypto User** on the key (or vault) and they can
+`envdrift decrypt` immediately:
+
+```bash
+az role assignment create --assignee teammate@example.com \
+  --role "Key Vault Crypto User" --scope "$SCOPE"
+```
+
+## Using `pull` and `lock` with SOPS
+
+Partly — and this trips people up, so here is the precise behavior.
+
+`pull` and `lock` are part of the **Vault Sync family**. They do two things:
+
+1. A **key-sync step** (fetch/verify the dotenvx `.env.keys` private key from a
+   vault) — this is **dotenvx-only**.
+2. An **encrypt/decrypt step** that uses whichever backend your config resolves to —
+   this **does** support SOPS.
+
+Consequences for SOPS:
+
+- `lock` and `pull` **refuse to start without a `[vault.sync]` section** (and a
+  `[vault]` provider block with a `vault_url`) — they derive their file work-list
+  and build a vault client up front, regardless of backend. A pure-SOPS project
+  has none of that.
+- Plain `envdrift pull` runs the key-sync step, which looks for a dotenvx secret and
+  **fails** for SOPS. You must use `envdrift pull --skip-sync` to skip straight to
+  decryption.
+
+**Recommendation:** for SOPS, use `envdrift encrypt` / `envdrift decrypt`. They need
+no vault scaffolding and are the intended SOPS workflow. Only reach for `lock`/`pull`
+if you specifically want their batch file-discovery, in which case add a minimal
+`[vault.sync]`/`[vault]` block and run `pull --skip-sync`.
+
+```toml
+# Minimal scaffolding ONLY if you want lock/pull to drive SOPS encrypt/decrypt.
+# No key is ever pushed/pulled here — access is your KMS/age/PGP.
+[vault]
+provider = "azure"
+
+[vault.azure]
+vault_url = "https://my-vault.vault.azure.net/"
+
+[vault.sync]
+default_vault_name = "my-vault"
+
+[[vault.sync.mappings]]
+secret_name = "unused-for-sops"   # never read for SOPS; only gives a work-list
+folder_path = "."
+environment = "production"
+```
+
+```bash
+envdrift lock --force          # encrypts mapped files with SOPS
+envdrift pull --skip-sync      # decrypts mapped files with SOPS (no secrets call)
+```
+
+## What SOPS does not support
+
+- **envdrift Vault Sync** (`vault-push`, `vault-pull`, `sync`,
+  `decrypt --verify-vault`) — dotenvx-only by design.
+- **Partial encryption** (`push` / `pull-partial`) — dotenvx-only.
+
+## See also
+
+- [Encryption Backends](../concepts/encryption-backends.md) — choosing dotenvx vs SOPS
+- [Encryption](encryption.md) — shared encrypt/decrypt mechanics
+- [`encrypt`](../cli/encrypt.md) / [`decrypt`](../cli/decrypt.md) — command reference
+- [Env File Sync](env-file-sync.md) — the dotenvx team (Vault Sync) workflow

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,6 +68,7 @@ nav:
       - Agent Setup: guides/agent-setup.md
       - VS Code Extension: guides/vscode-extension.md
       - Encryption: guides/encryption.md
+      - SOPS Backend: guides/sops.md
       - Guard Scanning: guides/guard.md
       - Schema Best Practices: guides/schema.md
       - CI/CD Integration: guides/cicd.md

--- a/tests/integration/test_encryption_tools.py
+++ b/tests/integration/test_encryption_tools.py
@@ -191,6 +191,31 @@ def _write_sops_age_setup(work_dir: Path, *, path_regex: str) -> None:
     )
 
 
+def _scrub_cloud_credentials(env: dict[str, str]) -> None:
+    """Remove cloud credential/identity hints so provider auth fails fast.
+
+    Without this, DefaultAzureCredential (and similar chains) may probe managed
+    identity / workload identity endpoints and make these tests environment-sensitive
+    in CI runners that have such identities configured.
+    """
+    for var in (
+        # Azure DefaultAzureCredential chain
+        "AZURE_CLIENT_ID",
+        "AZURE_TENANT_ID",
+        "AZURE_CLIENT_SECRET",
+        "AZURE_CLIENT_CERTIFICATE_PATH",
+        "AZURE_FEDERATED_TOKEN_FILE",
+        "IDENTITY_ENDPOINT",
+        "MSI_ENDPOINT",
+        "IMDS_ENDPOINT",
+        "AZURE_POD_IDENTITY_AUTHORITY_HOST",
+        # HashiCorp Vault
+        "VAULT_TOKEN",
+        "VAULT_ADDR",
+    ):
+        env.pop(var, None)
+
+
 @pytest.mark.integration
 def test_sops_lock_and_pull_roundtrip(integration_env):
     """The playground flow: `lock` encrypts and `pull --skip-sync` decrypts SOPS files.
@@ -203,14 +228,8 @@ def test_sops_lock_and_pull_roundtrip(integration_env):
     work_dir = integration_env["base_dir"] / "sops-lock-pull"
     work_dir.mkdir()
     env = integration_env["env"].copy()
-    # Simulate CI: no Azure credentials available to the vault client.
-    for var in (
-        "AZURE_CLIENT_ID",
-        "AZURE_TENANT_ID",
-        "AZURE_CLIENT_SECRET",
-        "AZURE_CLIENT_CERTIFICATE_PATH",
-    ):
-        env.pop(var, None)
+    # Simulate CI: no cloud credentials available to the vault client.
+    _scrub_cloud_credentials(env)
 
     env_file = work_dir / ".env.production"
     env_file.write_text(
@@ -303,6 +322,62 @@ def test_sops_lock_pull_require_vault_sync_config(integration_env):
     pull_result = _run_envdrift(["pull", "--skip-sync"], cwd=work_dir, env=env, check=False)
     assert pull_result.returncode != 0
     assert "No sync configuration found" in (pull_result.stdout + pull_result.stderr)
+
+
+@pytest.mark.integration
+def test_sops_plain_pull_runs_dotenvx_key_sync_step(integration_env):
+    """Plain `pull` (no --skip-sync) runs the dotenvx-only key-sync step and fails
+    for a SOPS project, even with a valid `[vault.sync]` section.
+
+    This guards the documented behavior that SOPS users must use `pull --skip-sync`
+    (or plain `encrypt`/`decrypt`). A HashiCorp provider with no `VAULT_TOKEN` makes
+    the key-sync step fail fast and deterministically, with no network probing.
+    """
+    work_dir = integration_env["base_dir"] / "sops-plain-pull"
+    work_dir.mkdir()
+    env = integration_env["env"].copy()
+    _scrub_cloud_credentials(env)
+
+    env_file = work_dir / ".env.production"
+    env_file.write_text("API_KEY=topsecret\n")
+    _write_sops_age_setup(work_dir, path_regex=r"\.env\.production$")
+
+    config = textwrap.dedent(
+        f"""\
+        [encryption]
+        backend = "sops"
+
+        [encryption.sops]
+        auto_install = true
+        config_file = ".sops.yaml"
+        age_key_file = "age.key"
+        age_recipients = "{AGE_PUBLIC_KEY}"
+
+        [vault]
+        provider = "hashicorp"
+
+        [vault.hashicorp]
+        url = "http://127.0.0.1:1"
+
+        [vault.sync]
+        default_vault_name = "dummy"
+
+        [[vault.sync.mappings]]
+        secret_name = "unused-for-sops"
+        folder_path = "."
+        environment = "production"
+        """
+    )
+    (work_dir / "envdrift.toml").write_text(config)
+
+    result = _run_envdrift(["pull"], cwd=work_dir, env=env, check=False)
+    assert result.returncode != 0
+    combined = result.stdout + result.stderr
+    # It reaches the dotenvx key-sync step (which SOPS does not use) and fails there.
+    assert "Syncing keys from vault" in combined
+    assert "Sync failed" in combined
+    # The file was never touched (still plaintext, never decrypted).
+    assert env_file.read_text() == "API_KEY=topsecret\n"
 
 
 @pytest.mark.integration

--- a/tests/integration/test_encryption_tools.py
+++ b/tests/integration/test_encryption_tools.py
@@ -169,6 +169,142 @@ def test_sops_encrypt_decrypt_roundtrip(integration_env):
     assert "ENC[" not in decrypted
 
 
+def _write_sops_age_setup(work_dir: Path, *, path_regex: str) -> None:
+    """Write age.key and .sops.yaml for a SOPS+age workspace."""
+    (work_dir / "age.key").write_text(
+        textwrap.dedent(
+            f"""\
+            # created: 2026-01-01T23:59:46-05:00
+            # public key: {AGE_PUBLIC_KEY}
+            {AGE_PRIVATE_KEY}
+            """
+        )
+    )
+    (work_dir / ".sops.yaml").write_text(
+        textwrap.dedent(
+            f"""\
+            creation_rules:
+              - path_regex: {path_regex}
+                age: {AGE_PUBLIC_KEY}
+            """
+        )
+    )
+
+
+@pytest.mark.integration
+def test_sops_lock_and_pull_roundtrip(integration_env):
+    """The playground flow: `lock` encrypts and `pull --skip-sync` decrypts SOPS files.
+
+    `lock`/`pull` are the Vault Sync family, so they require a `[vault.sync]` section
+    even for SOPS. `lock --force` never contacts the vault, and `pull --skip-sync`
+    skips the (dotenvx-only) key-sync step, so this runs with a dummy vault URL and
+    no cloud credentials.
+    """
+    work_dir = integration_env["base_dir"] / "sops-lock-pull"
+    work_dir.mkdir()
+    env = integration_env["env"].copy()
+    # Simulate CI: no Azure credentials available to the vault client.
+    for var in (
+        "AZURE_CLIENT_ID",
+        "AZURE_TENANT_ID",
+        "AZURE_CLIENT_SECRET",
+        "AZURE_CLIENT_CERTIFICATE_PATH",
+    ):
+        env.pop(var, None)
+
+    env_file = work_dir / ".env.production"
+    env_file.write_text(
+        textwrap.dedent(
+            """\
+            API_KEY=topsecret
+            DEBUG=true
+            """
+        )
+    )
+
+    _write_sops_age_setup(work_dir, path_regex=r"\.env\.production$")
+
+    config = textwrap.dedent(
+        f"""\
+        [encryption]
+        backend = "sops"
+
+        [encryption.sops]
+        auto_install = true
+        config_file = ".sops.yaml"
+        age_key_file = "age.key"
+        age_recipients = "{AGE_PUBLIC_KEY}"
+
+        [vault]
+        provider = "azure"
+
+        [vault.azure]
+        vault_url = "https://dummy.vault.azure.net/"
+
+        [vault.sync]
+        default_vault_name = "dummy"
+
+        [[vault.sync.mappings]]
+        secret_name = "unused-for-sops"
+        folder_path = "."
+        environment = "production"
+        """
+    )
+    (work_dir / "envdrift.toml").write_text(config)
+
+    # lock encrypts the SOPS file in place (no vault contact).
+    _run_envdrift(["lock", "--force"], cwd=work_dir, env=env)
+    locked = env_file.read_text()
+    assert "ENC[" in locked
+    assert "API_KEY=topsecret" not in locked
+
+    # pull --skip-sync decrypts via the SOPS backend (no secrets API call).
+    _run_envdrift(["pull", "--skip-sync"], cwd=work_dir, env=env)
+    pulled = env_file.read_text()
+    assert "API_KEY=topsecret" in pulled
+    assert "ENC[" not in pulled
+
+
+@pytest.mark.integration
+def test_sops_lock_pull_require_vault_sync_config(integration_env):
+    """`lock`/`pull` are the Vault Sync family and fail fast without `[vault.sync]`.
+
+    This guards the documented behavior that the SOPS path for these commands needs
+    a `[vault.sync]` section (whereas plain `encrypt`/`decrypt` do not).
+    """
+    work_dir = integration_env["base_dir"] / "sops-no-sync"
+    work_dir.mkdir()
+    env = integration_env["env"].copy()
+
+    env_file = work_dir / ".env.production"
+    env_file.write_text("API_KEY=topsecret\n")
+    _write_sops_age_setup(work_dir, path_regex=r"\.env\.production$")
+
+    # No [vault] / [vault.sync] sections.
+    (work_dir / "envdrift.toml").write_text(
+        textwrap.dedent(
+            f"""\
+            [encryption]
+            backend = "sops"
+
+            [encryption.sops]
+            auto_install = true
+            config_file = ".sops.yaml"
+            age_key_file = "age.key"
+            age_recipients = "{AGE_PUBLIC_KEY}"
+            """
+        )
+    )
+
+    lock_result = _run_envdrift(["lock", "--force"], cwd=work_dir, env=env, check=False)
+    assert lock_result.returncode != 0
+    assert "No sync configuration found" in (lock_result.stdout + lock_result.stderr)
+
+    pull_result = _run_envdrift(["pull", "--skip-sync"], cwd=work_dir, env=env, check=False)
+    assert pull_result.returncode != 0
+    assert "No sync configuration found" in (pull_result.stdout + pull_result.stderr)
+
+
 @pytest.mark.integration
 def test_dotenvx_smart_encryption_skips_unchanged(integration_env):
     """Smart encryption should restore from git when content is unchanged.


### PR DESCRIPTION
## Summary

There was **no dedicated SOPS guide** in the docs — SOPS was mentioned across ~30 pages, but the coverage had real gaps and at least one broken example. This PR adds a focused SOPS guide and fixes the surrounding docs, all verified against the code and a live Azure Key Vault round-trip.

### New: `docs/guides/sops.md`
End-to-end SOPS reference covering the things that were missing or scattered:
- **The core difference** — dotenvx distributes a portable `.env.keys` private key via envdrift **Vault Sync**; SOPS has no such file and delegates decrypt access to KMS/age/PGP, so it doesn't use (or need) Vault Sync.
- **Two meanings of "vault"** — envdrift Vault Sync uses the cloud vault's **secrets** API (dotenvx only); SOPS uses the **keys** API (RSA envelope encryption). Different RBAC.
- **Correct `[encryption.sops]` config** and the simple `encrypt`/`decrypt` path.
- **Verified Azure Key Vault walkthrough** — the exact roles (`Key Vault Crypto Officer` to create the key, `Key Vault Crypto User` to encrypt/decrypt), key creation, the `azure_kv` config, and a working round trip. This RBAC detail wasn't documented anywhere.
- **`Using pull and lock with SOPS`** — the precise behavior (they need a `[vault.sync]` stub + `pull --skip-sync`; recommended SOPS path is plain `encrypt`/`decrypt`).

### Fixes
- **`concepts/encryption-backends.md`** — the TOML example used flat keys (`sops_config_file`, `sops_age_recipients`) under `[encryption]`, which the parser **ignores** (it reads `[encryption.sops]` / `[encryption.dotenvx]`). Corrected to the working nested form.
- **`cli/lock.md` / `cli/pull.md`** — replaced the misleading "this workflow is specific to dotenvx and does not apply to SOPS" with the accurate nuance: only the **key-sync** step is dotenvx-only; the **encrypt/decrypt** step works with SOPS.
- **`mkdocs.yml`** — added "SOPS Backend" to the Guides nav.

## Verification
- Encrypt → decrypt → `lock` → `pull --skip-sync` round trip run live against a real Azure Key Vault key (RSA 2048).
- `mkdocs build --strict` passes (no broken links); anchor link to the guide section is slug-safe.

## Follow-up (code, not in this PR)
The docs now describe behavior that's arguably a UX wart worth fixing in `cli_commands/sync.py`:
1. `lock`/`pull` require a `[vault.sync]` + `[vault]` block even for SOPS (they build a vault client and file work-list up front, regardless of backend).
2. Plain `envdrift pull` runs the dotenvx key-sync step for SOPS and fails confusingly (`Secret '…' not found`); it could auto-skip the sync step when the resolved backend is SOPS.

Happy to do these in a separate PR with tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive SOPS Backend guide with setup, Azure Key Vault walkthrough, and usage workflows
  * Clarified lock and pull command behavior across encryption backends
  * Updated encryption backend configuration structure and examples

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a dedicated SOPS Backend guide (`docs/guides/sops.md`), fixes a broken TOML config example in the encryption-backends concept doc, and corrects the lock/pull CLI pages to replace the blanket \"SOPS does not apply\" statement with the accurate nuance. Three integration tests are added to guard the documented lock/pull/pull-with-skip-sync behaviors for SOPS.

- **New `docs/guides/sops.md`**: End-to-end reference covering the dotenvx-vs-SOPS conceptual difference, an Azure Key Vault walkthrough (with verified RBAC roles), the `[encryption.sops]` config structure, and precise `lock`/`pull` behavior for SOPS users.
- **`docs/concepts/encryption-backends.md` fix**: TOML example corrected from flat `sops_*` / `dotenvx_*` keys (silently ignored by the parser) to the proper nested `[encryption.sops]` / `[encryption.dotenvx]` subsections.
- **Three new integration tests**: cover the lock→pull roundtrip for SOPS, the expected failure without a `[vault.sync]` block, and plain `pull` (no `--skip-sync`) reaching and failing on the dotenvx key-sync step.

<h3>Confidence Score: 4/5</h3>

Safe to merge after correcting the HashiCorp provider config key in the SOPS guide.

The new SOPS guide documents `vault_url` as the required config key for the HashiCorp provider block, but the integration test added in this same PR configures HashiCorp with `url` — a different field name. A user following the guide to set up lock/pull with HashiCorp Vault would write the wrong key, causing the vault client to fail with a confusing error. Everything else is accurate and well-constructed.

docs/guides/sops.md — specifically the provider config key description in the Using pull and lock with SOPS section.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/guides/sops.md | New comprehensive SOPS guide — well-structured, but the lock/pull section incorrectly documents the HashiCorp provider config key as `vault_url` when tests show it is `url`. |
| tests/integration/test_encryption_tools.py | Three new integration tests added: lock/pull roundtrip, missing vault.sync failure, and plain-pull negative test. Tests are well-isolated with credential scrubbing. |
| docs/concepts/encryption-backends.md | Fixed TOML config example to use nested `[encryption.sops]` and `[encryption.dotenvx]` subsections instead of flat keys; added pointer to the new SOPS guide. |
| docs/cli/lock.md | Clarified that only the key-sync/verify step is dotenvx-only; `lock` can drive SOPS encryption with a `[vault.sync]` section present. |
| docs/cli/pull.md | Replaced blanket 'SOPS does not apply' with accurate nuance that `pull --skip-sync` can drive SOPS decryption. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User wants to use SOPS with envdrift] --> B{Which workflow?}
    B -->|Simple| C[envdrift encrypt / decrypt]
    B -->|Batch file-discovery| D{Has vault.sync config?}
    C --> E[No vault scaffolding needed]
    E --> F[SOPS uses KMS/age/PGP for access]
    D -->|No| G[Fail: No sync configuration found]
    D -->|Yes| H{Which command?}
    H -->|lock --force| I[Encrypt files with SOPS backend]
    H -->|pull --skip-sync| J[Decrypt files with SOPS backend]
    H -->|plain pull| K[Runs dotenvx key-sync step FIRST]
    K --> L[Fail: looks for dotenvx secret in vault]
    I --> M[Success: ENC encrypted files]
    J --> N[Success: plaintext files]
    style G fill:#f88,stroke:#c00
    style L fill:#f88,stroke:#c00
    style M fill:#8f8,stroke:#0a0
    style N fill:#8f8,stroke:#0a0
```

<sub>Reviews (2): Last reviewed commit: ["test(sops): add plain-pull negative test..."](https://github.com/jainal09/envdrift/commit/367a53f0a046ecb2e8f8fd2e4589c6ac1d516f90) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35385130)</sub>

<!-- /greptile_comment -->