### PR TITLE
feat(vault-sync): support custom dotenv filenames via env_file

### DIFF
--- a/docs/cli/hook.md
+++ b/docs/cli/hook.md
@@ -70,6 +70,13 @@ repos:
         files: ^\.env\.(production|staging)$
         pass_filenames: true
 
+      - id: envdrift-guard
+        name: Guard staged env files
+        entry: envdrift guard --staged --native-only --ci
+        language: system
+        always_run: true
+        pass_filenames: false
+
       # Optional: Verify encryption keys match vault (prevents key drift)
       # - id: envdrift-vault-verify
       #   name: Verify vault key can decrypt
@@ -156,7 +163,23 @@ If you prefer manual setup:
   pass_filenames: true
 ```
 
-This blocks commits with unencrypted secrets in production/staging files.
+This blocks commits with unencrypted secrets in production/staging files that
+match the hook regex.
+
+### Guard Hook
+
+```yaml
+- id: envdrift-guard
+  name: Guard staged env files
+  entry: envdrift guard --staged --native-only --ci
+  language: system
+  always_run: true
+  pass_filenames: false
+```
+
+This runs the config-aware staged scanner. It covers normal `.env*` files,
+partial-encryption `.secret` files, `.env.keys`, and custom
+`[vault.sync].mappings.env_file` names such as `postgresql.env`.
 
 ## Customization
 

--- a/docs/cli/lock.md
+++ b/docs/cli/lock.md
@@ -394,6 +394,12 @@ secret_name = "myapp-key"
 folder_path = "services/myapp"
 environment = "production"
 
+[[vault.sync.mappings]]
+secret_name = "postgres-key"
+folder_path = "secrets/postgresql"
+environment = "production"  # Key stays DOTENV_PRIVATE_KEY_PRODUCTION
+env_file = "postgresql.env" # Encrypt secrets/postgresql/postgresql.env
+
 # Profile mappings (processed only with --profile)
 [[vault.sync.mappings]]
 secret_name = "local-key"

--- a/docs/cli/pull.md
+++ b/docs/cli/pull.md
@@ -216,6 +216,12 @@ secret_name = "myapp-key"
 folder_path = "services/myapp"
 environment = "production"
 
+[[vault.sync.mappings]]
+secret_name = "postgres-key"
+folder_path = "secrets/postgresql"
+environment = "production"  # Key stays DOTENV_PRIVATE_KEY_PRODUCTION
+env_file = "postgresql.env" # Decrypt secrets/postgresql/postgresql.env
+
 # Profile mappings (processed only with --profile)
 [[vault.sync.mappings]]
 secret_name = "local-key"
@@ -233,6 +239,7 @@ activate_to = ".env"
 ### Profile vs Environment
 
 - **`environment`**: Specifies which `.env.<environment>` file to look for (e.g., `production` → `.env.production`)
+- **`env_file`**: Overrides the file path when a service uses another dotenv-style filename (e.g., `postgresql.env`)
 - **`profile`**: Tags a mapping for filtering with `--profile`
 
 The effective environment is resolved in this priority order:

--- a/docs/cli/sync.md
+++ b/docs/cli/sync.md
@@ -133,6 +133,12 @@ secret_name = "auth-service-key"
 folder_path = "services/auth"
 vault_name = "other-vault"  # Override default
 environment = "staging"     # Use DOTENV_PRIVATE_KEY_STAGING
+
+[[vault.sync.mappings]]
+secret_name = "postgres-key"
+folder_path = "secrets/postgresql"
+environment = "production"  # Use DOTENV_PRIVATE_KEY_PRODUCTION
+env_file = "postgresql.env" # Custom dotenv filename inside folder_path
 ```
 
 Place the file in the project root so auto-discovery finds it; pass `-c envdrift.toml` in CI to pin the exact file.

--- a/docs/cli/vault-pull.md
+++ b/docs/cli/vault-pull.md
@@ -42,6 +42,14 @@ envdrift vault-pull ./services/myapp my-secret-name --env production \
 This fetches `my-secret-name`, writes `DOTENV_PRIVATE_KEY_PRODUCTION` to
 `./services/myapp/.env.keys`, and decrypts `./services/myapp/.env.production`.
 
+For a custom dotenv filename, pass `--env-file` while keeping `--env` as the key
+suffix:
+
+```bash
+envdrift vault-pull ./secrets/postgresql postgres-key --env production \
+  --env-file postgresql.env -p azure --vault-url https://myvault.vault.azure.net/
+```
+
 ### Pull key only (skip decryption)
 
 Use `--no-decrypt` to only write the key without touching the `.env.<env>` file.
@@ -74,6 +82,12 @@ The secret value may be stored as either `DOTENV_PRIVATE_KEY_<ENV>=<value>`
 ### `--no-decrypt`
 
 Only write the key to `.env.keys`; do not decrypt the `.env.<env>` file.
+
+### `--env-file`
+
+Custom dotenv filename to decrypt, relative to `FOLDER`. This is useful for files
+like `postgresql.env` or `dotnet-service-template.env.sqa`. The key name still
+comes from `--env`.
 
 ### `--config`, `-c`
 

--- a/docs/cli/vault-push.md
+++ b/docs/cli/vault-push.md
@@ -57,6 +57,17 @@ that are missing from the vault.
 envdrift vault-push --all
 ```
 
+If a sync mapping sets `env_file`, `--all` encrypts that custom dotenv filename
+and still pushes the canonical key named by `environment`:
+
+```toml
+[[vault.sync.mappings]]
+secret_name = "postgres-key"
+folder_path = "secrets/postgresql"
+environment = "production"
+env_file = "postgresql.env"
+```
+
 To overwrite existing secrets instead of skipping them, add `--force`:
 
 ```bash

