### PR TITLE
fix: remove stale verify-vault sync config hint

### DIFF
--- a/docs/cli/decrypt.md
+++ b/docs/cli/decrypt.md
@@ -169,8 +169,10 @@ On failure it prints `✗ Vault key CANNOT decrypt this file!` followed by repai
 steps:
 
 - `git restore <file>`
-- `envdrift sync --force -c pair.txt -p <provider>` (with `--vault-url`/`--region`/`--project-id`
-  appended when those flags were passed) to restore the vault key locally
+- `envdrift sync --force -p <provider>` to restore the vault key locally. When
+  the current command discovered a TOML config, the hint includes
+  `-c <resolved-config>`; `--vault-url`/`--region`/`--project-id` are appended
+  when those flags were passed.
 - `envdrift encrypt <file>` to re-encrypt with the vault key
 
 !!! note "`--verify-vault` only verifies — it does not fetch the key"
@@ -200,7 +202,7 @@ When using `--verify-vault`, a wrong key returns exit 1 with a message like:
 ...
 To fix:
   1. Restore the encrypted file: git restore .env.production
-  2. Restore vault key locally: envdrift sync --force -c pair.txt -p azure
+  2. Restore vault key locally: envdrift sync --force -p azure
   3. Re-encrypt with the vault key: envdrift encrypt .env.production
 ```
 

--- a/docs/guides/env-file-sync.md
+++ b/docs/guides/env-file-sync.md
@@ -482,8 +482,9 @@ envdrift decrypt .env.production --verify-vault --ci \
 Exit `0` if the vault key can decrypt the file, `1` if it can't — with repair steps:
 
 1. `git restore .env.production`
-2. `envdrift sync --force -c pair.txt -p <provider>` (the printed command also
-   appends `--vault-url` / `--region` / `--project-id` when you passed them)
+2. `envdrift sync --force -p <provider>` (the printed command includes
+   `-c <resolved-config>` when a TOML config was discovered, and appends
+   `--vault-url` / `--region` / `--project-id` when you passed them)
 3. `envdrift encrypt .env.production`
 
 See [`decrypt`](../cli/decrypt.md) for the full verify-vault behavior.

--- a/src/envdrift/cli_commands/encryption.py
+++ b/src/envdrift/cli_commands/encryption.py
@@ -7,6 +7,7 @@ Supports multiple encryption backends:
 
 from __future__ import annotations
 
+import shlex
 from pathlib import Path
 from typing import Annotated
 
@@ -306,6 +307,7 @@ def _verify_decryption_with_vault(
     secret_name: str,
     ci: bool = False,
     auto_install: bool = False,
+    config_path: Path | None = None,
 ) -> bool:
     """
     Verify that a vault-stored private key can decrypt the given .env file.
@@ -319,6 +321,7 @@ def _verify_decryption_with_vault(
         region (str | None): Region identifier for providers that require it (e.g., AWS); may be None.
         project_id (str | None): GCP project ID for Secret Manager.
         secret_name (str): Name of the secret in the vault that contains the private key (or an environment-style value like "DOTENV_PRIVATE_KEY_ENV=key").
+        config_path (Path | None): Resolved TOML config path to preserve in the repair hint when known.
 
     Returns:
         bool: `True` if the vault key successfully decrypts a temporary copy of `env_file`, `False` otherwise.
@@ -435,13 +438,16 @@ def _verify_decryption_with_vault(
                 console.print(f"  1. Restore the encrypted file: git restore {env_file}")
 
                 # Construct sync command with the same provider options
-                sync_cmd = f"envdrift sync --force -c pair.txt -p {provider}"
+                sync_cmd = "envdrift sync --force"
+                if config_path:
+                    sync_cmd += f" -c {shlex.quote(str(config_path))}"
+                sync_cmd += f" -p {shlex.quote(provider)}"
                 if vault_url:
-                    sync_cmd += f" --vault-url {vault_url}"
+                    sync_cmd += f" --vault-url {shlex.quote(vault_url)}"
                 if region:
-                    sync_cmd += f" --region {region}"
+                    sync_cmd += f" --region {shlex.quote(region)}"
                 if project_id:
-                    sync_cmd += f" --project-id {project_id}"
+                    sync_cmd += f" --project-id {shlex.quote(project_id)}"
                 console.print(f"  2. Restore vault key locally: {sync_cmd}")
 
                 console.print(f"  3. Re-encrypt with the vault key: envdrift encrypt {env_file}")
@@ -616,6 +622,7 @@ def decrypt_cmd(
             secret_name=vault_secret,
             ci=ci,
             auto_install=encryption_config.dotenvx_auto_install if encryption_config else False,
+            config_path=config_path,
         )
         if not vault_check_passed:
             raise typer.Exit(code=1)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import shlex
 import tomllib
 from pathlib import Path
 from textwrap import dedent
 from types import SimpleNamespace
 from typing import Any, cast
 
+import pytest
 from typer.testing import CliRunner
 
 from envdrift.cli import app
@@ -584,7 +586,7 @@ class TestDecryptCommand:
         env_file = tmp_path / ".env.production"
         env_file.write_text("SECRET=encrypted")
 
-        called = {"verify": False}
+        called: dict[str, Any] = {"verify": False}
 
         def fake_verify(**kwargs):
             """
@@ -597,6 +599,7 @@ class TestDecryptCommand:
                 True indicating the verification succeeded.
             """
             called["verify"] = True
+            called["kwargs"] = kwargs
             return True
 
         monkeypatch.setattr(
@@ -627,6 +630,46 @@ class TestDecryptCommand:
 
         assert result.exit_code == 0
         assert called["verify"] is True
+        assert called["kwargs"]["config_path"] is None
+
+    def test_decrypt_verify_vault_passes_discovered_config_path(self, monkeypatch, tmp_path: Path):
+        """--verify-vault should pass the resolved TOML config path to repair hints."""
+
+        env_file = tmp_path / ".env.production"
+        env_file.write_text("SECRET=encrypted")
+
+        config_path = tmp_path / "envdrift.toml"
+        config_path.write_text('[encryption]\nbackend = "dotenvx"\n')
+
+        captured: dict[str, Any] = {}
+
+        def fake_verify(**kwargs):
+            captured.update(kwargs)
+            return True
+
+        monkeypatch.setattr("envdrift.config.find_config", lambda: config_path)
+        monkeypatch.setattr(
+            "envdrift.cli_commands.encryption._verify_decryption_with_vault", fake_verify
+        )
+
+        result = runner.invoke(
+            app,
+            [
+                "decrypt",
+                str(env_file),
+                "--verify-vault",
+                "-p",
+                "azure",
+                "--vault-url",
+                "https://example.vault.azure.net",
+                "--secret",
+                "env-drift-production-key",
+                "--ci",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert captured["config_path"] == config_path
         assert "not decrypted" in result.output.lower()
 
     def test_encrypt_verify_vault_is_deprecated(self, tmp_path: Path):
@@ -1081,11 +1124,74 @@ class TestVaultVerification:
         assert "DOTENV_PRIVATE_KEY_STAGING" not in subprocess_env
         assert captured["cwd"] is not None and captured["cwd"] != env_file.parent
 
-    def test_verify_vault_failure_suggests_restore(self, monkeypatch, tmp_path: Path):
+    @pytest.mark.parametrize(
+        (
+            "provider",
+            "vault_url",
+            "region",
+            "project_id",
+            "config_filename",
+            "expected_extra_options",
+        ),
+        [
+            (
+                "azure",
+                "https://example.vault.azure.net",
+                None,
+                None,
+                None,
+                " --vault-url https://example.vault.azure.net",
+            ),
+            (
+                "aws",
+                None,
+                "us-east-1",
+                None,
+                None,
+                " --region us-east-1",
+            ),
+            (
+                "gcp",
+                None,
+                None,
+                "my-gcp-project",
+                None,
+                " --project-id my-gcp-project",
+            ),
+            (
+                "azure",
+                "https://example.vault.azure.net",
+                None,
+                None,
+                "envdrift.toml",
+                " --vault-url https://example.vault.azure.net",
+            ),
+            (
+                "azure",
+                "https://example.vault.azure.net",
+                None,
+                None,
+                "env drift.toml",
+                " --vault-url https://example.vault.azure.net",
+            ),
+        ],
+    )
+    def test_verify_vault_failure_suggests_restore(
+        self,
+        monkeypatch,
+        tmp_path: Path,
+        provider: str,
+        vault_url: str | None,
+        region: str | None,
+        project_id: str | None,
+        config_filename: str | None,
+        expected_extra_options: str,
+    ):
         """Vault verification failure should guide restoring encrypted file and keys."""
 
         env_file = tmp_path / ".env.production"
         env_file.write_text("SECRET=encrypted")
+        config_path = tmp_path / config_filename if config_filename else None
 
         secret_value = SimpleNamespace(value="DOTENV_PRIVATE_KEY_PRODUCTION=vault-key")
 
@@ -1127,18 +1233,24 @@ class TestVaultVerification:
 
         result = _verify_decryption_with_vault(
             env_file=env_file,
-            provider="azure",
-            vault_url="https://example.vault.azure.net",
-            region=None,
-            project_id=None,
+            provider=provider,
+            vault_url=vault_url,
+            region=region,
+            project_id=project_id,
             secret_name="env-drift-production-key",
+            config_path=config_path,
         )
 
         assert result is False
         joined = " ".join(printed)
+        expected_sync_cmd = "envdrift sync --force"
+        if config_path:
+            expected_sync_cmd += f" -c {shlex.quote(str(config_path))}"
+        expected_sync_cmd += f" -p {provider}{expected_extra_options}"
         assert "git restore" in joined
         assert str(env_file) in joined
-        assert "envdrift sync --force" in joined
+        assert expected_sync_cmd in joined
+        assert "-c pair.txt" not in joined
 
     def test_verify_vault_gcp_passes_project_id(self, monkeypatch, tmp_path: Path):
         """GCP provider should pass project_id through to the vault client."""
@@ -1182,48 +1294,6 @@ class TestVaultVerification:
         assert result is True
         assert captured["provider"] == "gcp"
         assert captured["kwargs"]["project_id"] == "my-gcp-project"
-
-    def test_verify_vault_gcp_failure_includes_project_id(self, monkeypatch, tmp_path: Path):
-        """Failure guidance should include gcp project-id in sync command."""
-        env_file = tmp_path / ".env.production"
-        env_file.write_text("SECRET=encrypted")
-
-        secret_value = SimpleNamespace(value="DOTENV_PRIVATE_KEY_PRODUCTION=vault-key")
-
-        class DummyVault:
-            def ensure_authenticated(self) -> None:
-                return None
-
-            def get_secret(self, name: str):
-                return secret_value
-
-        monkeypatch.setattr("envdrift.vault.get_vault_client", lambda *_, **__: DummyVault())
-        monkeypatch.setattr(
-            "envdrift.integrations.dotenvx.DotenvxWrapper.is_installed",
-            lambda self: True,
-        )
-        monkeypatch.setattr(
-            "envdrift.integrations.dotenvx.DotenvxWrapper.decrypt",
-            lambda *_, **__: (_ for _ in ()).throw(DotenvxError("bad key")),
-        )
-
-        printed: list[str] = []
-        monkeypatch.setattr(
-            "envdrift.output.rich.console.print", lambda msg="", *a, **k: printed.append(str(msg))
-        )
-
-        result = _verify_decryption_with_vault(
-            env_file=env_file,
-            provider="gcp",
-            vault_url=None,
-            region=None,
-            project_id="my-gcp-project",
-            secret_name="env-drift-production-key",
-        )
-
-        assert result is False
-        joined = " ".join(printed)
-        assert "--project-id my-gcp-project" in joined
 
     def test_verify_vault_aws_with_raw_secret(self, monkeypatch, tmp_path: Path):
         """Vault verification should accept raw secrets and derive key name."""


### PR DESCRIPTION
## Summary
- remove the stale `-c pair.txt` placeholder from the `decrypt --verify-vault` repair hint
- assert the repair hint is runnable without the legacy config placeholder
- update verify-vault docs to match the command now printed by the CLI

## Tests
- `uv run --extra dev pytest tests/unit/test_cli.py::TestVaultVerification::test_verify_vault_failure_suggests_restore`
- `uv run --extra dev ruff check src/envdrift/cli_commands/encryption.py tests/unit/test_cli.py`
- `npx markdownlint-cli2 docs/cli/decrypt.md docs/guides/env-file-sync.md`
- pre-commit hooks on commit/push: ruff, ruff format, pyrefly, bandit

Closes #292

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refined vault verification failure remediation instructions in decrypt and env-file-sync guides with improved command syntax and conditional config file handling.

* **Tests**
  * Enhanced test coverage for vault verification scenarios using parametrized testing across different providers and config file conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the stale `-c pair.txt` placeholder from the `--verify-vault` repair hint in `_verify_decryption_with_vault`, replacing it with a conditional `-c <resolved-config>` fragment that is only included when the caller passes a real `config_path`. The same change extends `shlex.quote` to all provider-specific values in the hint command.

- **`encryption.py`**: Adds `config_path: Path | None = None` to `_verify_decryption_with_vault`, builds the hint conditionally, and wraps all injected strings with `shlex.quote`. `decrypt_cmd` now forwards `config_path` to the helper.
- **Tests**: The previously single-provider failure test is replaced by a parametrised suite covering azure/aws/gcp and a config filename containing a space; a new integration-level test asserts `config_path` is forwarded end-to-end from `decrypt_cmd`.
- **Docs**: `docs/cli/decrypt.md` and `docs/guides/env-file-sync.md` updated to match the new conditional hint format.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is narrowly scoped to the repair hint printed on verification failure, with no effect on the decryption path itself.

The fix is straightforward: a hardcoded placeholder string is replaced with a conditional expression, and the new parametrised tests cover the key combinations (azure/aws/gcp with and without config path, including a path with a space). The only gap left is that `env_file` is still interpolated bare in the two adjacent hint lines, but that is pre-existing and does not affect correctness of the decryption logic.

No files require special attention — the one inconsistency (unquoted `env_file` in the hint) is minor and pre-existing.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/envdrift/cli_commands/encryption.py | Adds `config_path` param to `_verify_decryption_with_vault`, replaces hardcoded `-c pair.txt` with a conditional `-c {shlex.quote(config_path)}`, and extends `shlex.quote` to all injected provider options. |
| tests/unit/test_cli.py | Converts the single `test_verify_vault_failure_suggests_restore` test into a parametrised suite covering azure/aws/gcp and config-with-spaces; adds `test_decrypt_verify_vault_passes_discovered_config_path`; removes the now-redundant GCP-specific failure test. |
| docs/cli/decrypt.md | Updated repair hint docs to reflect the conditional `-c <resolved-config>` flag and drop the stale `-c pair.txt` placeholder. |
| docs/guides/env-file-sync.md | Mirrors decrypt.md update — repair step 2 now documents the conditional `-c <resolved-config>` behaviour. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CLI as decrypt_cmd
    participant Config as _load_encryption_config
    participant VV as _verify_decryption_with_vault
    participant Vault as VaultClient
    participant Console as console.print

    CLI->>Config: _load_encryption_config()
    Config-->>CLI: (envdrift_config, config_path)
    CLI->>VV: "_verify_decryption_with_vault(..., config_path=config_path)"
    VV->>Vault: get_secret(secret_name)
    Vault-->>VV: secret_value
    VV->>VV: dotenvx.decrypt(tmp_copy)
    alt Decryption fails (DotenvxError)
        VV->>Console: git restore env_file
        VV->>VV: build sync_cmd (conditional -c, shlex.quote all parts)
        VV->>Console: envdrift sync --force [-c config] -p provider [...]
        VV->>Console: envdrift encrypt env_file
        VV-->>CLI: False
    else Decryption succeeds
        VV-->>CLI: True
    end
    CLI->>Console: Vault verification completed.
```

<sub>Reviews (4): Last reviewed commit: ["fix: remove stale verify-vault sync conf..."](https://github.com/jainal09/envdrift/commit/1dd915106e1257a0c835f8109af734c1a2b23041) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35424069)</sub>

<!-- /greptile_comment -->