--- a/docs/guides/agent-setup.md
+++ b/docs/guides/agent-setup.md
@@ -105,6 +105,11 @@ recursive = true                   # Watch subdirectories
 | `directories.watch` | string[] | `["~/projects"]` | Directories to monitor (display only — not used to select watched directories; see [Selecting which projects to watch](#selecting-which-projects-to-watch)) |
 | `directories.recursive` | bool | `true` | Watch subdirectories |
 
+When a project has `[guardian] enabled = true`, custom
+`[vault.sync].mappings.env_file` names are added to the effective watch patterns
+automatically. This lets the agent react to files such as `postgresql.env` even
+though the global default is `.env*`.
+
 ### Duration Format
 
 The `idle_timeout` accepts Go duration strings:
@@ -234,6 +239,8 @@ The agent calls `envdrift lock`, which means it respects all settings in your pr
 - **Partial encryption** - Only secrets are encrypted
 - **Vault integration** - Keys are pushed to vault if configured
 - **Ephemeral keys** - Keys never touch disk if enabled
+- **Custom env filenames** - `vault.sync.mappings.env_file` names are watched
+  automatically when project guardian config is enabled
 
 ## Troubleshooting
 

--- a/docs/guides/cicd.md
+++ b/docs/guides/cicd.md
@@ -92,7 +92,17 @@ repos:
         language: system
         files: ^\.env\.(production|staging)$
         pass_filenames: true
+
+      - id: envdrift-guard
+        name: Guard staged env files
+        entry: envdrift guard --staged --native-only --ci
+        language: system
+        always_run: true
+        pass_filenames: false
 ```
+
+`envdrift-guard` is the config-aware safety net. Keep it enabled for custom
+`[vault.sync].mappings.env_file` names that do not match `.env*`.
 
 Install:
 

--- a/docs/guides/encryption.md
+++ b/docs/guides/encryption.md
@@ -183,7 +183,17 @@ repos:
         language: system
         files: ^\.env\.(production|staging)$
         pass_filenames: true
+
+      - id: envdrift-guard
+        name: Guard staged env files
+        entry: envdrift guard --staged --native-only --ci
+        language: system
+        always_run: true
+        pass_filenames: false
 ```
+
+Use the guard hook when you rely on `[vault.sync].mappings.env_file`; it reads
+the TOML mapping and blocks custom dotenv filenames such as `postgresql.env`.
 
 ## Dotenvx Key Management
 

--- a/docs/guides/env-file-sync.md
+++ b/docs/guides/env-file-sync.md
@@ -148,6 +148,12 @@ folder_path = "services/myapp"
 secret_name = "auth-service-dotenvx-key"
 folder_path = "services/auth"
 environment = "staging"   # reads/writes DOTENV_PRIVATE_KEY_STAGING
+
+[[vault.sync.mappings]]
+secret_name = "postgres-key"
+folder_path = "secrets/postgresql"
+environment = "production"
+env_file = "postgresql.env"  # custom dotenv filename inside folder_path
 ```
 
 Using a different provider? Replace the `provider` value and the provider block:
@@ -345,6 +351,17 @@ vault_name = "production-vault"  # informational only — see note below
     `[vault.azure].vault_url` (or `--region` / `--project-id`). A per-mapping
     `vault_name` does **not** route that secret to a different vault. To use a
     separate vault, run a separate config.
+
+By default, envdrift looks for `.env.<environment>` and then falls back to `.env`
+or a single `.env.*` file. Use `env_file` when a service uses another dotenv-style
+filename, such as `postgresql.env` or `dotnet-service-template.env.sqa`.
+`environment` remains the source of truth for key names, so the examples above
+still use keys like `DOTENV_PRIVATE_KEY_PRODUCTION` and `DOTENV_PRIVATE_KEY_STAGING`.
+The installed git hook and `guard --staged` read these mappings and block
+plaintext custom env files before commit. The background agent also adds mapped
+`env_file` names to its watch patterns when project `[guardian]` is enabled; the
+VS Code extension remains settings-driven, so add custom names to
+`envdrift.patterns` there.
 
 ### Ephemeral keys mode
 

--- a/docs/guides/vscode-extension.md
+++ b/docs/guides/vscode-extension.md
@@ -75,7 +75,7 @@ Access settings via `Code > Preferences > Settings > Extensions > EnvDrift`
 ```json
 {
   "envdrift.enabled": true,
-  "envdrift.patterns": [".env*", "*.env"],
+  "envdrift.patterns": [".env*", "*.env", "postgresql.env"],
   "envdrift.exclude": [
     ".env.example",
     ".env.sample", 
@@ -123,7 +123,7 @@ Access via Command Palette (`Cmd+Shift+P` / `Ctrl+Shift+P`):
 └─────────────────────────────────────────────────────┘
 ```
 
-1. **File Close Listener** - Detects when `.env*` files are closed
+1. **File Close Listener** - Detects when configured env file patterns are closed
 2. **Pattern Matching** - Checks if file matches configured patterns
 3. **Encryption Check** - Verifies file isn't already encrypted
 4. **envdrift lock** - Calls CLI to encrypt (respects `envdrift.toml`)
@@ -171,6 +171,11 @@ When the extension encrypts a file:
 - **Vault sync** happens if configured
 - **Ephemeral keys**: only active when triggered via the terminal commands
   noted above; the extension's encrypt action does not honor this flag
+
+For custom `[vault.sync].mappings.env_file` names, add the filename to
+`envdrift.patterns` in VS Code settings. The extension calls `envdrift lock`
+after a matching file closes, but pattern matching itself is controlled by the
+extension settings.
 
 ## Workflow Examples
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -284,6 +284,7 @@ Each mapping defines how a vault secret maps to a local service directory.
 | `folder_path` | `string` | **required** | Local folder containing `.env.keys` |
 | `vault_name` | `string` | `null` | Parsed but informational only — every mapping is fetched from the single vault you configured via `--vault-url` / `[vault.<provider>]`. See the note in [env-file-sync.md](../guides/env-file-sync.md#mappings). |
 | `environment` | `string` | `null` (resolves to profile name, else `"production"`) | **Identity** — which `.env.<environment>` file this mapping targets and which `DOTENV_PRIVATE_KEY_<ENVIRONMENT>` key it reads/writes. Always runs (unless filtered out by `profile`). |
+| `env_file` | `string` | `null` | Custom dotenv filename relative to `folder_path` (e.g. `postgresql.env`). When set, this exact file is used instead of the `.env.<environment>` lookup; `environment` still controls the `DOTENV_PRIVATE_KEY_<ENVIRONMENT>` key name. |
 | `profile` | `string` | `null` | **Selector** — tags this mapping as profile-only. Untagged mappings always run. Profile-tagged mappings only run when you pass a matching `--profile <name>` on the CLI. |
 | `activate_to` | `string` | `null` | After decrypt, copy the decrypted file to this path. Typical use: `activate_to = ".env"` on a profile mapping so apps that read a plain `.env` get the right one for the active profile. |
 | `ephemeral_keys` | `bool` | `null` | Per-mapping override for ephemeral mode (no `.env.keys` written to disk). |
@@ -323,6 +324,13 @@ environment = "production"
 secret_name = "service2-key"
 folder_path = "services/service2"
 environment = "staging"
+
+# Mapping with a custom dotenv filename
+[[vault.sync.mappings]]
+secret_name = "postgres-key"
+folder_path = "secrets/postgresql"
+environment = "production"  # key stays DOTENV_PRIVATE_KEY_PRODUCTION
+env_file = "postgresql.env" # file path is secrets/postgresql/postgresql.env
 
 # Profile mapping — only runs with `envdrift pull --profile local`.
 # `environment` defaults to the profile name, so this targets .env.local
@@ -369,6 +377,29 @@ files = [
 ".env.production" = "config.settings:ProductionSettings"
 ".env.staging" = "config.settings:StagingSettings"
 ```
+
+### [git_hook_check] — Git Hook Enforcement
+
+Configuration for automatic git hook setup checks. When enabled, envdrift
+commands install or verify either direct git hooks or a `.pre-commit-config.yaml`
+entry.
+
+| Option | Type | Default | Description |
+|:-------|:-----|:--------|:------------|
+| `method` | `string` | `null` | Hook setup method. Use `"direct git hook"` or `"precommit.yaml"` |
+| `precommit_config` | `string` | `null` | Pre-commit config path, required when `method = "precommit.yaml"` |
+
+```toml
+[git_hook_check]
+method = "direct git hook"
+
+# Or:
+# method = "precommit.yaml"
+# precommit_config = ".pre-commit-config.yaml"
+```
+
+The installed pre-commit enforcement runs `envdrift guard --staged --native-only --ci`,
+so custom `[vault.sync].mappings.env_file` names are checked before commit.
 
 ### [partial_encryption] — Partial Encryption Settings
 

--- a/envdrift-agent/README.md
+++ b/envdrift-agent/README.md
@@ -104,6 +104,10 @@ recursive = true
 5. **Encrypts** using `envdrift lock` (respects `envdrift.toml`)
 6. **Notifies** (optional) via desktop notification
 
+Project-level `vault.sync.mappings.env_file` names are added to the effective
+watch patterns when `[guardian] enabled = true`, so custom dotenv filenames such
+as `postgresql.env` can be encrypted automatically.
+
 > 📖 **See the [comprehensive setup guide](../docs/guides/agent-setup.md) for detailed configuration and troubleshooting.**
 
 ## Platform-Specific Details

--- a/envdrift-agent/internal/project/config.go
+++ b/envdrift-agent/internal/project/config.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/pelletier/go-toml/v2"
@@ -33,9 +34,10 @@ type GuardianConfig struct {
 	IdleTimeoutStr string `toml:"idle_timeout"`
 }
 
-// envdriftConfig represents the full envdrift.toml structure (we only need guardian section).
+// envdriftConfig represents the envdrift.toml structure used by the agent.
 type envdriftConfig struct {
 	Guardian guardianToml `toml:"guardian"`
+	Vault    vaultToml    `toml:"vault"`
 }
 
 // guardianToml is the raw TOML representation.
@@ -45,6 +47,18 @@ type guardianToml struct {
 	Patterns    []string `toml:"patterns"`
 	Exclude     []string `toml:"exclude"`
 	Notify      *bool    `toml:"notify"`
+}
+
+type vaultToml struct {
+	Sync vaultSyncToml `toml:"sync"`
+}
+
+type vaultSyncToml struct {
+	Mappings []vaultSyncMappingToml `toml:"mappings"`
+}
+
+type vaultSyncMappingToml struct {
+	EnvFile string `toml:"env_file"`
 }
 
 // LoadProjectConfig loads the guardian configuration from a project's envdrift.toml.
@@ -65,7 +79,7 @@ func LoadProjectConfig(projectPath string) (*GuardianConfig, error) {
 		return nil, err
 	}
 
-	return parseGuardianConfig(&cfg.Guardian)
+	return parseGuardianConfig(&cfg.Guardian, cfg.Vault.Sync.Mappings)
 }
 
 // DefaultGuardianConfig returns a GuardianConfig with default values.
@@ -80,7 +94,7 @@ func DefaultGuardianConfig() *GuardianConfig {
 }
 
 // parseGuardianConfig converts the raw TOML config to GuardianConfig with defaults.
-func parseGuardianConfig(raw *guardianToml) (*GuardianConfig, error) {
+func parseGuardianConfig(raw *guardianToml, vaultMappings []vaultSyncMappingToml) (*GuardianConfig, error) {
 	cfg := DefaultGuardianConfig()
 
 	// Apply values from TOML if present
@@ -109,7 +123,51 @@ func parseGuardianConfig(raw *guardianToml) (*GuardianConfig, error) {
 		cfg.Notify = *raw.Notify
 	}
 
+	cfg.Patterns = appendVaultEnvFilePatterns(cfg.Patterns, vaultMappings)
+
 	return cfg, nil
+}
+
+func appendVaultEnvFilePatterns(patterns []string, mappings []vaultSyncMappingToml) []string {
+	result := append([]string{}, patterns...)
+
+	for _, mapping := range mappings {
+		envFile := strings.TrimSpace(mapping.EnvFile)
+		if envFile == "" || filepath.IsAbs(envFile) {
+			continue
+		}
+
+		clean := filepath.Clean(envFile)
+		if clean == "." || clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+			continue
+		}
+
+		name := filepath.Base(clean)
+		if name == "." || name == string(filepath.Separator) {
+			continue
+		}
+
+		if patternListMatches(result, name) {
+			continue
+		}
+
+		result = append(result, name)
+	}
+
+	return result
+}
+
+func patternListMatches(patterns []string, name string) bool {
+	for _, pattern := range patterns {
+		matched, err := filepath.Match(pattern, name)
+		if err == nil && matched {
+			return true
+		}
+		if pattern == name {
+			return true
+		}
+	}
+	return false
 }
 
 // ParseIdleTimeout parses a duration string like "5m", "30s", "1h", "2d" into time.Duration.

--- a/envdrift-agent/internal/project/config_test.go
+++ b/envdrift-agent/internal/project/config_test.go
@@ -146,6 +146,71 @@ idle_timeout = "1m"
 	}
 }
 
+func TestLoadProjectConfig_AppendsVaultEnvFilePatterns(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	tomlContent := `
+[guardian]
+enabled = true
+patterns = [".env*", "service.env"]
+
+[vault.sync]
+[[vault.sync.mappings]]
+folder_path = "secrets/postgresql"
+environment = "production"
+secret_name = "postgresql-key"
+env_file = "postgresql.env"
+
+[[vault.sync.mappings]]
+folder_path = "secrets/keycloak"
+environment = "production"
+secret_name = "keycloak-key"
+env_file = "keycloak/keycloak-local.env"
+
+[[vault.sync.mappings]]
+folder_path = "secrets/ignored"
+environment = "production"
+secret_name = "ignored-key"
+env_file = "../outside.env"
+
+[[vault.sync.mappings]]
+folder_path = "secrets/already-covered"
+environment = "production"
+secret_name = "already-covered-key"
+env_file = "service.env"
+`
+	if err := os.WriteFile(filepath.Join(tmpDir, "envdrift.toml"), []byte(tomlContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadProjectConfig(tmpDir)
+	if err != nil {
+		t.Fatalf("LoadProjectConfig() error = %v", err)
+	}
+
+	if !patternListMatches(cfg.Patterns, "postgresql.env") {
+		t.Errorf("Expected postgresql.env to be covered, got %v", cfg.Patterns)
+	}
+
+	if !patternListMatches(cfg.Patterns, "keycloak-local.env") {
+		t.Errorf("Expected keycloak-local.env to be covered, got %v", cfg.Patterns)
+	}
+
+	if patternListMatches(cfg.Patterns, "outside.env") {
+		t.Errorf("Expected escaping env_file to be ignored, got %v", cfg.Patterns)
+	}
+
+	servicePatternCount := 0
+	for _, pattern := range cfg.Patterns {
+		if pattern == "service.env" {
+			servicePatternCount++
+		}
+	}
+	if servicePatternCount != 1 {
+		t.Errorf("Expected service.env to stay de-duplicated, got %v", cfg.Patterns)
+	}
+}
+
 func TestLoadAllProjectConfigs(t *testing.T) {
 	// Create two project directories
 	proj1 := t.TempDir()

--- a/envdrift-vscode/src/fileWatcher.ts
+++ b/envdrift-vscode/src/fileWatcher.ts
@@ -101,7 +101,7 @@ export async function encryptCurrentFile(): Promise<void> {
 
     // Check if file matches pattern
     if (!matchesPatterns(path.basename(filePath), config.patterns)) {
-        vscode.window.showWarningMessage('This file does not match .env patterns');
+        vscode.window.showWarningMessage('This file does not match configured EnvDrift patterns');
         return;
     }
 

--- a/src/envdrift/cli_commands/guard.py
+++ b/src/envdrift/cli_commands/guard.py
@@ -394,7 +394,11 @@ def guard(
         if mapping.env_file:
             try:
                 mapped_env_files.append(
-                    str(resolve_custom_env_file(Path(mapping.folder_path), mapping.env_file))
+                    str(
+                        resolve_custom_env_file(
+                            Path(mapping.folder_path), mapping.env_file
+                        ).resolve()
+                    )
                 )
             except ValueError as e:
                 console.print(f"[red]Error:[/red] Invalid env_file for {mapping.folder_path}: {e}")

--- a/src/envdrift/cli_commands/guard.py
+++ b/src/envdrift/cli_commands/guard.py
@@ -35,6 +35,7 @@ from rich.spinner import Spinner
 from rich.text import Text
 
 from envdrift.config import load_config
+from envdrift.env_files import resolve_custom_env_file
 from envdrift.scanner.base import FindingSeverity
 from envdrift.scanner.engine import GuardConfig, ScanEngine
 from envdrift.scanner.output import format_json, format_rich, format_sarif
@@ -381,12 +382,23 @@ def guard(
     # These files are intentionally unencrypted and should not be flagged
     allowed_clear_files = []
     combined_files = []
+    mapped_env_files = []
     if file_config.partial_encryption.enabled:
         for env in file_config.partial_encryption.environments:
             if env.clear_file:
                 allowed_clear_files.append(env.clear_file)
             if env.combined_file:
                 combined_files.append(env.combined_file)
+
+    for mapping in file_config.vault.sync.mappings:
+        if mapping.env_file:
+            try:
+                mapped_env_files.append(
+                    str(resolve_custom_env_file(Path(mapping.folder_path), mapping.env_file))
+                )
+            except ValueError as e:
+                console.print(f"[red]Error:[/red] Invalid env_file for {mapping.folder_path}: {e}")
+                raise typer.Exit(code=1) from e
 
     # Determine skip_clear_files (CLI overrides config)
     skip_clear_final = skip_clear if skip_clear is not None else guard_cfg.skip_clear_files
@@ -430,6 +442,7 @@ def guard(
         fail_on_severity=fail_severity,
         allowed_clear_files=allowed_clear_files,
         combined_files=combined_files,
+        mapped_env_files=mapped_env_files,
     )
 
     # Create output console (suppress colors in CI mode or JSON/SARIF output)

--- a/src/envdrift/cli_commands/hook.py
+++ b/src/envdrift/cli_commands/hook.py
@@ -49,6 +49,13 @@ repos:
         files: ^\\.env\\.(production|staging)$
         pass_filenames: true
 
+      - id: envdrift-guard
+        name: Guard staged env files
+        entry: envdrift guard --staged --native-only --ci
+        language: system
+        always_run: true
+        pass_filenames: false
+
       # Optional: Verify encryption keys match vault (prevents key drift)
       # - id: envdrift-vault-verify
       #   name: Verify vault key can decrypt

--- a/src/envdrift/cli_commands/sync.py
+++ b/src/envdrift/cli_commands/sync.py
@@ -246,7 +246,9 @@ def _normalize_mapped_dotenvx_metadata(
     effective_environment: str,
     backend_provider: Any,
 ) -> None:
-    if getattr(backend_provider, "value", None) != "dotenvx" or mapping.env_file is None:
+    from envdrift.encryption import EncryptionProvider
+
+    if backend_provider != EncryptionProvider.DOTENVX or mapping.env_file is None:
         return
 
     from envdrift.integrations.dotenvx import normalize_dotenvx_metadata

--- a/src/envdrift/cli_commands/sync.py
+++ b/src/envdrift/cli_commands/sync.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Annotated, Any
 import typer
 from rich.panel import Panel
 
-from envdrift.env_files import detect_env_file
+from envdrift.env_files import resolve_mapping_env_file
 from envdrift.output.rich import console, print_error, print_success, print_warning
 from envdrift.utils import normalize_max_workers
 from envdrift.vault.base import SecretNotFoundError, VaultError
@@ -34,6 +34,7 @@ class _EncryptTask:
     mapping: ServiceMapping
     env_file: Path
     env_keys_file: Path
+    effective_environment: str
 
 
 def load_sync_config_and_client(
@@ -155,6 +156,7 @@ def load_sync_config_and_client(
                     folder_path=Path(m.folder_path),
                     vault_name=m.vault_name,
                     environment=m.environment,
+                    env_file=Path(m.env_file) if m.env_file else None,
                     profile=m.profile,
                     activate_to=Path(m.activate_to) if m.activate_to else None,
                     ephemeral_keys=m.ephemeral_keys,
@@ -235,6 +237,21 @@ def load_sync_config_and_client(
 
 def _normalize_max_workers(max_workers: int | None) -> int | None:
     return normalize_max_workers(max_workers, warn=print_warning)
+
+
+def _normalize_mapped_dotenvx_metadata(
+    mapping: ServiceMapping,
+    env_file: Path,
+    env_keys_file: Path,
+    effective_environment: str,
+    backend_provider: Any,
+) -> None:
+    if getattr(backend_provider, "value", None) != "dotenvx" or mapping.env_file is None:
+        return
+
+    from envdrift.integrations.dotenvx import normalize_dotenvx_metadata
+
+    normalize_dotenvx_metadata(env_file, env_keys_file, effective_environment)
 
 
 def _find_config_path(config_file: Path | None) -> Path | None:
@@ -673,25 +690,31 @@ def pull(
     partial_clear, _, partial_combined = _load_partial_encryption_paths(config_file)
 
     for mapping in filtered_mappings:
-        effective_env = mapping.effective_environment
-        env_file = mapping.folder_path / f".env.{effective_env}"
+        try:
+            detection = resolve_mapping_env_file(mapping)
+        except ValueError as e:
+            console.print(
+                f"  [red]![/red] {mapping.folder_path} [red]- invalid env_file: {e}[/red]"
+            )
+            error_count += 1
+            continue
+        effective_env = detection.environment or mapping.effective_environment
+        env_file = (
+            detection.path
+            if detection.path is not None
+            else mapping.folder_path / f".env.{effective_env}"
+        )
 
-        if not env_file.exists():
-            # Try to auto-detect .env.* file
-            detection = detect_env_file(mapping.folder_path)
-            if detection.status == "found" and detection.path is not None:
-                env_file = detection.path
-            elif detection.status == "multiple_found":
+        if detection.status != "found" or detection.path is None:
+            if detection.status == "multiple_found":
                 console.print(
                     f"  [yellow]?[/yellow] {mapping.folder_path} "
                     f"[yellow]- skipped (multiple .env.* files, specify environment)[/yellow]"
                 )
-                skipped_count += 1
-                continue
             else:
                 console.print(f"  [dim]=[/dim] {env_file} [dim]- skipped (not found)[/dim]")
-                skipped_count += 1
-                continue
+            skipped_count += 1
+            continue
 
         resolved_env_file = env_file.resolve()
         if resolved_env_file in partial_combined:
@@ -706,6 +729,14 @@ def pull(
             )
             skipped_count += 1
             continue
+
+        _normalize_mapped_dotenvx_metadata(
+            mapping,
+            env_file,
+            mapping.folder_path / (sync_config.env_keys_filename or ".env.keys"),
+            effective_env,
+            backend_provider,
+        )
 
         # Check if file is encrypted
         content = env_file.read_text()
@@ -1294,28 +1325,35 @@ def lock(
     dotenvx_locks: dict[Path, Lock] = {}
 
     for mapping in filtered_mappings:
-        effective_env = mapping.effective_environment
-        env_file = mapping.folder_path / f".env.{effective_env}"
+        try:
+            detection = resolve_mapping_env_file(mapping)
+        except ValueError as e:
+            console.print(
+                f"  [red]![/red] {mapping.folder_path} [red]- invalid env_file: {e}[/red]"
+            )
+            errors.append(f"{mapping.folder_path}: invalid env_file - {e}")
+            error_count += 1
+            continue
+        effective_env = detection.environment or mapping.effective_environment
+        env_file = (
+            detection.path
+            if detection.path is not None
+            else mapping.folder_path / f".env.{effective_env}"
+        )
 
         # Check if env file exists
-        if not env_file.exists():
-            # Try to auto-detect .env.* file
-            detection = detect_env_file(mapping.folder_path)
-            if detection.status == "found" and detection.path is not None:
-                env_file = detection.path
-            elif detection.status == "multiple_found":
+        if detection.status != "found" or detection.path is None:
+            if detection.status == "multiple_found":
                 console.print(
                     f"  [yellow]?[/yellow] {mapping.folder_path} "
                     f"[yellow]- skipped (multiple .env.* files, specify environment)[/yellow]"
                 )
                 warnings.append(f"{mapping.folder_path}: multiple .env files found")
-                skipped_count += 1
-                continue
             else:
                 console.print(f"  [dim]=[/dim] {env_file} [dim]- skipped (not found)[/dim]")
                 warnings.append(f"{env_file}: file not found")
-                skipped_count += 1
-                continue
+            skipped_count += 1
+            continue
 
         resolved_env_file = env_file.resolve()
         if resolved_env_file in partial_combined and not all_files:
@@ -1346,6 +1384,14 @@ def lock(
                 f"[yellow]- warning: no .env.keys file, will generate new key[/yellow]"
             )
             warnings.append(f"{env_file}: no .env.keys file found, new key will be generated")
+
+        _normalize_mapped_dotenvx_metadata(
+            mapping,
+            env_file,
+            env_keys_file,
+            effective_env,
+            backend_provider,
+        )
 
         # Check if file is already encrypted
         content = env_file.read_text()
@@ -1451,6 +1497,13 @@ def lock(
                                     errors.append(f"{env_file}: re-encryption for rekey failed")
                                     error_count += 1
                                     continue
+                                _normalize_mapped_dotenvx_metadata(
+                                    mapping,
+                                    env_file,
+                                    env_keys_file,
+                                    effective_env,
+                                    backend_provider,
+                                )
                                 console.print(
                                     f"  [green]+[/green] {env_file} [dim]- re-encrypted with new key[/dim]"
                                 )
@@ -1518,7 +1571,12 @@ def lock(
 
         if force:
             encrypt_tasks.append(
-                _EncryptTask(mapping=mapping, env_file=env_file, env_keys_file=env_keys_file)
+                _EncryptTask(
+                    mapping=mapping,
+                    env_file=env_file,
+                    env_keys_file=env_keys_file,
+                    effective_environment=effective_env,
+                )
             )
             if backend_provider == EncryptionProvider.DOTENVX:
                 lock_key = env_keys_file.resolve()
@@ -1534,6 +1592,13 @@ def lock(
                 errors.append(f"{env_file}: encryption failed - {result.message}")
                 error_count += 1
                 continue
+            _normalize_mapped_dotenvx_metadata(
+                mapping,
+                env_file,
+                env_keys_file,
+                effective_env,
+                backend_provider,
+            )
             console.print(f"  [green]+[/green] {env_file} [dim]- encrypted[/dim]")
             encrypted_count += 1
 
@@ -1580,6 +1645,13 @@ def lock(
                 errors.append(f"{env_file}: encryption failed - {message}")
                 error_count += 1
                 continue
+            _normalize_mapped_dotenvx_metadata(
+                task.mapping,
+                task.env_file,
+                task.env_keys_file,
+                task.effective_environment,
+                backend_provider,
+            )
             console.print(f"  [green]+[/green] {env_file} [dim]- encrypted[/dim]")
             encrypted_count += 1
 

--- a/src/envdrift/cli_commands/vault.py
+++ b/src/envdrift/cli_commands/vault.py
@@ -7,7 +7,7 @@ from typing import Annotated
 
 import typer
 
-from envdrift.env_files import detect_env_file
+from envdrift.env_files import resolve_custom_env_file, resolve_mapping_env_file
 from envdrift.output.rich import console, print_error, print_success, print_warning
 
 
@@ -288,22 +288,22 @@ def vault_push(
 
         for mapping in sync_config.mappings:
             try:
-                # Check/Detect .env file (unless --skip-encrypt, where we only need .env.keys)
-                env_file = mapping.folder_path / f".env.{mapping.effective_environment}"
-                effective_environment = mapping.effective_environment
+                detection = resolve_mapping_env_file(mapping)
+                env_file = (
+                    detection.path
+                    if detection.path is not None
+                    else mapping.folder_path / f".env.{mapping.effective_environment}"
+                )
+                effective_environment = detection.environment or mapping.effective_environment
 
                 if not skip_encrypt:
-                    if not env_file.exists():
-                        # Auto-detect logic similar to sync
-                        detected = detect_env_file(mapping.folder_path)
-                        if detected.status == "found" and detected.path:
-                            env_file = detected.path
-                            if detected.environment:
-                                effective_environment = detected.environment
-
-                    if not env_file.exists():
+                    if detection.status != "found" or detection.path is None:
+                        missing_description = (
+                            f"{env_file.name} file" if mapping.env_file is not None else ".env file"
+                        )
                         console.print(
-                            f"[dim]Skipped[/dim] {mapping.folder_path}: No .env file found"
+                            f"[dim]Skipped[/dim] {mapping.folder_path}: "
+                            f"No {missing_description} found"
                         )
                         skipped_count += 1
                         continue
@@ -344,6 +344,22 @@ def vault_push(
                             print_error(f"Failed to encrypt {env_file}: {e}")
                             error_count += 1
                             continue
+
+                    # Normalize dotenvx metadata for custom filenames so the vault
+                    # key name stays canonical (DOTENV_*_<environment>). This runs
+                    # whether we just encrypted the file or it was already encrypted
+                    # by a prior run, so the canonical key always exists below.
+                    if (
+                        backend_provider == EncryptionProvider.DOTENVX
+                        and mapping.env_file is not None
+                    ):
+                        from envdrift.integrations.dotenvx import normalize_dotenvx_metadata
+
+                        normalize_dotenvx_metadata(
+                            env_file,
+                            mapping.folder_path / sync_config.env_keys_filename,
+                            effective_environment,
+                        )
 
                 # Check if secret exists in vault
                 if not force:
@@ -505,6 +521,13 @@ def vault_pull(
             help="Only write the key to .env.keys; do not decrypt the .env.<env> file",
         ),
     ] = False,
+    env_file: Annotated[
+        Path | None,
+        typer.Option(
+            "--env-file",
+            help="Custom env filename to decrypt, relative to FOLDER",
+        ),
+    ] = None,
 ) -> None:
     r"""
     Pull a single encryption key from a cloud vault into a local .env.keys file.
@@ -595,13 +618,25 @@ def vault_pull(
     if no_decrypt:
         return
 
-    env_file = folder / f".env.{env}"
-    if not env_file.exists():
-        console.print(f"[dim]Key written; no {env_file} found to decrypt.[/dim]")
+    try:
+        target_env_file = (
+            resolve_custom_env_file(folder, env_file)
+            if env_file is not None
+            else folder / f".env.{env}"
+        )
+    except ValueError as e:
+        print_error(f"Invalid --env-file: {e}")
+        raise typer.Exit(code=1) from None
+    if not target_env_file.exists():
+        console.print(f"[dim]Key written; no {target_env_file} found to decrypt.[/dim]")
         return
 
     from envdrift.cli_commands.encryption_helpers import resolve_encryption_backend
-    from envdrift.encryption import EncryptionBackendError, EncryptionNotFoundError
+    from envdrift.encryption import (
+        EncryptionBackendError,
+        EncryptionNotFoundError,
+        EncryptionProvider,
+    )
 
     # resolve_encryption_backend only honours `config` when it has a `.toml`
     # suffix; a config path without that suffix is silently ignored here (falls
@@ -614,7 +649,7 @@ def vault_pull(
         )
 
     try:
-        encryption_backend, _, _ = resolve_encryption_backend(config)
+        encryption_backend, backend_provider, _ = resolve_encryption_backend(config)
     except ValueError as e:
         print_error(f"Unsupported encryption backend: {e}")
         raise typer.Exit(code=1) from None
@@ -624,16 +659,24 @@ def vault_pull(
         console.print(encryption_backend.install_instructions())
         raise typer.Exit(code=1)
 
+    if backend_provider == EncryptionProvider.DOTENVX and env_file is not None:
+        from envdrift.integrations.dotenvx import normalize_dotenvx_metadata
+
+        normalize_dotenvx_metadata(target_env_file, env_keys_path, env)
+
     try:
         # Point the backend at the .env.keys we just wrote so decryption works
         # even when FOLDER is not the current working directory (monorepo usage).
-        result = encryption_backend.decrypt(env_file.resolve(), keys_file=env_keys_path.resolve())
+        result = encryption_backend.decrypt(
+            target_env_file.resolve(),
+            keys_file=env_keys_path.resolve(),
+        )
     except (EncryptionNotFoundError, EncryptionBackendError) as e:
-        print_error(f"Failed to decrypt {env_file}: {e}")
+        print_error(f"Failed to decrypt {target_env_file}: {e}")
         raise typer.Exit(code=1) from None
 
     if not result.success:
-        print_error(f"Failed to decrypt {env_file}: {result.message}")
+        print_error(f"Failed to decrypt {target_env_file}: {result.message}")
         raise typer.Exit(code=1)
 
-    print_success(f"Decrypted {env_file}")
+    print_success(f"Decrypted {target_env_file}")

--- a/src/envdrift/cli_commands/vault.py
+++ b/src/envdrift/cli_commands/vault.py
@@ -357,7 +357,7 @@ def vault_push(
 
                         normalize_dotenvx_metadata(
                             env_file,
-                            mapping.folder_path / sync_config.env_keys_filename,
+                            mapping.folder_path / (sync_config.env_keys_filename or ".env.keys"),
                             effective_environment,
                         )
 

--- a/src/envdrift/config.py
+++ b/src/envdrift/config.py
@@ -33,6 +33,7 @@ class SyncMappingConfig:
     folder_path: str
     vault_name: str | None = None
     environment: str | None = None  # None = derive from profile or default to "production"
+    env_file: str | None = None  # Optional custom env filename relative to folder_path
     profile: str | None = None  # Profile name for filtering (e.g., "local", "prod")
     activate_to: str | None = None  # Path to copy decrypted file when profile is activated
     ephemeral_keys: bool | None = None  # None = inherit from central SyncConfig
@@ -251,6 +252,7 @@ class EnvdriftConfig:
                 folder_path=m["folder_path"],
                 vault_name=m.get("vault_name"),
                 environment=m.get("environment"),  # None = derive from profile
+                env_file=m.get("env_file"),
                 profile=m.get("profile"),
                 activate_to=m.get("activate_to"),
                 ephemeral_keys=m.get("ephemeral_keys"),  # None = inherit from central

--- a/src/envdrift/env_files.py
+++ b/src/envdrift/env_files.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal
+from typing import Any, Literal
 
 EnvFileStatus = Literal["found", "folder_not_found", "multiple_found", "not_found"]
 
@@ -58,3 +58,55 @@ def detect_env_file(folder_path: Path, default_environment: str = "production") 
         return EnvFileDetection(None, None, "multiple_found")
 
     return EnvFileDetection(None, None, "not_found")
+
+
+def resolve_custom_env_file(folder_path: Path, env_file: Path | str) -> Path:
+    """Resolve a configured env filename under a service folder.
+
+    The ``env_file`` setting is intentionally scoped to ``folder_path`` so a sync
+    mapping cannot read or mutate an unrelated path via ``..`` or an absolute path.
+    """
+    env_file_path = Path(env_file)
+    if env_file_path.is_absolute():
+        raise ValueError("env_file must be relative to folder_path")
+
+    resolved_folder = folder_path.resolve()
+    resolved_file = (folder_path / env_file_path).resolve()
+    try:
+        resolved_file.relative_to(resolved_folder)
+    except ValueError as e:
+        raise ValueError("env_file must stay inside folder_path") from e
+
+    return folder_path / env_file_path
+
+
+def resolve_mapping_env_file(mapping: Any) -> EnvFileDetection:
+    """Resolve the env file for a sync mapping.
+
+    Resolution order:
+    1. Explicit ``mapping.env_file`` relative to ``mapping.folder_path``.
+    2. Exact ``.env.<effective_environment>``.
+    3. Existing legacy auto-detection for ``.env`` or a single ``.env.*`` file.
+
+    Explicit custom filenames keep ``mapping.effective_environment`` as the
+    environment of record. This preserves canonical vault key names even when
+    the dotenv filename uses a service-specific convention.
+    """
+    folder_path = Path(mapping.folder_path)
+    effective_environment = mapping.effective_environment
+    env_file = getattr(mapping, "env_file", None)
+
+    if env_file is not None:
+        if not folder_path.exists():
+            return EnvFileDetection(None, effective_environment, "folder_not_found")
+
+        resolved = resolve_custom_env_file(folder_path, env_file)
+        if resolved.exists() and resolved.is_file():
+            return EnvFileDetection(resolved, effective_environment, "found")
+        return EnvFileDetection(resolved, effective_environment, "not_found")
+
+    exact_env = folder_path / f".env.{effective_environment}"
+    if exact_env.exists() and exact_env.is_file():
+        return EnvFileDetection(exact_env, effective_environment, "found")
+
+    return detect_env_file(folder_path)

--- a/src/envdrift/env_files.py
+++ b/src/envdrift/env_files.py
@@ -69,6 +69,8 @@ def resolve_custom_env_file(folder_path: Path, env_file: Path | str) -> Path:
     env_file_path = Path(env_file)
     if env_file_path.is_absolute():
         raise ValueError("env_file must be relative to folder_path")
+    if ".." in env_file_path.parts:
+        raise ValueError("env_file must not contain '..'")
 
     resolved_folder = folder_path.resolve()
     resolved_file = (folder_path / env_file_path).resolve()

--- a/src/envdrift/integrations/dotenvx.py
+++ b/src/envdrift/integrations/dotenvx.py
@@ -136,8 +136,17 @@ def normalize_dotenvx_metadata(
 
     if env_file.exists():
         content = env_file.read_text(encoding="utf-8")
-        new_content = _PUBLIC_KEY_NAME_RE.sub(f"{canonical_public_key}=", content)
-        new_content = new_content.replace(custom_comment, canonical_comment)
+        rewritten = []
+        for line in content.splitlines():
+            # Line-anchored: only rewrite the dotenvx filename comment and the
+            # public-key assignment line, never substrings of unrelated prose.
+            if line.strip() == custom_comment:
+                rewritten.append(canonical_comment)
+            else:
+                rewritten.append(_PUBLIC_KEY_NAME_RE.sub(f"{canonical_public_key}=", line))
+        new_content = "\n".join(rewritten)
+        if content.endswith("\n"):
+            new_content += "\n"
         if new_content != content:
             env_file.write_text(new_content, encoding="utf-8")
 
@@ -157,25 +166,22 @@ def normalize_dotenvx_metadata(
     )
 
     generated_idx = None
+    key_value = ""
     if custom_comment_idx is not None:
         for i in range(custom_comment_idx + 1, len(lines)):
-            line = lines[i].strip()
-            if not line:
+            stripped = lines[i].strip()
+            if not stripped:
                 continue
-            if line.startswith("#"):
+            if stripped.startswith("#"):
                 break
-            if _PRIVATE_KEY_LINE_RE.match(line):
+            match = _PRIVATE_KEY_LINE_RE.match(stripped)
+            if match:
                 generated_idx = i
+                key_value = match.group(1)
             break
 
     if generated_idx is None:
         return
-
-    match = _PRIVATE_KEY_LINE_RE.match(lines[generated_idx].strip())
-    if not match:
-        return
-
-    key_value = match.group(1)
     if canonical_idx is not None and canonical_idx != generated_idx:
         lines[canonical_idx] = f"{canonical_private_key}={key_value}"
         indexes_to_delete = [generated_idx]

--- a/src/envdrift/integrations/dotenvx.py
+++ b/src/envdrift/integrations/dotenvx.py
@@ -109,6 +109,91 @@ PROBLEMATIC_FILENAME_PATTERNS = [
     r"^\.env\.local$",
 ]
 
+_PUBLIC_KEY_NAME_RE = re.compile(r"\bDOTENV_PUBLIC_KEY_[A-Za-z0-9_-]+=")
+_PRIVATE_KEY_LINE_RE = re.compile(r"^DOTENV_PRIVATE_KEY_[A-Za-z0-9_-]+=(.*)$")
+
+
+def normalize_dotenvx_metadata(
+    env_file: Path | str,
+    env_keys_file: Path | str,
+    environment: str,
+) -> None:
+    """Normalize dotenvx metadata to envdrift's configured environment name.
+
+    dotenvx can encrypt any dotenv-format filename via ``--env-file``, but it
+    derives ``DOTENV_PUBLIC_KEY_*`` and ``DOTENV_PRIVATE_KEY_*`` names from that
+    filename. Vault sync uses the configured mapping environment as the source of
+    truth, so mapped custom filenames are normalized back to
+    ``DOTENV_*_<environment>`` after dotenvx runs.
+    """
+    env_file = Path(env_file)
+    env_keys_file = Path(env_keys_file)
+    canonical_suffix = environment.upper()
+    canonical_public_key = f"DOTENV_PUBLIC_KEY_{canonical_suffix}"
+    canonical_private_key = f"DOTENV_PRIVATE_KEY_{canonical_suffix}"
+    custom_comment = f"# {env_file.name}"
+    canonical_comment = f"# .env.{environment}"
+
+    if env_file.exists():
+        content = env_file.read_text(encoding="utf-8")
+        new_content = _PUBLIC_KEY_NAME_RE.sub(f"{canonical_public_key}=", content)
+        new_content = new_content.replace(custom_comment, canonical_comment)
+        if new_content != content:
+            env_file.write_text(new_content, encoding="utf-8")
+
+    if not env_keys_file.exists():
+        return
+
+    content = env_keys_file.read_text(encoding="utf-8")
+    lines = content.splitlines()
+
+    canonical_idx = next(
+        (i for i, line in enumerate(lines) if line.startswith(f"{canonical_private_key}=")),
+        None,
+    )
+    custom_comment_idx = next(
+        (i for i, line in enumerate(lines) if line.strip() == custom_comment),
+        None,
+    )
+
+    generated_idx = None
+    if custom_comment_idx is not None:
+        for i in range(custom_comment_idx + 1, len(lines)):
+            line = lines[i].strip()
+            if not line:
+                continue
+            if line.startswith("#"):
+                break
+            if _PRIVATE_KEY_LINE_RE.match(line):
+                generated_idx = i
+            break
+
+    if generated_idx is None:
+        return
+
+    match = _PRIVATE_KEY_LINE_RE.match(lines[generated_idx].strip())
+    if not match:
+        return
+
+    key_value = match.group(1)
+    if canonical_idx is not None and canonical_idx != generated_idx:
+        lines[canonical_idx] = f"{canonical_private_key}={key_value}"
+        indexes_to_delete = [generated_idx]
+        if custom_comment_idx is not None:
+            indexes_to_delete.append(custom_comment_idx)
+        for idx in sorted(indexes_to_delete, reverse=True):
+            del lines[idx]
+    else:
+        if custom_comment_idx is not None:
+            lines[custom_comment_idx] = canonical_comment
+        lines[generated_idx] = f"{canonical_private_key}={key_value}"
+
+    new_content = "\n".join(lines)
+    if content.endswith("\n") or new_content:
+        new_content += "\n"
+    if new_content != content:
+        env_keys_file.write_text(new_content, encoding="utf-8")
+
 
 def get_platform_info() -> tuple[str, str]:
     """

--- a/src/envdrift/integrations/hook_check.py
+++ b/src/envdrift/integrations/hook_check.py
@@ -42,25 +42,15 @@ _PRE_COMMIT_HOOK_LINES = [
     "fi",
     "staged_files=$(git diff --cached --name-only --diff-filter=ACM)",
     'key_files=$(printf "%s\\n" "$staged_files" | grep -E "(^|/)\\.env\\.keys(\\.|$)" || true)',
-    "# Enforce encryption on staged .env* files, but skip .clear files: in a"
-    " partial-encryption setup the .clear half is meant to be committed as"
-    " plaintext, so encrypt --check would wrongly block it. A plaintext .secret"
-    " (or any other .env*) still fails the check and blocks the commit.",
-    'env_files=$(printf "%s\\n" "$staged_files" | grep -E "(^|/)\\.env(\\.|$)" |'
-    ' grep -vE "\\.clear$" || true)',
     'if [ -n "$key_files" ]; then',
     '  echo "envdrift: refusing to commit .env.keys files" >&2',
     "  exit 1",
     "fi",
-    'if [ -n "$env_files" ]; then',
-    "  failed=0",
-    "  for f in $env_files; do",
-    '    envdrift encrypt --check "$f" || failed=1',
-    "  done",
-    "  if [ $failed -ne 0 ]; then",
-    '    echo "envdrift: encryption check failed" >&2',
-    "    exit 1",
-    "  fi",
+    "# Run the config-aware guard over staged files so vault.sync env_file",
+    "# mappings are enforced even when filenames do not match .env*.",
+    "if ! envdrift guard --staged --native-only --ci; then",
+    '  echo "envdrift: guard scan failed" >&2',
+    "  exit 1",
     "fi",
     "# <<< envdrift hook: pre-commit",
 ]
@@ -304,7 +294,7 @@ def check_precommit_hooks(
 ) -> dict[str, bool]:
     """Check for envdrift hooks in a pre-commit config."""
     if required_hooks is None:
-        required_hooks = ("envdrift-encryption",)
+        required_hooks = ("envdrift-encryption", "envdrift-guard")
     required = dict.fromkeys(required_hooks, False)
 
     if not precommit_path:

--- a/src/envdrift/integrations/precommit.py
+++ b/src/envdrift/integrations/precommit.py
@@ -26,6 +26,14 @@ repos:
         files: ^\\.env\\.(production|staging)$
         pass_filenames: true
         description: Ensures sensitive .env files are encrypted
+
+      - id: envdrift-guard
+        name: Guard staged env files
+        entry: envdrift guard --staged --native-only --ci
+        language: system
+        always_run: true
+        pass_filenames: false
+        description: Scans staged files, including vault.sync env_file mappings
 """
 
 # Minimal hook entry for injection
@@ -47,6 +55,15 @@ HOOK_ENTRY = {
             "language": "system",
             "files": r"^\.env\.(production|staging)$",
             "pass_filenames": True,  # nosec B105 - not a password
+        },
+        {
+            "id": "envdrift-guard",
+            "name": "Guard staged env files",
+            "entry": "envdrift guard --staged --native-only --ci",
+            "language": "system",
+            "always_run": True,
+            "pass_filenames": False,  # nosec B105 - not a password
+            "description": "Scans staged files, including vault.sync env_file mappings",
         },
     ],
 }
@@ -242,23 +259,27 @@ def verify_hooks_installed(config_path: Path | None = None) -> dict[str, bool]:
         config_path (Path | None): Path to a .pre-commit-config.yaml file. If None, the file is searched for by walking up from the current working directory.
 
     Returns:
-        dict[str, bool]: Mapping of hook id to installation status: `{"envdrift-validate": bool, "envdrift-encryption": bool}`. Returns both `False` if the config file is missing or unreadable, or if the PyYAML package is not available.
+        dict[str, bool]: Mapping of hook id to installation status. Returns all
+        hooks as `False` if the config file is missing or unreadable, or if the
+        PyYAML package is not available.
     """
+    hook_ids = [str(hook["id"]) for hook in HOOK_ENTRY["hooks"]]
+    empty_result: dict[str, bool] = dict.fromkeys(hook_ids, False)
     try:
         import yaml
     except ImportError:
-        return {"envdrift-validate": False, "envdrift-encryption": False}
+        return empty_result
 
     if config_path is None:
         config_path = find_precommit_config()
 
     if config_path is None or not config_path.exists():
-        return {"envdrift-validate": False, "envdrift-encryption": False}
+        return empty_result
 
     content = config_path.read_text()
     config = yaml.safe_load(content) or {}
 
-    result = {"envdrift-validate": False, "envdrift-encryption": False}
+    result = empty_result.copy()
 
     for repo in config.get("repos", []):
         if repo.get("repo") == "local":

--- a/src/envdrift/integrations/precommit.py
+++ b/src/envdrift/integrations/precommit.py
@@ -276,8 +276,14 @@ def verify_hooks_installed(config_path: Path | None = None) -> dict[str, bool]:
     if config_path is None or not config_path.exists():
         return empty_result
 
-    content = config_path.read_text()
-    config = yaml.safe_load(content) or {}
+    try:
+        content = config_path.read_text()
+        config = yaml.safe_load(content) or {}
+    except (OSError, yaml.YAMLError):
+        return empty_result
+
+    if not isinstance(config, dict):
+        return empty_result
 
     result = empty_result.copy()
 

--- a/src/envdrift/scanner/engine.py
+++ b/src/envdrift/scanner/engine.py
@@ -66,6 +66,7 @@ class GuardConfig:
         fail_on_severity: Minimum severity to cause non-zero exit.
         allowed_clear_files: Files that are intentionally unencrypted (from partial_encryption config).
         combined_files: Combined files from partial_encryption config (secret + clear merged).
+        mapped_env_files: Custom env files from vault.sync mappings.
     """
 
     use_native: bool = True
@@ -92,6 +93,7 @@ class GuardConfig:
     combined_files: list[str] = field(
         default_factory=list
     )  # Combined files from partial_encryption
+    mapped_env_files: list[str] = field(default_factory=list)
 
     @classmethod
     def from_dict(cls, config: dict) -> GuardConfig:
@@ -226,6 +228,7 @@ class ScanEngine:
                     additional_ignore_patterns=self.config.ignore_paths,
                     allowed_clear_files=self.config.allowed_clear_files,
                     skip_clear_files=self.config.skip_clear_files,
+                    mapped_env_files=self.config.mapped_env_files,
                 )
             )
 

--- a/src/envdrift/scanner/native.py
+++ b/src/envdrift/scanner/native.py
@@ -287,7 +287,14 @@ class NativeScanner(ScannerBackend):
         self._entropy_threshold = entropy_threshold
         self._allowed_clear_files = set(allowed_clear_files or [])
         self._skip_clear_files = skip_clear_files
-        self._mapped_env_files = {Path(p) for p in mapped_env_files or []}
+        # Canonicalize mapped env files to absolute paths so they match regardless
+        # of which directory is being scanned (relative paths would otherwise be
+        # re-rooted per scan dir, letting a mapped file slip past the guard).
+        cwd = Path.cwd()
+        self._mapped_env_files = {
+            (Path(p) if Path(p).is_absolute() else cwd / Path(p)).resolve()
+            for p in mapped_env_files or []
+        }
 
         if ignore_patterns is not None:
             self._ignore_patterns = tuple(ignore_patterns)
@@ -447,8 +454,13 @@ class NativeScanner(ScannerBackend):
 
         # Method 4: Add explicitly configured custom env files from vault.sync.
         # These may not match ".env*" and can otherwise be missed when untracked.
-        for configured in self._mapped_env_files:
-            candidate = configured if configured.is_absolute() else directory / configured
+        # Paths are already absolute; only include those under the scan directory.
+        directory_resolved = directory.resolve()
+        for candidate in self._mapped_env_files:
+            try:
+                candidate.relative_to(directory_resolved)
+            except ValueError:
+                continue
             if candidate.exists() and candidate.is_file():
                 files.add(candidate)
 
@@ -678,20 +690,13 @@ class NativeScanner(ScannerBackend):
         if not self._mapped_env_files:
             return False
 
-        path_str = path.as_posix()
-        with_cwd = (Path.cwd() / path).resolve() if not path.is_absolute() else path.resolve()
-        for configured in self._mapped_env_files:
-            configured_str = configured.as_posix()
-            configured_abs = (
-                configured.resolve()
-                if configured.is_absolute()
-                else (Path.cwd() / configured).resolve()
-            )
-            if with_cwd == configured_abs:
-                return True
-            if path_str == configured_str or path_str.endswith(f"/{configured_str}"):
-                return True
-        return False
+        # _mapped_env_files are canonical absolute paths; compare on the same form.
+        candidate = path if path.is_absolute() else Path.cwd() / path
+        try:
+            resolved = candidate.resolve()
+        except OSError:
+            return False
+        return resolved in self._mapped_env_files
 
     def _is_private_key_file(self, path: Path) -> bool:
         """Check if a file is dotenvx's private-key file (``.env.keys``).

--- a/src/envdrift/scanner/native.py
+++ b/src/envdrift/scanner/native.py
@@ -270,6 +270,7 @@ class NativeScanner(ScannerBackend):
         additional_ignore_patterns: list[str] | None = None,
         allowed_clear_files: list[str] | None = None,
         skip_clear_files: bool = False,
+        mapped_env_files: list[str] | None = None,
     ) -> None:
         """Initialize the native scanner.
 
@@ -280,11 +281,13 @@ class NativeScanner(ScannerBackend):
             additional_ignore_patterns: Additional patterns to ignore (added to defaults).
             allowed_clear_files: Files that are intentionally unencrypted (from partial_encryption config).
             skip_clear_files: Skip .clear files from scanning entirely.
+            mapped_env_files: Custom env files from vault.sync mappings that must be treated as env files.
         """
         self._check_entropy = check_entropy
         self._entropy_threshold = entropy_threshold
         self._allowed_clear_files = set(allowed_clear_files or [])
         self._skip_clear_files = skip_clear_files
+        self._mapped_env_files = {Path(p) for p in mapped_env_files or []}
 
         if ignore_patterns is not None:
             self._ignore_patterns = tuple(ignore_patterns)
@@ -441,6 +444,13 @@ class NativeScanner(ScannerBackend):
                         files.add(directory / rel_path)
         except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
             pass
+
+        # Method 4: Add explicitly configured custom env files from vault.sync.
+        # These may not match ".env*" and can otherwise be missed when untracked.
+        for configured in self._mapped_env_files:
+            candidate = configured if configured.is_absolute() else directory / configured
+            if candidate.exists() and candidate.is_file():
+                files.add(candidate)
 
         # Return deterministically ordered list for stable scan results
         return sorted(files, key=lambda p: str(p))
@@ -662,7 +672,26 @@ class NativeScanner(ScannerBackend):
             True if this is a .env file.
         """
         name = path.name
-        return name == ".env" or name.startswith(".env.")
+        return name == ".env" or name.startswith(".env.") or self._is_mapped_env_file(path)
+
+    def _is_mapped_env_file(self, path: Path) -> bool:
+        if not self._mapped_env_files:
+            return False
+
+        path_str = path.as_posix()
+        with_cwd = (Path.cwd() / path).resolve() if not path.is_absolute() else path.resolve()
+        for configured in self._mapped_env_files:
+            configured_str = configured.as_posix()
+            configured_abs = (
+                configured.resolve()
+                if configured.is_absolute()
+                else (Path.cwd() / configured).resolve()
+            )
+            if with_cwd == configured_abs:
+                return True
+            if path_str == configured_str or path_str.endswith(f"/{configured_str}"):
+                return True
+        return False
 
     def _is_private_key_file(self, path: Path) -> bool:
         """Check if a file is dotenvx's private-key file (``.env.keys``).

--- a/src/envdrift/sync/config.py
+++ b/src/envdrift/sync/config.py
@@ -24,6 +24,7 @@ class ServiceMapping:
     folder_path: Path
     vault_name: str | None = None
     environment: str | None = None  # Defaults to profile if set, else "production"
+    env_file: Path | None = None  # Optional custom env filename relative to folder_path
     profile: str | None = None  # Profile name for filtering (e.g., "local", "prod")
     activate_to: Path | None = None  # Path to copy decrypted file when profile is activated
     ephemeral_keys: bool | None = None  # None = inherit from central SyncConfig
@@ -146,6 +147,9 @@ class SyncConfig:
                     folder_path=Path(mapping_data["folder_path"]),
                     vault_name=mapping_data.get("vault_name"),
                     environment=mapping_data.get("environment"),  # None = use effective_environment
+                    env_file=Path(mapping_data["env_file"])
+                    if mapping_data.get("env_file")
+                    else None,
                     profile=mapping_data.get("profile"),
                     activate_to=Path(activate_to) if activate_to else None,
                     ephemeral_keys=mapping_data.get("ephemeral_keys"),  # None = inherit

--- a/src/envdrift/sync/engine.py
+++ b/src/envdrift/sync/engine.py
@@ -90,11 +90,12 @@ class SyncEngine:
                 or detection.path is None
                 or detection.environment is None
             ):
-                expected = (
-                    detection.path
-                    if detection.path is not None
-                    else mapping.folder_path / f".env.{mapping.effective_environment}"
-                )
+                if detection.path is not None:
+                    expected = detection.path
+                elif mapping.env_file is not None:
+                    expected = mapping.folder_path / mapping.env_file
+                else:
+                    expected = mapping.folder_path / f".env.{mapping.effective_environment}"
                 return ServiceSyncResult(
                     secret_name=mapping.secret_name,
                     folder_path=mapping.folder_path,

--- a/src/envdrift/sync/engine.py
+++ b/src/envdrift/sync/engine.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from envdrift.env_files import detect_env_file
+from envdrift.env_files import detect_env_file, resolve_mapping_env_file
 from envdrift.sync.config import ServiceMapping, SyncConfig
 from envdrift.sync.operations import EnvKeysFile, ensure_directory, preview_value
 from envdrift.sync.result import (
@@ -84,22 +84,25 @@ class SyncEngine:
     def _sync_service(self, mapping: ServiceMapping) -> ServiceSyncResult:
         """Sync a single service."""
         try:
-            # Check if corresponding .env.<environment> file exists
-            env_file = mapping.folder_path / f".env.{mapping.effective_environment}"
-            effective_environment = mapping.effective_environment
+            detection = resolve_mapping_env_file(mapping)
+            if (
+                detection.status != "found"
+                or detection.path is None
+                or detection.environment is None
+            ):
+                expected = (
+                    detection.path
+                    if detection.path is not None
+                    else mapping.folder_path / f".env.{mapping.effective_environment}"
+                )
+                return ServiceSyncResult(
+                    secret_name=mapping.secret_name,
+                    folder_path=mapping.folder_path,
+                    action=SyncAction.SKIPPED,
+                    message=f"No {expected.name} file found - skipping",
+                )
 
-            if not env_file.exists():
-                # Try to auto-detect: find any .env.* file or plain .env in the folder
-                detected = self._detect_env_file(mapping.folder_path)
-                if detected:
-                    env_file, effective_environment = detected
-                else:
-                    return ServiceSyncResult(
-                        secret_name=mapping.secret_name,
-                        folder_path=mapping.folder_path,
-                        action=SyncAction.SKIPPED,
-                        message=f"No .env.{mapping.effective_environment} file found - skipping",
-                    )
+            effective_environment = detection.environment
 
             # Use effective environment for key name
             effective_key_name = f"DOTENV_PRIVATE_KEY_{effective_environment.upper()}"
@@ -290,17 +293,10 @@ class SyncEngine:
             DecryptionTestResult.FAILED if decryption or re-encryption fails (the original file is restored).
             DecryptionTestResult.SKIPPED if no suitable env file exists, the file does not appear encrypted, or the `dotenvx` utility is not available.
         """
-        # Find .env file to test (prefer .env.<effective_environment>)
-        env_files = [
-            mapping.folder_path / f".env.{mapping.effective_environment}",
-            mapping.folder_path / ".env.production",
-            mapping.folder_path / ".env.staging",
-            mapping.folder_path / ".env.development",
-        ]
-
-        target_file = next((f for f in env_files if f.exists()), None)
-        if not target_file:
+        detection = resolve_mapping_env_file(mapping)
+        if detection.status != "found" or detection.path is None:
             return DecryptionTestResult.SKIPPED
+        target_file = detection.path
 
         # Check if file is encrypted (contains dotenvx markers)
         content = target_file.read_text()
@@ -368,14 +364,10 @@ class SyncEngine:
             from envdrift.core.schema import SchemaLoader
             from envdrift.core.validator import Validator
 
-            # Find env file (mirror _sync_service's detection behavior)
-            env_file_path = mapping.folder_path / f".env.{mapping.effective_environment}"
-            if not env_file_path.exists():
-                detected = self._detect_env_file(mapping.folder_path)
-                if detected:
-                    env_file_path, _effective_environment = detected
-                else:
-                    return True  # No file to validate
+            detection = resolve_mapping_env_file(mapping)
+            if detection.status != "found" or detection.path is None:
+                return True  # No file to validate
+            env_file_path = detection.path
 
             # Load schema
             service_dir = self.mode.service_dir or mapping.folder_path

--- a/tests/integration/test_encryption_tools.py
+++ b/tests/integration/test_encryption_tools.py
@@ -285,6 +285,92 @@ def test_sops_lock_and_pull_roundtrip(integration_env):
 
 
 @pytest.mark.integration
+def test_dotenvx_lock_pull_custom_env_files_use_canonical_keys(integration_env):
+    """Custom vault.sync env_file names keep key names based on environment."""
+    work_dir = integration_env["base_dir"] / "dotenvx-custom-lock-pull"
+    work_dir.mkdir()
+    env = integration_env["env"].copy()
+    _scrub_cloud_credentials(env)
+
+    postgres_dir = work_dir / "postgresql"
+    postgres_dir.mkdir()
+    postgres_env = postgres_dir / "postgresql.env"
+    postgres_env.write_text("POSTGRES_PASSWORD=topsecret\n")
+
+    dotnet_dir = work_dir / "dotnet-service-template"
+    dotnet_dir.mkdir()
+    dotnet_env = dotnet_dir / "dotnet-service-template.env.sqa"
+    dotnet_env.write_text("API_KEY=service-secret\n")
+
+    config = textwrap.dedent(
+        """\
+        [encryption]
+        backend = "dotenvx"
+
+        [encryption.dotenvx]
+        auto_install = true
+
+        [vault]
+        provider = "azure"
+
+        [vault.azure]
+        vault_url = "https://dummy.vault.azure.net/"
+
+        [vault.sync]
+        default_vault_name = "dummy"
+
+        [[vault.sync.mappings]]
+        secret_name = "postgres-key"
+        folder_path = "postgresql"
+        environment = "production"
+        env_file = "postgresql.env"
+
+        [[vault.sync.mappings]]
+        secret_name = "dotnet-key"
+        folder_path = "dotnet-service-template"
+        environment = "sqa"
+        env_file = "dotnet-service-template.env.sqa"
+        """
+    )
+    (work_dir / "envdrift.toml").write_text(config)
+
+    _run_envdrift(["lock", "--force"], cwd=work_dir, env=env)
+
+    postgres_locked = postgres_env.read_text()
+    assert "encrypted:" in postgres_locked
+    assert "POSTGRES_PASSWORD=topsecret" not in postgres_locked
+    assert "DOTENV_PUBLIC_KEY_PRODUCTION" in postgres_locked
+    assert "postgresql.env" not in postgres_locked
+
+    postgres_keys = (postgres_dir / ".env.keys").read_text()
+    postgres_private_keys = [
+        line for line in postgres_keys.splitlines() if line.startswith("DOTENV_PRIVATE_KEY_")
+    ]
+    assert len(postgres_private_keys) == 1
+    assert postgres_private_keys[0].startswith("DOTENV_PRIVATE_KEY_PRODUCTION=")
+
+    dotnet_locked = dotnet_env.read_text()
+    assert "encrypted:" in dotnet_locked
+    assert "API_KEY=service-secret" not in dotnet_locked
+    assert "DOTENV_PUBLIC_KEY_SQA" in dotnet_locked
+    assert "dotnet-service-template.env.sqa" not in dotnet_locked
+
+    dotnet_keys = (dotnet_dir / ".env.keys").read_text()
+    dotnet_private_keys = [
+        line for line in dotnet_keys.splitlines() if line.startswith("DOTENV_PRIVATE_KEY_")
+    ]
+    assert len(dotnet_private_keys) == 1
+    assert dotnet_private_keys[0].startswith("DOTENV_PRIVATE_KEY_SQA=")
+
+    _run_envdrift(["pull", "--skip-sync"], cwd=work_dir, env=env)
+
+    assert "POSTGRES_PASSWORD=topsecret" in postgres_env.read_text()
+    assert "encrypted:" not in postgres_env.read_text()
+    assert "API_KEY=service-secret" in dotnet_env.read_text()
+    assert "encrypted:" not in dotnet_env.read_text()
+
+
+@pytest.mark.integration
 def test_sops_lock_pull_require_vault_sync_config(integration_env):
     """`lock`/`pull` are the Vault Sync family and fail fast without `[vault.sync]`.
 

--- a/tests/integration/test_git_hooks_advanced.py
+++ b/tests/integration/test_git_hooks_advanced.py
@@ -158,7 +158,7 @@ def test_hook_blocks_unencrypted_commit(git_hook_env):
     # Verify hooks were installed
     pre_commit = work_dir / ".git" / "hooks" / "pre-commit"
     assert pre_commit.exists(), "pre-commit hook should be installed"
-    assert "envdrift encrypt --check" in pre_commit.read_text()
+    assert "envdrift guard --staged --native-only --ci" in pre_commit.read_text()
 
     # Stage the plaintext file
     _run_git(["add", env_file.name], cwd=work_dir)
@@ -171,9 +171,69 @@ def test_hook_blocks_unencrypted_commit(git_hook_env):
     )
 
     assert result.returncode != 0, "Commit should be blocked by pre-commit hook"
-    assert (
-        "encryption check failed" in result.stderr or "encryption check failed" in result.stdout
-    ), "Error message should mention encryption check failure"
+    assert "guard scan failed" in result.stderr or "guard scan failed" in result.stdout, (
+        "Error message should mention guard failure"
+    )
+
+
+@pytest.mark.integration
+def test_hook_blocks_custom_mapped_env_file(git_hook_env):
+    """Direct pre-commit hook must enforce custom vault.sync env_file names."""
+    work_dir = git_hook_env["work_dir"]
+    env = git_hook_env["env"]
+
+    config = textwrap.dedent(
+        """\
+        [git_hook_check]
+        method = "direct git hook"
+
+        [encryption]
+        backend = "dotenvx"
+
+        [encryption.dotenvx]
+        auto_install = true
+
+        [vault]
+        provider = "azure"
+
+        [vault.sync]
+        [[vault.sync.mappings]]
+        secret_name = "test-postgresql-key"
+        folder_path = "secrets/postgresql"
+        environment = "production"
+        env_file = "postgresql.env"
+        """
+    )
+    (work_dir / "envdrift.toml").write_text(config)
+
+    service_dir = work_dir / "secrets" / "postgresql"
+    service_dir.mkdir(parents=True)
+    env_file = service_dir / "postgresql.env"
+    env_file.write_text("POSTGRES_PASSWORD=plaintext-leak\n")
+
+    _run_envdrift(
+        ["encrypt", "--check", str(env_file.relative_to(work_dir))],
+        cwd=work_dir,
+        env=env,
+        check=False,
+    )
+
+    pre_commit = work_dir / ".git" / "hooks" / "pre-commit"
+    assert pre_commit.exists(), "pre-commit hook should be installed"
+    assert "envdrift guard --staged --native-only --ci" in pre_commit.read_text()
+
+    _run_git(["add", "envdrift.toml", str(env_file.relative_to(work_dir))], cwd=work_dir)
+
+    result = _run_git(
+        ["commit", "-m", "Add plaintext custom env file"],
+        cwd=work_dir,
+        check=False,
+    )
+
+    assert result.returncode != 0, "Commit should be blocked by pre-commit hook"
+    combined_output = result.stderr + result.stdout
+    assert "guard scan failed" in combined_output
+    assert "postgresql.env" in combined_output
 
 
 @pytest.mark.integration
@@ -286,8 +346,8 @@ def _install_partial_hooks(work_dir: Path, env: dict[str, str]) -> Path:
 def test_hook_allows_plaintext_clear_file(git_hook_env):
     """A plaintext .clear file must commit fine — it is plaintext by design.
 
-    Regression test for the bug where the hook ran ``encrypt --check`` on every
-    staged ``.env*`` file, including ``.clear`` files, and wrongly blocked them.
+    Regression test for hook enforcement on staged env files. The guard scans
+    ``.clear`` content for secrets but does not require encryption for it.
     """
     work_dir = git_hook_env["work_dir"]
     env = git_hook_env["env"]
@@ -320,9 +380,9 @@ def test_hook_blocks_plaintext_secret_file(git_hook_env):
     result = _run_git(["commit", "-m", "Oops plaintext secret"], cwd=work_dir, check=False)
 
     assert result.returncode != 0, "Committing a plaintext .secret file must be blocked"
-    assert (
-        "encryption check failed" in result.stderr or "encryption check failed" in result.stdout
-    ), f"Expected an encryption-check failure message. stderr:\n{result.stderr}"
+    assert "guard scan failed" in result.stderr or "guard scan failed" in result.stdout, (
+        f"Expected a guard failure message. stderr:\n{result.stderr}"
+    )
 
 
 @pytest.mark.integration

--- a/tests/integration/test_guard_setup.py
+++ b/tests/integration/test_guard_setup.py
@@ -570,7 +570,7 @@ class TestHookScriptContent:
         content = pre_commit.read_text()
 
         # Should contain encryption check
-        assert "envdrift encrypt --check" in content or "envdrift" in content
+        assert "envdrift guard --staged --native-only --ci" in content
 
     def test_pre_push_script_checks_lock(self, guard_test_env):
         """Test that pre-push hook checks lock status."""

--- a/tests/integration/test_hook_setup.py
+++ b/tests/integration/test_hook_setup.py
@@ -100,7 +100,9 @@ def test_hook_setup_precommit_auto_installs(hook_integration_env):
 
     _run_envdrift(["decrypt", env_file.name], cwd=work_dir, env=env)
     assert precommit_path.exists()
-    assert "envdrift-encryption" in precommit_path.read_text()
+    precommit_content = precommit_path.read_text()
+    assert "envdrift-encryption" in precommit_content
+    assert "envdrift-guard" in precommit_content
 
 
 @pytest.mark.integration
@@ -141,5 +143,5 @@ def test_hook_setup_direct_auto_installs(hook_integration_env):
 
     assert pre_commit.exists()
     assert pre_push.exists()
-    assert "envdrift encrypt --check" in pre_commit.read_text()
+    assert "envdrift guard --staged --native-only --ci" in pre_commit.read_text()
     assert "envdrift lock --check" in pre_push.read_text()

--- a/tests/scanner/test_native.py
+++ b/tests/scanner/test_native.py
@@ -147,6 +147,29 @@ class TestNativeScannerInternals:
 
         assert mapped_env.resolve() in collected
 
+    def test_collect_files_finds_relative_mapped_file_in_subdir_scan(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """A relative mapped path is found when scanning its subdirectory.
+
+        Regression: relative mapped paths used to be re-rooted under each scan
+        directory, so ``guard secrets/postgresql`` looked for
+        ``secrets/postgresql/secrets/postgresql/postgresql.env`` and missed it.
+        """
+        service_dir = tmp_path / "secrets" / "postgresql"
+        service_dir.mkdir(parents=True)
+        mapped_env = service_dir / "postgresql.env"
+        mapped_env.write_text("POSTGRES_PASSWORD=plaintext-leak\n")
+
+        monkeypatch.chdir(tmp_path)
+        # Path is relative to cwd, as guard would pass it.
+        scanner = NativeScanner(mapped_env_files=["secrets/postgresql/postgresql.env"])
+
+        # Scanning the service subdirectory still collects the mapped file.
+        collected = {p.resolve() for p in scanner._collect_files(service_dir)}
+        assert mapped_env.resolve() in collected
+        assert scanner._is_env_file(mapped_env)
+
     def test_collect_files_excludes_gitignored_env_keys(self, tmp_path: Path):
         """A gitignored .env.keys must NOT be collected — that is its correct state.
 

--- a/tests/scanner/test_native.py
+++ b/tests/scanner/test_native.py
@@ -120,6 +120,33 @@ class TestNativeScannerInternals:
 
         assert (tmp_path / ".env.production.secret").resolve() in {p.resolve() for p in collected}
 
+    def test_collect_files_includes_gitignored_mapped_env_file(self, tmp_path: Path):
+        """A gitignored custom env filename from vault.sync must still be collected."""
+        import shutil
+        import subprocess
+
+        if shutil.which("git") is None:
+            pytest.skip("git not available")
+
+        def git(*args: str) -> None:
+            subprocess.run(["git", *args], cwd=tmp_path, check=True, capture_output=True)
+
+        git("init")
+        git("config", "user.email", "test@example.com")
+        git("config", "user.name", "Test")
+
+        mapped_env = tmp_path / "postgresql.env"
+        (tmp_path / ".gitignore").write_text("postgresql.env\n")
+        mapped_env.write_text("POSTGRES_PASSWORD=plaintext-leak\n")
+        (tmp_path / "tracked.txt").write_text("hello\n")
+        git("add", ".gitignore", "tracked.txt")
+        git("commit", "-m", "init")
+
+        scanner = NativeScanner(mapped_env_files=[str(mapped_env)])
+        collected = {p.resolve() for p in scanner._collect_files(tmp_path)}
+
+        assert mapped_env.resolve() in collected
+
     def test_collect_files_excludes_gitignored_env_keys(self, tmp_path: Path):
         """A gitignored .env.keys must NOT be collected — that is its correct state.
 
@@ -326,6 +353,28 @@ sops:
         result = scanner.scan([tmp_path])
 
         assert len(result.findings) == 0
+
+    def test_detects_unencrypted_mapped_env_file(self, tmp_path: Path):
+        """Custom mapped dotenv files are subject to the unencrypted env rule."""
+        env_file = tmp_path / "postgresql.env"
+        env_file.write_text("POSTGRES_PASSWORD=plaintext-leak\n")
+
+        scanner = NativeScanner(mapped_env_files=[str(env_file)])
+        result = scanner.scan([tmp_path])
+
+        unencrypted_findings = [f for f in result.findings if f.rule_id == "unencrypted-env-file"]
+        assert len(unencrypted_findings) == 1
+        assert unencrypted_findings[0].file_path == env_file
+
+    def test_ignores_encrypted_mapped_env_file(self, tmp_path: Path):
+        """Encrypted custom mapped dotenv files are not flagged as plaintext."""
+        env_file = tmp_path / "postgresql.env"
+        env_file.write_text('POSTGRES_PASSWORD="encrypted:xyz789"\n')
+
+        scanner = NativeScanner(mapped_env_files=[str(env_file)])
+        result = scanner.scan([tmp_path])
+
+        assert not [f for f in result.findings if f.rule_id == "unencrypted-env-file"]
 
 
 class TestUnencryptedSecretFile:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1933,6 +1933,47 @@ class TestPullCommand:
         assert env_file in decrypted
         assert "setup complete" in result.output.lower()
 
+    def test_pull_skip_sync_decrypts_custom_env_file(self, monkeypatch, tmp_path: Path):
+        """Pull should decrypt custom env_file mappings."""
+        service_dir = tmp_path / "service"
+        service_dir.mkdir()
+        env_file = service_dir / "dotnet-service-template-local.env"
+        env_file.write_text("SECRET=encrypted:abc123")
+
+        config_file = tmp_path / "envdrift.toml"
+        config_file.write_text(
+            dedent(
+                f"""
+                [vault]
+                provider = "aws"
+
+                [vault.aws]
+                region = "us-east-1"
+
+                [vault.sync]
+                env_keys_filename = ".env.keys"
+
+                [[vault.sync.mappings]]
+                secret_name = "dotenv-key"
+                folder_path = "{service_dir.as_posix()}"
+                environment = "local"
+                env_file = "{env_file.name}"
+                """
+            ).lstrip()
+        )
+
+        monkeypatch.setattr("envdrift.vault.get_vault_client", lambda *_, **__: SimpleNamespace())
+        _mock_sync_engine_success(monkeypatch)
+
+        decrypted: list[Path] = []
+        _mock_encryption_backend(monkeypatch, decrypted_paths=decrypted)
+
+        result = runner.invoke(app, ["pull", "-c", str(config_file), "--skip-sync"])
+
+        assert result.exit_code == 0, result.output
+        assert env_file in decrypted
+        assert "setup complete" in result.output.lower()
+
     def test_pull_skips_partial_combined_file(self, monkeypatch, tmp_path: Path):
         """Pull should skip combined partial-encryption files."""
         service_dir = tmp_path / "service"
@@ -2859,6 +2900,49 @@ class TestLockCommand:
 
         assert result.exit_code == 1
         assert "need encryption" in result.output.lower()
+
+    def test_lock_force_encrypts_custom_env_file(self, monkeypatch, tmp_path: Path):
+        """Lock should encrypt custom env_file mappings."""
+        service_dir = tmp_path / "service"
+        service_dir.mkdir()
+        env_file = service_dir / "dotnet-service-template.env.sqa"
+        env_file.write_text("SECRET=value")
+
+        config_file = tmp_path / "envdrift.toml"
+        config_file.write_text(
+            dedent(
+                f"""
+                [vault]
+                provider = "aws"
+
+                [vault.aws]
+                region = "us-east-1"
+
+                [vault.sync]
+                env_keys_filename = ".env.keys"
+
+                [[vault.sync.mappings]]
+                secret_name = "dotenv-key"
+                folder_path = "{service_dir.as_posix()}"
+                environment = "sqa"
+                env_file = "{env_file.name}"
+                """
+            ).lstrip()
+        )
+
+        monkeypatch.setattr("envdrift.vault.get_vault_client", lambda *_, **__: SimpleNamespace())
+        monkeypatch.setattr(
+            "envdrift.integrations.hook_check.ensure_git_hook_setup",
+            lambda **_kwargs: [],
+        )
+
+        encrypted: list[Path] = []
+        _mock_encryption_backend(monkeypatch, encrypted_paths=encrypted)
+
+        result = runner.invoke(app, ["lock", "-c", str(config_file), "--force"])
+
+        assert result.exit_code == 0, result.output
+        assert env_file.resolve() in [path.resolve() for path in encrypted]
 
     def test_lock_skips_partial_combined_file(self, monkeypatch, tmp_path: Path):
         """Lock should skip combined partial-encryption files."""

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1974,6 +1974,41 @@ class TestPullCommand:
         assert env_file in decrypted
         assert "setup complete" in result.output.lower()
 
+    def test_pull_reports_invalid_env_file(self, monkeypatch, tmp_path: Path):
+        """An env_file that escapes folder_path is reported, not silently used."""
+        service_dir = tmp_path / "service"
+        service_dir.mkdir()
+
+        config_file = tmp_path / "envdrift.toml"
+        config_file.write_text(
+            dedent(
+                f"""
+                [vault]
+                provider = "aws"
+
+                [vault.aws]
+                region = "us-east-1"
+
+                [vault.sync]
+                env_keys_filename = ".env.keys"
+
+                [[vault.sync.mappings]]
+                secret_name = "dotenv-key"
+                folder_path = "{service_dir.as_posix()}"
+                environment = "local"
+                env_file = "../escape.env"
+                """
+            ).lstrip()
+        )
+
+        monkeypatch.setattr("envdrift.vault.get_vault_client", lambda *_, **__: SimpleNamespace())
+        _mock_sync_engine_success(monkeypatch)
+        _mock_encryption_backend(monkeypatch, decrypted_paths=[])
+
+        result = runner.invoke(app, ["pull", "-c", str(config_file), "--skip-sync"])
+
+        assert "invalid env_file" in result.output.lower()
+
     def test_pull_skips_partial_combined_file(self, monkeypatch, tmp_path: Path):
         """Pull should skip combined partial-encryption files."""
         service_dir = tmp_path / "service"
@@ -2943,6 +2978,44 @@ class TestLockCommand:
 
         assert result.exit_code == 0, result.output
         assert env_file.resolve() in [path.resolve() for path in encrypted]
+
+    def test_lock_reports_invalid_env_file(self, monkeypatch, tmp_path: Path):
+        """An env_file that escapes folder_path is reported during lock."""
+        service_dir = tmp_path / "service"
+        service_dir.mkdir()
+
+        config_file = tmp_path / "envdrift.toml"
+        config_file.write_text(
+            dedent(
+                f"""
+                [vault]
+                provider = "aws"
+
+                [vault.aws]
+                region = "us-east-1"
+
+                [vault.sync]
+                env_keys_filename = ".env.keys"
+
+                [[vault.sync.mappings]]
+                secret_name = "dotenv-key"
+                folder_path = "{service_dir.as_posix()}"
+                environment = "sqa"
+                env_file = "../escape.env"
+                """
+            ).lstrip()
+        )
+
+        monkeypatch.setattr("envdrift.vault.get_vault_client", lambda *_, **__: SimpleNamespace())
+        monkeypatch.setattr(
+            "envdrift.integrations.hook_check.ensure_git_hook_setup",
+            lambda **_kwargs: [],
+        )
+        _mock_encryption_backend(monkeypatch, encrypted_paths=[])
+
+        result = runner.invoke(app, ["lock", "-c", str(config_file), "--force"])
+
+        assert "invalid env_file" in result.output.lower()
 
     def test_lock_skips_partial_combined_file(self, monkeypatch, tmp_path: Path):
         """Lock should skip combined partial-encryption files."""

--- a/tests/unit/test_cli_vault_pull.py
+++ b/tests/unit/test_cli_vault_pull.py
@@ -65,6 +65,51 @@ class TestVaultPullSingleSecret:
 
     @patch("envdrift.cli_commands.encryption_helpers.resolve_encryption_backend")
     @patch("envdrift.vault.get_vault_client")
+    def test_pull_decrypts_custom_env_file(
+        self,
+        mock_get_client,
+        mock_resolve_backend,
+        tmp_path,
+    ):
+        """--env-file decrypts the specified dotenv file with canonical key names."""
+        mock_get_client.return_value = _make_client("DOTENV_PRIVATE_KEY_PRODUCTION=abc123secret")
+        backend = DummyEncryptionBackend()
+        mock_resolve_backend.return_value = (backend, EncryptionProvider.DOTENVX, None)
+
+        env_file = tmp_path / "postgresql.env"
+        env_file.write_text(
+            "# postgresql.env\n"
+            'DOTENV_PUBLIC_KEY_POSTGRESQLDEVELOPMENT="public"\n'
+            "SECRET=encrypted:xyz\n"
+        )
+
+        result = runner.invoke(
+            app,
+            [
+                "vault-pull",
+                str(tmp_path),
+                "my-secret",
+                "--env",
+                "production",
+                "--env-file",
+                env_file.name,
+                "-p",
+                "azure",
+                "--vault-url",
+                "https://myvault.vault.azure.net/",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert backend.decrypt_calls == [env_file.resolve()]
+        assert "DOTENV_PRIVATE_KEY_PRODUCTION=abc123secret" in (tmp_path / ".env.keys").read_text()
+        custom_content = env_file.read_text()
+        assert "# .env.production" in custom_content
+        assert "DOTENV_PUBLIC_KEY_PRODUCTION" in custom_content
+        assert "POSTGRESQLDEVELOPMENT" not in custom_content
+
+    @patch("envdrift.cli_commands.encryption_helpers.resolve_encryption_backend")
+    @patch("envdrift.vault.get_vault_client")
     def test_pull_value_without_prefix(
         self,
         mock_get_client,
@@ -154,6 +199,35 @@ class TestVaultPullSingleSecret:
         assert result.exit_code == 0, result.output
         assert "found to decrypt" in result.output
         assert "DOTENV_PRIVATE_KEY_PRODUCTION=abc123" in (tmp_path / ".env.keys").read_text()
+
+    @patch("envdrift.vault.get_vault_client")
+    def test_pull_rejects_custom_env_file_outside_folder(
+        self,
+        mock_get_client,
+        tmp_path,
+    ):
+        """--env-file must stay inside FOLDER."""
+        mock_get_client.return_value = _make_client("DOTENV_PRIVATE_KEY_PRODUCTION=abc123")
+
+        result = runner.invoke(
+            app,
+            [
+                "vault-pull",
+                str(tmp_path),
+                "my-secret",
+                "--env",
+                "production",
+                "--env-file",
+                "../outside.env",
+                "-p",
+                "azure",
+                "--vault-url",
+                "https://myvault.vault.azure.net/",
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert "invalid --env-file" in result.output.lower()
 
     def test_pull_missing_env_flag(self, tmp_path):
         """--env is required; omitting it fails."""

--- a/tests/unit/test_cli_vault_push.py
+++ b/tests/unit/test_cli_vault_push.py
@@ -83,6 +83,51 @@ class TestVaultPushAll:
 
     @patch("envdrift.cli_commands.encryption_helpers.resolve_encryption_backend")
     @patch("envdrift.cli_commands.sync.load_sync_config_and_client")
+    def test_push_all_uses_custom_env_file(
+        self,
+        mock_loader,
+        mock_resolve_backend,
+        tmp_path,
+    ):
+        """vault-push --all should use a mapping's custom env_file."""
+        mock_client = MagicMock()
+        service_dir = tmp_path / "postgresql"
+        service_dir.mkdir()
+        env_file = service_dir / "postgresql.env"
+        env_file.write_text("POSTGRES_PASSWORD=secret\n")
+        (service_dir / ".env.keys").write_text("DOTENV_PRIVATE_KEY_PRODUCTION=secret123\n")
+
+        mock_sync_config = SyncConfig(
+            mappings=[
+                ServiceMapping(
+                    secret_name="postgres-key",
+                    folder_path=service_dir,
+                    environment="production",
+                    env_file=env_file.name,
+                )
+            ]
+        )
+        mock_loader.return_value = (mock_sync_config, mock_client, "azure", None, None, None)
+
+        dummy_backend = DummyEncryptionBackend()
+        mock_resolve_backend.return_value = (
+            dummy_backend,
+            EncryptionProvider.DOTENVX,
+            None,
+        )
+        mock_client.get_secret.side_effect = SecretNotFoundError("missing")
+
+        result = runner.invoke(app, ["vault-push", "--all"])
+
+        assert result.exit_code == 0, result.output
+        assert dummy_backend.encrypt_calls == [env_file]
+        mock_client.set_secret.assert_called_once_with(
+            "postgres-key",
+            "DOTENV_PRIVATE_KEY_PRODUCTION=secret123",
+        )
+
+    @patch("envdrift.cli_commands.encryption_helpers.resolve_encryption_backend")
+    @patch("envdrift.cli_commands.sync.load_sync_config_and_client")
     def test_push_all_skips_existing(
         self,
         mock_loader,

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -369,11 +369,13 @@ class TestSyncConfig:
             folder_path="services/api",
             vault_name="other-vault",
             environment="staging",
+            env_file="api.env.staging",
         )
         assert mapping.secret_name == "api-key"
         assert mapping.folder_path == "services/api"
         assert mapping.vault_name == "other-vault"
         assert mapping.environment == "staging"
+        assert mapping.env_file == "api.env.staging"
 
     def test_sync_mapping_config_with_profile(self):
         """Test SyncMappingConfig with profile and activate_to."""
@@ -425,6 +427,7 @@ class TestSyncConfig:
                             "secret_name": "app-key",
                             "folder_path": "services/app",
                             "environment": "production",
+                            "env_file": "app.env",
                         },
                         {
                             "secret_name": "api-key",
@@ -448,6 +451,7 @@ class TestSyncConfig:
         assert first_mapping.folder_path == "services/app"
         assert first_mapping.vault_name is None
         assert first_mapping.environment == "production"
+        assert first_mapping.env_file == "app.env"
 
         second_mapping = config.vault.sync.mappings[1]
         assert second_mapping.secret_name == "api-key"
@@ -492,6 +496,7 @@ max_workers = 2
 secret_name = "myapp-key"
 folder_path = "."
 environment = "production"
+env_file = "myapp.env"
 
 [[vault.sync.mappings]]
 secret_name = "service-key"
@@ -507,6 +512,7 @@ environment = "staging"
         assert config.vault.sync.max_workers == 2
         assert len(config.vault.sync.mappings) == 2
         assert config.vault.sync.mappings[0].secret_name == "myapp-key"
+        assert config.vault.sync.mappings[0].env_file == "myapp.env"
         assert config.vault.sync.mappings[1].vault_name == "backend-vault"
 
 

--- a/tests/unit/test_env_files.py
+++ b/tests/unit/test_env_files.py
@@ -1,0 +1,116 @@
+"""Tests for env file resolution helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from envdrift.env_files import resolve_custom_env_file, resolve_mapping_env_file
+from envdrift.sync.config import ServiceMapping
+
+
+@pytest.mark.parametrize(
+    ("filename", "environment"),
+    [
+        ("dotnet-service-template.env.sqa", "sqa"),
+        ("dotnet-service-template-local.env", "local"),
+        ("postgresql.env", "production"),
+    ],
+)
+def test_resolve_mapping_env_file_uses_configured_env_file(
+    tmp_path: Path,
+    filename: str,
+    environment: str,
+) -> None:
+    """A configured env_file is resolved relative to folder_path."""
+    service_dir = tmp_path / "service"
+    service_dir.mkdir()
+    custom_env_file = service_dir / filename
+    custom_env_file.write_text("SECRET=value\n")
+
+    mapping = ServiceMapping(
+        secret_name="dotenv-key",
+        folder_path=service_dir,
+        environment=environment,
+        env_file=Path(filename),
+    )
+
+    detection = resolve_mapping_env_file(mapping)
+
+    assert detection.status == "found"
+    assert detection.path == custom_env_file
+    assert detection.environment == environment
+
+
+def test_resolve_mapping_env_file_missing_custom_file_reports_expected_path(
+    tmp_path: Path,
+) -> None:
+    service_dir = tmp_path / "service"
+    service_dir.mkdir()
+    mapping = ServiceMapping(
+        secret_name="dotenv-key",
+        folder_path=service_dir,
+        environment="production",
+        env_file=Path("postgresql.env"),
+    )
+
+    detection = resolve_mapping_env_file(mapping)
+
+    assert detection.status == "not_found"
+    assert detection.path == service_dir / "postgresql.env"
+    assert detection.environment == "production"
+
+
+@pytest.mark.parametrize("env_file", ["../outside.env", "/tmp/outside.env"])
+def test_resolve_custom_env_file_rejects_paths_outside_folder(
+    tmp_path: Path,
+    env_file: str,
+) -> None:
+    service_dir = tmp_path / "service"
+    service_dir.mkdir()
+
+    with pytest.raises(ValueError):
+        resolve_custom_env_file(service_dir, env_file)
+
+
+def test_resolve_mapping_env_file_preserves_legacy_exact_environment(
+    tmp_path: Path,
+) -> None:
+    service_dir = tmp_path / "service"
+    service_dir.mkdir()
+    env_file = service_dir / ".env.production"
+    env_file.write_text("SECRET=value\n")
+
+    mapping = ServiceMapping(
+        secret_name="dotenv-key",
+        folder_path=service_dir,
+        environment="production",
+    )
+
+    detection = resolve_mapping_env_file(mapping)
+
+    assert detection.status == "found"
+    assert detection.path == env_file
+    assert detection.environment == "production"
+
+
+def test_resolve_mapping_env_file_preserves_legacy_single_env_detection(
+    tmp_path: Path,
+) -> None:
+    service_dir = tmp_path / "service"
+    service_dir.mkdir()
+    env_file = service_dir / ".env.sqa"
+    env_file.write_text("SECRET=value\n")
+
+    mapping = ServiceMapping(
+        secret_name="dotenv-key",
+        folder_path=service_dir,
+        environment="production",
+    )
+
+    detection = resolve_mapping_env_file(mapping)
+
+    assert detection.status == "found"
+    assert detection.path == env_file
+    assert detection.environment == "sqa"

--- a/tests/unit/test_env_files.py
+++ b/tests/unit/test_env_files.py
@@ -62,7 +62,10 @@ def test_resolve_mapping_env_file_missing_custom_file_reports_expected_path(
     assert detection.environment == "production"
 
 
-@pytest.mark.parametrize("env_file", ["../outside.env", "/tmp/outside.env"])
+@pytest.mark.parametrize(
+    "env_file",
+    ["../outside.env", "/tmp/outside.env", "nested/../postgresql.env", "../service/inside.env"],
+)
 def test_resolve_custom_env_file_rejects_paths_outside_folder(
     tmp_path: Path,
     env_file: str,
@@ -70,6 +73,7 @@ def test_resolve_custom_env_file_rejects_paths_outside_folder(
     service_dir = tmp_path / "service"
     service_dir.mkdir()
 
+    # Any '..' segment is rejected up front, even if it would resolve back inside.
     with pytest.raises(ValueError):
         resolve_custom_env_file(service_dir, env_file)
 
@@ -114,3 +118,19 @@ def test_resolve_mapping_env_file_preserves_legacy_single_env_detection(
     assert detection.status == "found"
     assert detection.path == env_file
     assert detection.environment == "sqa"
+
+
+def test_resolve_mapping_env_file_reports_folder_not_found(tmp_path: Path) -> None:
+    """A custom env_file under a missing folder reports folder_not_found."""
+    mapping = ServiceMapping(
+        secret_name="dotenv-key",
+        folder_path=tmp_path / "does-not-exist",
+        environment="production",
+        env_file=Path("postgresql.env"),
+    )
+
+    detection = resolve_mapping_env_file(mapping)
+
+    assert detection.status == "folder_not_found"
+    assert detection.path is None
+    assert detection.environment == "production"

--- a/tests/unit/test_guard_cli.py
+++ b/tests/unit/test_guard_cli.py
@@ -13,6 +13,9 @@ from envdrift.config import (
     EnvdriftConfig,
     PartialEncryptionConfig,
     PartialEncryptionEnvironmentConfig,
+    SyncConfig,
+    SyncMappingConfig,
+    VaultConfig,
 )
 from envdrift.config import (
     GuardConfig as FileGuardConfig,
@@ -141,6 +144,57 @@ def test_guard_uses_config_scanners(tmp_path: Path, monkeypatch):
     assert guard_config.include_git_history is True
     assert guard_config.check_entropy is True
     assert guard_config.ignore_paths == ["vendor/**"]
+
+
+def test_guard_passes_custom_env_files_to_engine(tmp_path: Path, monkeypatch):
+    """vault.sync env_file mappings should be treated as guard env files."""
+    service_dir = tmp_path / "secrets" / "postgresql"
+    service_dir.mkdir(parents=True)
+    config = EnvdriftConfig(
+        vault=VaultConfig(
+            sync=SyncConfig(
+                mappings=[
+                    SyncMappingConfig(
+                        secret_name="postgres-key",
+                        folder_path="secrets/postgresql",
+                        environment="production",
+                        env_file="postgresql.env",
+                    )
+                ]
+            )
+        )
+    )
+    created_configs, _info_calls = _patch_guard_dependencies(monkeypatch, config, _build_result([]))
+
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["guard", "."])
+
+    assert result.exit_code == 0, result.output
+    assert created_configs[0].mapped_env_files == ["secrets/postgresql/postgresql.env"]
+
+
+def test_guard_rejects_custom_env_files_outside_folder(tmp_path: Path, monkeypatch):
+    """guard should fail fast when a configured env_file escapes folder_path."""
+    config = EnvdriftConfig(
+        vault=VaultConfig(
+            sync=SyncConfig(
+                mappings=[
+                    SyncMappingConfig(
+                        secret_name="postgres-key",
+                        folder_path="secrets/postgresql",
+                        environment="production",
+                        env_file="../outside.env",
+                    )
+                ]
+            )
+        )
+    )
+    _patch_guard_dependencies(monkeypatch, config, _build_result([]))
+
+    result = runner.invoke(app, ["guard", str(tmp_path)])
+
+    assert result.exit_code == 1
+    assert "invalid env_file" in result.output.lower()
 
 
 def test_guard_pr_base_fetch_warns_on_failure(tmp_path: Path, monkeypatch):

--- a/tests/unit/test_guard_cli.py
+++ b/tests/unit/test_guard_cli.py
@@ -170,7 +170,9 @@ def test_guard_passes_custom_env_files_to_engine(tmp_path: Path, monkeypatch):
     result = runner.invoke(app, ["guard", "."])
 
     assert result.exit_code == 0, result.output
-    assert created_configs[0].mapped_env_files == ["secrets/postgresql/postgresql.env"]
+    # Guard resolves mapped env files to absolute paths so the scanner matches
+    # them regardless of which directory is scanned.
+    assert created_configs[0].mapped_env_files == [str((service_dir / "postgresql.env").resolve())]
 
 
 def test_guard_rejects_custom_env_files_outside_folder(tmp_path: Path, monkeypatch):

--- a/tests/unit/test_hook_check.py
+++ b/tests/unit/test_hook_check.py
@@ -201,6 +201,7 @@ class TestCheckPrecommitHooks:
         result = check_precommit_hooks(None)
 
         assert result["envdrift-encryption"] is False
+        assert result["envdrift-guard"] is False
 
     def test_reports_installed_hooks(self, monkeypatch, tmp_path: Path):
         config_path = tmp_path / ".pre-commit-config.yaml"
@@ -214,6 +215,7 @@ class TestCheckPrecommitHooks:
         result = check_precommit_hooks(config_path)
 
         assert result["envdrift-encryption"] is True
+        assert result["envdrift-guard"] is False
 
     def test_custom_required_hooks(self, monkeypatch, tmp_path: Path):
         config_path = tmp_path / ".pre-commit-config.yaml"
@@ -330,6 +332,7 @@ class TestEnsureGitHookSetup:
         assert errors == []
         content = (tmp_path / ".pre-commit-config.yaml").read_text()
         assert "envdrift-encryption" in content
+        assert "envdrift-guard" in content
 
     def test_ensure_direct_installs_hooks(self, tmp_path: Path):
         hooks_dir = tmp_path / ".git" / "hooks"
@@ -344,7 +347,7 @@ class TestEnsureGitHookSetup:
         pre_push = hooks_dir / "pre-push"
         assert pre_commit.exists()
         assert pre_push.exists()
-        assert "envdrift encrypt --check" in pre_commit.read_text()
+        assert "envdrift guard --staged --native-only --ci" in pre_commit.read_text()
         assert "envdrift lock --check" in pre_push.read_text()
 
     def test_unknown_method_returns_error(self):

--- a/tests/unit/test_integration_dotenvx.py
+++ b/tests/unit/test_integration_dotenvx.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import MagicMock, patch
 
-from envdrift.integrations.dotenvx import DotenvxWrapper
+from envdrift.integrations.dotenvx import DotenvxWrapper, normalize_dotenvx_metadata
 
 
 def test_dotenvx_get_success(tmp_path):
@@ -47,3 +47,117 @@ def test_dotenvx_set_success(tmp_path):
         wrapper.set(env_file, "KEY", "value")
 
         mock_run.assert_called_once_with(["set", "-f", str(env_file), "KEY", "value"])
+
+
+# ---------------------------------------------------------------------------
+# normalize_dotenvx_metadata
+# ---------------------------------------------------------------------------
+
+
+def _keys_header() -> str:
+    return (
+        "#/------------------!DOTENV_PRIVATE_KEYS!-------------------/\n"
+        "#/ private decryption keys. DO NOT commit to source control /\n"
+        "#/----------------------------------------------------------/\n"
+    )
+
+
+def test_normalize_rewrites_env_file_public_key_and_comment(tmp_path):
+    """The env file's public key name and dotenvx comment are canonicalized."""
+    env_file = tmp_path / "postgresql.env"
+    env_file.write_text(
+        "#/-------------------[DOTENV_PUBLIC_KEY]--------------------/\n"
+        "# postgresql.env\n"
+        "DOTENV_PUBLIC_KEY_POSTGRESQLPRODUCTION=03abc\n"
+        'POSTGRES_PASSWORD="encrypted:BASE64=="\n'
+    )
+    keys_file = tmp_path / ".env.keys"  # absent on purpose
+
+    normalize_dotenvx_metadata(env_file, keys_file, "production")
+
+    content = env_file.read_text()
+    assert "DOTENV_PUBLIC_KEY_PRODUCTION=03abc" in content
+    assert "POSTGRESQLPRODUCTION" not in content
+    assert "# .env.production" in content
+    assert "# postgresql.env" not in content
+
+
+def test_normalize_returns_when_keys_file_missing(tmp_path):
+    """A missing .env.keys is a no-op (env file already handled)."""
+    env_file = tmp_path / "postgresql.env"
+    env_file.write_text("DOTENV_PUBLIC_KEY_PRODUCTION=03abc\n")
+    keys_file = tmp_path / ".env.keys"
+
+    normalize_dotenvx_metadata(env_file, keys_file, "production")
+
+    assert not keys_file.exists()
+
+
+def test_normalize_renames_generated_private_key(tmp_path):
+    """A filename-derived private key is renamed to the canonical environment."""
+    env_file = tmp_path / "postgresql.env"
+    env_file.write_text("DOTENV_PUBLIC_KEY_POSTGRESQLPRODUCTION=03abc\n")
+    keys_file = tmp_path / ".env.keys"
+    keys_file.write_text(
+        _keys_header()
+        + "\n# postgresql.env\n"
+        + "DOTENV_PRIVATE_KEY_POSTGRESQLPRODUCTION=deadbeef\n"
+    )
+
+    normalize_dotenvx_metadata(env_file, keys_file, "production")
+
+    content = keys_file.read_text()
+    assert "DOTENV_PRIVATE_KEY_PRODUCTION=deadbeef" in content
+    assert "POSTGRESQLPRODUCTION" not in content
+    assert "# .env.production" in content
+    assert "# postgresql.env" not in content
+    assert content.endswith("\n")
+
+
+def test_normalize_merges_into_existing_canonical_key(tmp_path):
+    """When a canonical key already exists, the generated key+comment are merged in."""
+    env_file = tmp_path / "postgresql.env"
+    env_file.write_text("DOTENV_PUBLIC_KEY_PRODUCTION=03abc\n")
+    keys_file = tmp_path / ".env.keys"
+    keys_file.write_text(
+        _keys_header()
+        + "\n# .env.production\n"
+        + "DOTENV_PRIVATE_KEY_PRODUCTION=stale\n"
+        + "\n# postgresql.env\n"
+        + "DOTENV_PRIVATE_KEY_POSTGRESQLPRODUCTION=fresh\n"
+    )
+
+    normalize_dotenvx_metadata(env_file, keys_file, "production")
+
+    content = keys_file.read_text()
+    # Canonical key takes the freshly generated value, duplicate is removed.
+    assert "DOTENV_PRIVATE_KEY_PRODUCTION=fresh" in content
+    assert content.count("DOTENV_PRIVATE_KEY_PRODUCTION=") == 1
+    assert "POSTGRESQLPRODUCTION" not in content
+    assert "# postgresql.env" not in content
+
+
+def test_normalize_noop_when_no_custom_comment(tmp_path):
+    """Without the dotenvx custom-filename comment, .env.keys is left untouched."""
+    env_file = tmp_path / "postgresql.env"
+    env_file.write_text("DOTENV_PUBLIC_KEY_PRODUCTION=03abc\n")
+    keys_file = tmp_path / ".env.keys"
+    original = _keys_header() + "\nDOTENV_PRIVATE_KEY_PRODUCTION=already\n"
+    keys_file.write_text(original)
+
+    normalize_dotenvx_metadata(env_file, keys_file, "production")
+
+    assert keys_file.read_text() == original
+
+
+def test_normalize_noop_when_comment_has_no_following_key(tmp_path):
+    """A custom comment with no private key after it does not crash or change keys."""
+    env_file = tmp_path / "postgresql.env"
+    env_file.write_text("DOTENV_PUBLIC_KEY_PRODUCTION=03abc\n")
+    keys_file = tmp_path / ".env.keys"
+    original = _keys_header() + "\n# postgresql.env\n\n# another-section\n"
+    keys_file.write_text(original)
+
+    normalize_dotenvx_metadata(env_file, keys_file, "production")
+
+    assert keys_file.read_text() == original

--- a/tests/unit/test_precommit.py
+++ b/tests/unit/test_precommit.py
@@ -315,3 +315,22 @@ class TestVerifyHooksInstalled:
         assert result["envdrift-validate"] is True
         assert result["envdrift-encryption"] is False
         assert result["envdrift-guard"] is False
+
+    def test_malformed_yaml_reports_all_hooks_absent(self, tmp_path: Path):
+        """Unparseable YAML reports all hooks as absent instead of crashing."""
+        config_file = tmp_path / ".pre-commit-config.yaml"
+        config_file.write_text("repos: [unbalanced\n")
+
+        result = verify_hooks_installed(config_path=config_file)
+
+        assert result == dict.fromkeys(result, False)
+        assert result["envdrift-guard"] is False
+
+    def test_non_mapping_yaml_reports_all_hooks_absent(self, tmp_path: Path):
+        """A YAML document whose root is not a mapping is treated as no hooks."""
+        config_file = tmp_path / ".pre-commit-config.yaml"
+        config_file.write_text("- just\n- a\n- list\n")
+
+        result = verify_hooks_installed(config_path=config_file)
+
+        assert result == dict.fromkeys(result, False)

--- a/tests/unit/test_precommit.py
+++ b/tests/unit/test_precommit.py
@@ -28,6 +28,7 @@ class TestGetHookConfig:
         assert result == HOOK_CONFIG
         assert "envdrift-validate" in result
         assert "envdrift-encryption" in result
+        assert "envdrift-guard" in result
 
     def test_contains_yaml_structure(self):
         """Test the config contains valid YAML structure markers."""
@@ -44,7 +45,7 @@ class TestHookEntry:
         """Test HOOK_ENTRY has correct structure."""
         assert HOOK_ENTRY["repo"] == "local"
         assert "hooks" in HOOK_ENTRY
-        assert len(HOOK_ENTRY["hooks"]) == 2
+        assert len(HOOK_ENTRY["hooks"]) == 3
 
     def test_validate_hook_entry(self):
         """Test envdrift-validate hook entry."""
@@ -59,6 +60,15 @@ class TestHookEntry:
         encrypt_hook = next(h for h in hooks if h["id"] == "envdrift-encryption")
         assert encrypt_hook["language"] == "system"
         assert "encrypt" in encrypt_hook["entry"]
+
+    def test_guard_hook_entry(self):
+        """Test envdrift-guard hook entry."""
+        hooks = cast(list[dict[str, Any]], HOOK_ENTRY["hooks"])
+        guard_hook = next(h for h in hooks if h["id"] == "envdrift-guard")
+        assert guard_hook["language"] == "system"
+        assert guard_hook["entry"] == "envdrift guard --staged --native-only --ci"
+        assert guard_hook["always_run"] is True
+        assert guard_hook["pass_filenames"] is False
 
 
 class TestFindPrecommitConfig:
@@ -184,6 +194,7 @@ class TestInstallHooks:
         hook_ids = [h["id"] for h in local_repo["hooks"]]
         assert "envdrift-validate" in hook_ids
         assert "envdrift-encryption" in hook_ids
+        assert "envdrift-guard" in hook_ids
 
     def test_raises_when_config_not_found_and_no_create(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -213,8 +224,8 @@ class TestInstallHooks:
                 if hook.get("id", "").startswith("envdrift-"):
                     envdrift_hooks.append(hook)
 
-        # Should only have 2 hooks (validate and encryption), not 4
-        assert len(envdrift_hooks) == 2
+        # Should only have 3 hooks (validate, encryption, guard), not 6
+        assert len(envdrift_hooks) == 3
 
 
 class TestUninstallHooks:
@@ -263,8 +274,8 @@ class TestUninstallHooks:
 class TestVerifyHooksInstalled:
     """Tests for verify_hooks_installed function."""
 
-    def test_both_hooks_installed(self, tmp_path: Path):
-        """Test detects both hooks when installed."""
+    def test_all_hooks_installed(self, tmp_path: Path):
+        """Test detects all hooks when installed."""
         config_file = tmp_path / ".pre-commit-config.yaml"
         install_hooks(config_path=config_file)
 
@@ -272,15 +283,17 @@ class TestVerifyHooksInstalled:
 
         assert result["envdrift-validate"] is True
         assert result["envdrift-encryption"] is True
+        assert result["envdrift-guard"] is True
 
     def test_no_hooks_installed(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
-        """Test returns False for both when no config."""
+        """Test returns False for all when no config."""
         monkeypatch.chdir(tmp_path)
 
         result = verify_hooks_installed()
 
         assert result["envdrift-validate"] is False
         assert result["envdrift-encryption"] is False
+        assert result["envdrift-guard"] is False
 
     def test_partial_hooks_installed(self, tmp_path: Path):
         """Test detects partial installation."""
@@ -301,3 +314,4 @@ class TestVerifyHooksInstalled:
 
         assert result["envdrift-validate"] is True
         assert result["envdrift-encryption"] is False
+        assert result["envdrift-guard"] is False

--- a/tests/unit/test_sync_config.py
+++ b/tests/unit/test_sync_config.py
@@ -219,6 +219,24 @@ class TestSyncConfigFromToml:
 
         assert config.mappings[0].environment == "staging"
 
+    def test_from_toml_with_env_file(self) -> None:
+        """Test TOML config with custom env filename."""
+        data = {
+            "mappings": [
+                {
+                    "secret_name": "myapp-key",
+                    "folder_path": "services/myapp",
+                    "environment": "sqa",
+                    "env_file": "dotnet-service-template.env.sqa",
+                },
+            ]
+        }
+
+        config = SyncConfig.from_toml(data)
+
+        assert config.mappings[0].environment == "sqa"
+        assert config.mappings[0].env_file == Path("dotnet-service-template.env.sqa")
+
     def test_from_toml_with_vault_name(self) -> None:
         """Test TOML config with vault name override."""
         data = {

--- a/tests/unit/test_sync_engine.py
+++ b/tests/unit/test_sync_engine.py
@@ -63,6 +63,32 @@ class TestSyncEngineBasic:
         assert result.services[0].action == SyncAction.CREATED
         assert (service_dir / ".env.keys").exists()
 
+    def test_sync_uses_custom_env_file(self, mock_vault_client: MagicMock, tmp_path: Path) -> None:
+        """Sync should use mapping.env_file when deciding whether a service exists."""
+        mock_vault_client.get_secret.return_value = SecretValue(name="test-key", value="secret123")
+
+        service_dir = tmp_path / "service1"
+        service_dir.mkdir()
+        (service_dir / "postgresql.env").write_text("DB_URL=encrypted:xyz\n")
+
+        config = SyncConfig(
+            mappings=[
+                ServiceMapping(
+                    secret_name="test-key",
+                    folder_path=service_dir,
+                    environment="production",
+                    env_file=Path("postgresql.env"),
+                ),
+            ],
+        )
+
+        engine = SyncEngine(config=config, vault_client=mock_vault_client)
+        result = engine.sync_all()
+
+        assert len(result.services) == 1
+        assert result.services[0].action == SyncAction.CREATED
+        assert "DOTENV_PRIVATE_KEY_PRODUCTION=secret123" in (service_dir / ".env.keys").read_text()
+
     def test_sync_skips_when_env_file_does_not_exist(
         self, mock_vault_client: MagicMock, tmp_path: Path
     ) -> None:


### PR DESCRIPTION
## Summary

Support custom dotenv filenames through an explicit per-mapping `env_file`
field, while keeping vault/dotenvx key names canonical from the configured
`environment`.

### The problem

With a config like the one below, `envdrift vault-push --all` (and `pull` /
`lock` / `sync`) only looked for `.env.<environment>` with a single-`.env.*`
fallback, so services whose dotenv files use a custom naming convention were
silently skipped:

```
Skipped secrets/postgresql: No .env file found
Skipped secrets/dotnet-service-template: No .env file found
```

```toml
[[vault.sync.mappings]]
secret_name = "dotnet-service-template-postgres"
folder_path = "secrets/postgresql"
environment = "production"
env_file = "postgresql.env"   # <-- new
```

## What changed

- **Config**: `SyncMappingConfig.env_file` / `ServiceMapping.env_file`, parsed
  from TOML in both loaders (and the Go agent).
- **Shared resolver** `resolve_mapping_env_file()` in `env_files.py`. Custom
  filenames are scoped to `folder_path` and reject `..` / absolute escapes.
  When unset, legacy `.env.<environment>` → single-`.env.*` detection is
  unchanged.
- **Canonical keys**: `environment` remains the source of truth for key names.
  dotenvx derives `DOTENV_*_<suffix>` from the filename, so after encrypting a
  mapped custom file we normalize `DOTENV_PUBLIC_KEY_*` / `DOTENV_PRIVATE_KEY_*`
  in the env file and `.env.keys`, plus the dotenvx comment, back to
  `DOTENV_*_<environment>` / `# .env.<environment>`. The key value is unchanged.
- **Commands**: `vault-push --all`, `pull`, `lock`, `sync`/`SyncEngine` use the
  resolver; `vault-pull` gains `--env-file <name>` for single-service pull.
- **Guard / hooks**: the native scanner treats mapped `env_file` names as env
  files (flagged when plaintext, even if gitignored). The installed git hook and
  pre-commit entry now run `envdrift guard --staged --native-only --ci` so
  custom files are enforced before commit. Existing skip mechanisms
  (skip-encrypted default, `[guard].ignore_paths`, inline `# envdrift:ignore`)
  still apply.
- **Background agent**: appends mapped `env_file` names to its watch patterns.
  The VS Code extension stays settings-driven (documented).

**Opt-in only** — behavior is unchanged when `env_file` is omitted.

## Testing

- Unit + scanner: 1719 passed. New tests cover the resolver (incl. `..`
  rejection and legacy fallbacks), TOML parsing, `vault-push --all` /
  `vault-pull --env-file`, and the native scanner (detects plaintext mapped
  files, ignores encrypted ones, collects gitignored mapped files).
- Integration (real dotenvx): `lock --force` + `pull --skip-sync` round-trip on
  `postgresql.env` (`production`) and `dotnet-service-template.env.sqa` (`sqa`)
  produce `DOTENV_PRIVATE_KEY_PRODUCTION` / `_SQA` — not filename-derived keys.
- Go agent: `go build` + `go test ./internal/project/...` pass.
- Manual playground (mirrors the original report): `guard` flags 3 plaintext
  custom env files (exit 2); after `lock --force` keys are canonical and `guard`
  is clean (exit 0); `ignore_paths` and inline `# envdrift:ignore` correctly
  suppress findings on custom files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for custom dotenv filenames per vault sync mapping via `env_file` configuration option.
  * Added new `--env-file` option to `vault-pull` command for specifying custom dotenv filenames during decryption.
  * Added new `envdrift-guard` pre-commit hook to validate staged environment files against configured mappings.

* **Improvements**
  * Agent now automatically watches custom environment files defined in vault sync mappings when guardian is enabled.
  * Enhanced dotenvx integration with automatic metadata normalization for custom env filenames.

* **Documentation**
  * Expanded guides and references with examples and explanations of custom `env_file` configuration and related features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds opt-in support for custom dotenv filenames per vault sync mapping via an `env_file` field in config, while keeping vault key names canonical from the configured `environment`. It also replaces the old shell-loop encryption check in the pre-commit hook with an `envdrift guard --staged --native-only --ci` call so custom-named files are enforced before commit.

- **Core resolver**: `resolve_mapping_env_file()` / `resolve_custom_env_file()` in `env_files.py` scope custom paths to `folder_path` and reject `..` / absolute escapes; legacy `.env.<environment>` detection is unchanged when `env_file` is omitted.
- **Metadata normalization**: `normalize_dotenvx_metadata()` rewrites filename-derived `DOTENV_PUBLIC_KEY_*` / `DOTENV_PRIVATE_KEY_*` names in the env file and `.env.keys` back to the canonical `DOTENV_*_<environment>` form after dotenvx runs, called from `vault-push`, `lock`, and `pull` commands.
- **Go agent and pre-commit**: the agent appends mapped `env_file` basenames to its watch patterns; the pre-commit hook and pre-commit YAML now include an `envdrift-guard` entry alongside the existing encryption hook.

<h3>Confidence Score: 4/5</h3>

Safe to merge with awareness that the decryption-test re-encrypt path in SyncEngine leaves custom env files with filename-derived key names until the next lock run (noted in previous review).

The opt-in resolver, path-traversal guards, and normalization flow are well-structured and backed by a broad new test suite. The remaining concern is the pre-existing gap where `_test_decryption` re-encrypts without calling normalization, leaving the env file with a non-canonical public-key name — `vault-pull` would then fail on that file until `lock` re-normalizes it. A newly introduced minor asymmetry in the `.env.keys` trailing-newline logic could cause spurious file writes but does not affect correctness.

src/envdrift/integrations/dotenvx.py (normalize_dotenvx_metadata — trailing-newline inconsistency and the overly-broad public-key regex from prior review); src/envdrift/sync/engine.py (_test_decryption — missing post-reencrypt normalization noted in prior review)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/envdrift/env_files.py | Adds resolve_custom_env_file (path-traversal guards via .. check + resolved relative_to) and resolve_mapping_env_file (3-step resolution: custom file → exact env → legacy detection). Logic is correct and well-tested. |
| src/envdrift/integrations/dotenvx.py | Adds normalize_dotenvx_metadata which rewrites dotenvx-derived key names in env and keys files. Two previously-flagged issues remain: the public-key regex replaces all DOTENV_PUBLIC_KEY_* entries (not just the filename-derived one), and the .env.keys trailing-newline logic unconditionally appends \n for non-empty content while the env file block preserves the original newline state. |
| src/envdrift/cli_commands/sync.py | Replaces detect_env_file with resolve_mapping_env_file throughout pull/lock, adds _normalize_mapped_dotenvx_metadata helper, and calls it at every encryption site. Normalization occurs before the encryption-status check in pull, which is safe since it only touches metadata lines. |
| src/envdrift/cli_commands/vault.py | Adds --env-file option to vault-pull with traversal validation, and inserts normalization after encryption in vault-push --all. Normalization in vault-pull is called after the key is written to .env.keys and before decryption, which is the correct ordering. |
| src/envdrift/sync/engine.py | Switches _sync_service, _test_decryption, and _validate_schema to use resolve_mapping_env_file. The _test_decryption re-encrypt path still does not call normalization after re-encryption (existing issue noted in prior review). |
| src/envdrift/integrations/precommit.py | Adds envdrift-guard hook entry; verify_hooks_installed now derives tracked hook IDs dynamically from HOOK_ENTRY, adds defensive error handling for malformed YAML, and resolves the stale hardcoded dict. Callers use .get() so the key change is safe. |
| envdrift-agent/internal/project/config.go | Adds TOML parsing for vault.sync.mappings and appends custom env_file basenames to guardian watch patterns. Path traversal is guarded; deduplication via patternListMatches is correct. |
| src/envdrift/scanner/native.py | Adds mapped_env_files support: absolute-path canonicalization on init, a new collection method that includes mapped files under the scan directory, and _is_mapped_env_file for the env-file classifier. Logic is correct. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant TOML as envdrift.toml
    participant Resolver as resolve_mapping_env_file()
    participant CustomFile as custom env file (e.g. postgresql.env)
    participant DotenvX as dotenvx encrypt
    participant Normalizer as normalize_dotenvx_metadata()
    participant KeysFile as .env.keys
    participant Vault as Cloud Vault

    Note over TOML,Vault: vault-push --all (with env_file set)
    TOML->>Resolver: "mapping with env_file=postgresql.env"
    Resolver->>CustomFile: resolve and existence check
    CustomFile-->>Resolver: "found (status=found, env=production)"
    Resolver-->>DotenvX: encrypt postgresql.env
    DotenvX->>CustomFile: "DOTENV_PUBLIC_KEY_POSTGRESQLPRODUCTION="
    DotenvX->>KeysFile: "DOTENV_PRIVATE_KEY_POSTGRESQLPRODUCTION="
    DotenvX-->>Normalizer: trigger normalization
    Normalizer->>CustomFile: "rename to DOTENV_PUBLIC_KEY_PRODUCTION="
    Normalizer->>KeysFile: "rename to DOTENV_PRIVATE_KEY_PRODUCTION="
    Normalizer-->>Vault: "push DOTENV_PRIVATE_KEY_PRODUCTION="

    Note over TOML,Vault: vault-pull --env-file postgresql.env
    Vault-->>KeysFile: "write DOTENV_PRIVATE_KEY_PRODUCTION="
    Normalizer->>CustomFile: normalize public key name
    Normalizer->>KeysFile: normalize private key name
    DotenvX->>CustomFile: decrypt using DOTENV_PRIVATE_KEY_PRODUCTION
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/envdrift/sync/engine.py`, line 330-342 ([link](https://github.com/jainal09/envdrift/blob/3c58800bd0ba4f095e2315ea855aac892f79fd42/src/envdrift/sync/engine.py#L330-L342)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Decryption test leaves custom env file in non-canonical key-name state**

   After `dotenvx encrypt` runs on a file like `postgresql.env`, dotenvx derives a fresh `DOTENV_PUBLIC_KEY_POSTGRESQL=` entry in the env file and adds a new `DOTENV_PRIVATE_KEY_POSTGRESQL=` entry to `.env.keys` — neither of which matches the canonical `DOTENV_*_PRODUCTION` names written by normalization. Because `normalize_dotenvx_metadata` is never called after this re-encrypt, `--check-decryption` leaves the file with the filename-derived public key and the keys file with an extra raw entry. The next `vault-pull` restores the production private key from vault but the env file still references the newly-generated postgresql public key, so decryption will fail until `lock` re-normalizes everything.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mai..."](https://github.com/jainal09/envdrift/commit/850a5453095fa551025d65890df6bd228c4de99d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35479875)</sub>

<!-- /greptile_comment -->