### PR TITLE
fix(vault-sync): auto-detect custom dotenv filenames without env_file

### DIFF
--- a/docs/guides/env-file-sync.md
+++ b/docs/guides/env-file-sync.md
@@ -153,7 +153,7 @@ environment = "staging"   # reads/writes DOTENV_PRIVATE_KEY_STAGING
 secret_name = "postgres-key"
 folder_path = "secrets/postgresql"
 environment = "production"
-env_file = "postgresql.env"  # custom dotenv filename inside folder_path
+# postgresql.env is auto-detected; set env_file only for a non-conventional name
 ```
 
 Using a different provider? Replace the `provider` value and the provider block:
@@ -352,11 +352,18 @@ vault_name = "production-vault"  # informational only — see note below
     `vault_name` does **not** route that secret to a different vault. To use a
     separate vault, run a separate config.
 
-By default, envdrift looks for `.env.<environment>` and then falls back to `.env`
-or a single `.env.*` file. Use `env_file` when a service uses another dotenv-style
-filename, such as `postgresql.env` or `dotnet-service-template.env.sqa`.
-`environment` remains the source of truth for key names, so the examples above
-still use keys like `DOTENV_PRIVATE_KEY_PRODUCTION` and `DOTENV_PRIVATE_KEY_STAGING`.
+By default, envdrift resolves each mapping's env file with no extra config, in
+this order: an exact `.env.<environment>`; then a custom-named file that encodes
+the environment — `<prefix>.env.<environment>` (e.g.
+`dotnet-service-template.env.sqa`), an infix `<prefix>-<environment>.env` /
+`<prefix>.<environment>.env` / `<prefix>_<environment>.env` (e.g.
+`dotnet-service-template-local.env`), or, for the default `production`
+environment, a plain `<prefix>.env` (e.g. `postgresql.env`); and finally a
+fallback to plain `.env` or a single `.env.*` file. Companion files (`.example`,
+`.sample`, `.template`, `.keys`) are never picked. Set `env_file` only for a name
+that matches none of these conventions. `environment` remains the source of truth
+for key names, so these files still use keys like `DOTENV_PRIVATE_KEY_PRODUCTION`
+and `DOTENV_PRIVATE_KEY_STAGING`.
 The installed git hook and `guard --staged` read these mappings and block
 plaintext custom env files before commit. The background agent also adds mapped
 `env_file` names to its watch patterns when project `[guardian]` is enabled; the

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -284,7 +284,7 @@ Each mapping defines how a vault secret maps to a local service directory.
 | `folder_path` | `string` | **required** | Local folder containing `.env.keys` |
 | `vault_name` | `string` | `null` | Parsed but informational only — every mapping is fetched from the single vault you configured via `--vault-url` / `[vault.<provider>]`. See the note in [env-file-sync.md](../guides/env-file-sync.md#mappings). |
 | `environment` | `string` | `null` (resolves to profile name, else `"production"`) | **Identity** — which `.env.<environment>` file this mapping targets and which `DOTENV_PRIVATE_KEY_<ENVIRONMENT>` key it reads/writes. Always runs (unless filtered out by `profile`). |
-| `env_file` | `string` | `null` | Custom dotenv filename relative to `folder_path` (e.g. `postgresql.env`). When set, this exact file is used instead of the `.env.<environment>` lookup; `environment` still controls the `DOTENV_PRIVATE_KEY_<ENVIRONMENT>` key name. |
+| `env_file` | `string` | `null` | Optional override for the dotenv filename, relative to `folder_path`. Usually unnecessary — common conventions are auto-detected: `.env.<environment>`, `<prefix>.env.<environment>`, infix `<prefix>-<environment>.env`, and a plain `<prefix>.env` for the default environment (e.g. `postgresql.env`). Set `env_file` only for an arbitrary name matching none of those. When set, this exact file is used and `environment` still controls the `DOTENV_PRIVATE_KEY_<ENVIRONMENT>` key name. |
 | `profile` | `string` | `null` | **Selector** — tags this mapping as profile-only. Untagged mappings always run. Profile-tagged mappings only run when you pass a matching `--profile <name>` on the CLI. |
 | `activate_to` | `string` | `null` | After decrypt, copy the decrypted file to this path. Typical use: `activate_to = ".env"` on a profile mapping so apps that read a plain `.env` get the right one for the active profile. |
 | `ephemeral_keys` | `bool` | `null` | Per-mapping override for ephemeral mode (no `.env.keys` written to disk). |
@@ -325,12 +325,13 @@ secret_name = "service2-key"
 folder_path = "services/service2"
 environment = "staging"
 
-# Mapping with a custom dotenv filename
+# Mapping with a custom dotenv filename (auto-detected — env_file not needed)
 [[vault.sync.mappings]]
 secret_name = "postgres-key"
 folder_path = "secrets/postgresql"
 environment = "production"  # key stays DOTENV_PRIVATE_KEY_PRODUCTION
-env_file = "postgresql.env" # file path is secrets/postgresql/postgresql.env
+# secrets/postgresql/postgresql.env is auto-detected; set env_file only for a
+# non-conventional name that none of the detection rules match
 
 # Profile mapping — only runs with `envdrift pull --profile local`.
 # `environment` defaults to the profile name, so this targets .env.local

--- a/src/envdrift/cli_commands/sync.py
+++ b/src/envdrift/cli_commands/sync.py
@@ -240,18 +240,24 @@ def _normalize_max_workers(max_workers: int | None) -> int | None:
 
 
 def _normalize_mapped_dotenvx_metadata(
-    mapping: ServiceMapping,
     env_file: Path,
     env_keys_file: Path,
     effective_environment: str,
     backend_provider: Any,
 ) -> None:
     from envdrift.encryption import EncryptionProvider
+    from envdrift.integrations.dotenvx import (
+        dotenvx_filename_needs_normalization,
+        normalize_dotenvx_metadata,
+    )
 
-    if backend_provider != EncryptionProvider.DOTENVX or mapping.env_file is None:
+    if backend_provider != EncryptionProvider.DOTENVX:
         return
-
-    from envdrift.integrations.dotenvx import normalize_dotenvx_metadata
+    # Normalize whenever the resolved filename is non-canonical — configured via
+    # env_file or auto-detected (e.g. postgresql.env) — since dotenvx derives its
+    # key name from the filename and would otherwise write a non-canonical key.
+    if not dotenvx_filename_needs_normalization(env_file, effective_environment):
+        return
 
     normalize_dotenvx_metadata(env_file, env_keys_file, effective_environment)
 
@@ -733,7 +739,6 @@ def pull(
             continue
 
         _normalize_mapped_dotenvx_metadata(
-            mapping,
             env_file,
             mapping.folder_path / (sync_config.env_keys_filename or ".env.keys"),
             effective_env,
@@ -1388,7 +1393,6 @@ def lock(
             warnings.append(f"{env_file}: no .env.keys file found, new key will be generated")
 
         _normalize_mapped_dotenvx_metadata(
-            mapping,
             env_file,
             env_keys_file,
             effective_env,
@@ -1500,7 +1504,6 @@ def lock(
                                     error_count += 1
                                     continue
                                 _normalize_mapped_dotenvx_metadata(
-                                    mapping,
                                     env_file,
                                     env_keys_file,
                                     effective_env,
@@ -1595,7 +1598,6 @@ def lock(
                 error_count += 1
                 continue
             _normalize_mapped_dotenvx_metadata(
-                mapping,
                 env_file,
                 env_keys_file,
                 effective_env,
@@ -1648,7 +1650,6 @@ def lock(
                 error_count += 1
                 continue
             _normalize_mapped_dotenvx_metadata(
-                task.mapping,
                 task.env_file,
                 task.env_keys_file,
                 task.effective_environment,

--- a/src/envdrift/cli_commands/vault.py
+++ b/src/envdrift/cli_commands/vault.py
@@ -238,6 +238,7 @@ def vault_push(
             EncryptionProvider,
             detect_encryption_provider,
         )
+        from envdrift.integrations.dotenvx import dotenvx_filename_needs_normalization
 
         # Load sync config and client
         sync_config, client, effective_provider, _, _, _ = load_sync_config_and_client(
@@ -348,10 +349,13 @@ def vault_push(
                     # Normalize dotenvx metadata for custom filenames so the vault
                     # key name stays canonical (DOTENV_*_<environment>). This runs
                     # whether we just encrypted the file or it was already encrypted
-                    # by a prior run, so the canonical key always exists below.
+                    # by a prior run, so the canonical key always exists below. It
+                    # applies to any non-canonical filename — configured (env_file)
+                    # or auto-detected (e.g. postgresql.env) — since dotenvx derives
+                    # its key name from the filename.
                     if (
                         backend_provider == EncryptionProvider.DOTENVX
-                        and mapping.env_file is not None
+                        and dotenvx_filename_needs_normalization(env_file, effective_environment)
                     ):
                         from envdrift.integrations.dotenvx import normalize_dotenvx_metadata
 

--- a/src/envdrift/env_files.py
+++ b/src/envdrift/env_files.py
@@ -8,6 +8,10 @@ from typing import Any, Literal
 
 EnvFileStatus = Literal["found", "folder_not_found", "multiple_found", "not_found"]
 
+# Suffixes that mark a file as a non-secret companion (examples, keys), never the
+# env file itself. Matched against the full filename, e.g. "service.env.example".
+_EXCLUDED_ENV_SUFFIXES = (".example", ".sample", ".template", ".keys")
+
 
 @dataclass(frozen=True)
 class EnvFileDetection:
@@ -18,43 +22,102 @@ class EnvFileDetection:
     status: EnvFileStatus
 
 
+def _is_excluded_env_file(name: str) -> bool:
+    """Return True for companion files (.example/.sample/.template/.keys)."""
+    return any(name.endswith(suffix) for suffix in _EXCLUDED_ENV_SUFFIXES)
+
+
+def _env_label_from_name(name: str, default_environment: str) -> str | None:
+    """Return the environment a dotenv-shaped filename belongs to, else None.
+
+    Recognizes both the canonical and common custom conventions:
+    - ``.env``                       -> ``default_environment``
+    - ``.env.<env>``                 -> ``<env>``           (e.g. ".env.docker")
+    - ``<prefix>.env.<env>``         -> ``<env>``           ("service.env.docker")
+    - ``<prefix>.env``               -> ``default_environment`` ("postgresql.env")
+
+    Returns None for files that are not dotenv files (or are companion files).
+    """
+    if _is_excluded_env_file(name):
+        return None
+    if name == ".env":
+        return default_environment
+    if ".env." in name:
+        # Environment is whatever follows ".env.": ".env.docker" / "svc.env.docker".
+        return name.split(".env.", 1)[1] or None
+    if name.endswith(".env"):
+        # Prefixed plain file with no encoded environment, e.g. "postgresql.env".
+        return default_environment
+    return None
+
+
+def _name_encodes_environment(name: str, environment: str) -> bool:
+    """Return True if ``name`` is a dotenv file that encodes ``environment``.
+
+    Covers the suffix convention (``<prefix>.env.<env>``) and the infix
+    convention where the environment precedes the ``.env`` extension
+    (``<prefix>-<env>.env`` / ``<prefix>.<env>.env`` / ``<prefix>_<env>.env`` /
+    ``<env>.env``).
+    """
+    if name.endswith(f".env.{environment}"):
+        return True
+    if name == f"{environment}.env":
+        return True
+    return any(name.endswith(f"{sep}{environment}.env") for sep in ("-", ".", "_"))
+
+
+def _match_env_files_for_environment(folder_path: Path, environment: str) -> list[Path]:
+    """Return env files in ``folder_path`` whose name encodes ``environment``."""
+    if not folder_path.exists():
+        return []
+    matches = [
+        f
+        for f in folder_path.iterdir()
+        if f.is_file()
+        and not _is_excluded_env_file(f.name)
+        and _name_encodes_environment(f.name, environment)
+    ]
+    return sorted(matches)
+
+
 def detect_env_file(folder_path: Path, default_environment: str = "production") -> EnvFileDetection:
     """
-    Auto-detect .env file in a folder.
+    Auto-detect the env file in a folder.
 
     Checks for:
     1. Plain .env file (returns default environment)
-    2. Single .env.* file (returns environment from suffix)
+    2. A single dotenv-shaped file, including custom names such as
+       ``service.env`` or ``service.env.docker`` (environment from suffix, or
+       the default for files without an encoded environment)
 
     Returns an EnvFileDetection with status:
     - "found": env file found
     - "folder_not_found": folder doesn't exist
-    - "multiple_found": multiple .env.* files exist (ambiguous)
+    - "multiple_found": multiple candidate env files exist (ambiguous)
     - "not_found": no env files found
     """
     if not folder_path.exists():
         return EnvFileDetection(None, None, "folder_not_found")
 
-    # First, check for plain .env file
+    # First, check for plain .env file (takes precedence over any other file)
     plain_env = folder_path / ".env"
     if plain_env.exists() and plain_env.is_file():
         return EnvFileDetection(plain_env, default_environment, "found")
 
-    # Find all .env.* files, excluding special files
-    exclude_patterns = {".env.keys", ".env.example", ".env.sample", ".env.template"}
-    env_files = []
-
+    candidates: list[tuple[Path, str]] = []
     for f in folder_path.iterdir():
-        if f.is_file() and f.name.startswith(".env.") and f.name not in exclude_patterns:
-            env_files.append(f)
+        if not f.is_file():
+            continue
+        environment = _env_label_from_name(f.name, default_environment)
+        if environment is None:
+            continue
+        candidates.append((f, environment))
 
-    if len(env_files) == 1:
-        env_file = env_files[0]
-        # Extract environment from filename: .env.soak -> soak
-        environment = env_file.name[5:]  # Remove ".env." prefix
+    if len(candidates) == 1:
+        env_file, environment = candidates[0]
         return EnvFileDetection(env_file, environment, "found")
 
-    if len(env_files) > 1:
+    if len(candidates) > 1:
         return EnvFileDetection(None, None, "multiple_found")
 
     return EnvFileDetection(None, None, "not_found")
@@ -88,11 +151,13 @@ def resolve_mapping_env_file(mapping: Any) -> EnvFileDetection:
     Resolution order:
     1. Explicit ``mapping.env_file`` relative to ``mapping.folder_path``.
     2. Exact ``.env.<effective_environment>``.
-    3. Existing legacy auto-detection for ``.env`` or a single ``.env.*`` file.
+    3. A custom-named file that encodes the environment, such as
+       ``service.env.<env>`` or ``service-<env>.env``.
+    4. Existing legacy auto-detection for ``.env`` or a single dotenv file.
 
-    Explicit custom filenames keep ``mapping.effective_environment`` as the
-    environment of record. This preserves canonical vault key names even when
-    the dotenv filename uses a service-specific convention.
+    Custom filenames matched via steps 2-3 keep ``mapping.effective_environment``
+    as the environment of record. This preserves canonical vault key names even
+    when the dotenv filename uses a service-specific convention.
     """
     folder_path = Path(mapping.folder_path)
     effective_environment = mapping.effective_environment
@@ -111,4 +176,13 @@ def resolve_mapping_env_file(mapping: Any) -> EnvFileDetection:
     if exact_env.exists() and exact_env.is_file():
         return EnvFileDetection(exact_env, effective_environment, "found")
 
-    return detect_env_file(folder_path)
+    # Match custom-named files that encode this environment (e.g.
+    # "service.env.docker" or "service-local.env"). The configured environment
+    # stays canonical so vault/dotenvx key names remain config-driven.
+    env_matches = _match_env_files_for_environment(folder_path, effective_environment)
+    if len(env_matches) == 1:
+        return EnvFileDetection(env_matches[0], effective_environment, "found")
+    if len(env_matches) > 1:
+        return EnvFileDetection(None, effective_environment, "multiple_found")
+
+    return detect_env_file(folder_path, effective_environment)

--- a/src/envdrift/env_files.py
+++ b/src/envdrift/env_files.py
@@ -8,6 +8,10 @@ from typing import Any, Literal
 
 EnvFileStatus = Literal["found", "folder_not_found", "multiple_found", "not_found"]
 
+# Environment a dotenv file belongs to when its name encodes none of its own
+# (a plain ``.env`` or ``<prefix>.env``). Mirrors ServiceMapping.effective_environment.
+_DEFAULT_ENVIRONMENT = "production"
+
 # Suffixes that mark a file as a non-secret companion (examples, keys), never the
 # env file itself. Matched against the full filename, e.g. "service.env.example".
 _EXCLUDED_ENV_SUFFIXES = (".example", ".sample", ".template", ".keys")
@@ -27,48 +31,33 @@ def _is_excluded_env_file(name: str) -> bool:
     return any(name.endswith(suffix) for suffix in _EXCLUDED_ENV_SUFFIXES)
 
 
-def _env_label_from_name(name: str, default_environment: str) -> str | None:
-    """Return the environment a dotenv-shaped filename belongs to, else None.
-
-    Recognizes both the canonical and common custom conventions:
-    - ``.env``                       -> ``default_environment``
-    - ``.env.<env>``                 -> ``<env>``           (e.g. ".env.docker")
-    - ``<prefix>.env.<env>``         -> ``<env>``           ("service.env.docker")
-    - ``<prefix>.env``               -> ``default_environment`` ("postgresql.env")
-
-    Returns None for files that are not dotenv files (or are companion files).
-    """
-    if _is_excluded_env_file(name):
-        return None
-    if name == ".env":
-        return default_environment
-    if ".env." in name:
-        # Environment is whatever follows ".env.": ".env.docker" / "svc.env.docker".
-        return name.split(".env.", 1)[1] or None
-    if name.endswith(".env"):
-        # Prefixed plain file with no encoded environment, e.g. "postgresql.env".
-        return default_environment
-    return None
-
-
 def _name_encodes_environment(name: str, environment: str) -> bool:
-    """Return True if ``name`` is a dotenv file that encodes ``environment``.
+    """Return True if dotenv file ``name`` belongs to ``environment``.
 
-    Covers the suffix convention (``<prefix>.env.<env>``) and the infix
-    convention where the environment precedes the ``.env`` extension
-    (``<prefix>-<env>.env`` / ``<prefix>.<env>.env`` / ``<prefix>_<env>.env`` /
-    ``<env>.env``).
+    Recognizes the conventions where the environment is encoded in the filename:
+    - suffix:  ``.env.<env>`` / ``<prefix>.env.<env>``   ("service.env.docker")
+    - infix:   ``<prefix>-<env>.env`` / ``.<env>.env`` / ``_<env>.env`` / ``<env>.env``
+               ("service-local.env")
+
+    A plain file that encodes no environment of its own (``.env`` or
+    ``<prefix>.env``, e.g. "postgresql.env") belongs to the default environment,
+    so it matches only when ``environment`` is the default. This keeps an
+    environment-specific lookup (e.g. "docker") from grabbing a plain file, and
+    avoids relabeling a plain file under a non-default environment.
     """
     if name.endswith(f".env.{environment}"):
         return True
     if name == f"{environment}.env":
         return True
-    return any(name.endswith(f"{sep}{environment}.env") for sep in ("-", ".", "_"))
+    if any(name.endswith(f"{sep}{environment}.env") for sep in ("-", ".", "_")):
+        return True
+    # Plain ".env" / "<prefix>.env" carries no encoded environment -> default only.
+    return environment == _DEFAULT_ENVIRONMENT and name.endswith(".env")
 
 
 def _match_env_files_for_environment(folder_path: Path, environment: str) -> list[Path]:
-    """Return env files in ``folder_path`` whose name encodes ``environment``."""
-    if not folder_path.exists():
+    """Return env files in ``folder_path`` whose name belongs to ``environment``."""
+    if not folder_path.is_dir():
         return []
     matches = [
         f
@@ -82,42 +71,43 @@ def _match_env_files_for_environment(folder_path: Path, environment: str) -> lis
 
 def detect_env_file(folder_path: Path, default_environment: str = "production") -> EnvFileDetection:
     """
-    Auto-detect the env file in a folder.
+    Auto-detect a canonical .env file in a folder.
 
     Checks for:
     1. Plain .env file (returns default environment)
-    2. A single dotenv-shaped file, including custom names such as
-       ``service.env`` or ``service.env.docker`` (environment from suffix, or
-       the default for files without an encoded environment)
+    2. Single .env.* file (returns environment from suffix)
+
+    Custom service-prefixed names (e.g. ``service.env.docker``) are intentionally
+    not handled here; that requires the mapping's environment and lives in
+    :func:`resolve_mapping_env_file`.
 
     Returns an EnvFileDetection with status:
     - "found": env file found
-    - "folder_not_found": folder doesn't exist
-    - "multiple_found": multiple candidate env files exist (ambiguous)
+    - "folder_not_found": folder doesn't exist (or isn't a directory)
+    - "multiple_found": multiple .env.* files exist (ambiguous)
     - "not_found": no env files found
     """
-    if not folder_path.exists():
+    if not folder_path.is_dir():
         return EnvFileDetection(None, None, "folder_not_found")
 
-    # First, check for plain .env file (takes precedence over any other file)
+    # First, check for plain .env file (takes precedence over any .env.* file)
     plain_env = folder_path / ".env"
-    if plain_env.exists() and plain_env.is_file():
+    if plain_env.is_file():
         return EnvFileDetection(plain_env, default_environment, "found")
 
-    candidates: list[tuple[Path, str]] = []
-    for f in folder_path.iterdir():
-        if not f.is_file():
-            continue
-        environment = _env_label_from_name(f.name, default_environment)
-        if environment is None:
-            continue
-        candidates.append((f, environment))
+    env_files = [
+        f
+        for f in folder_path.iterdir()
+        if f.is_file() and f.name.startswith(".env.") and not _is_excluded_env_file(f.name)
+    ]
 
-    if len(candidates) == 1:
-        env_file, environment = candidates[0]
+    if len(env_files) == 1:
+        env_file = env_files[0]
+        # Extract environment from filename: .env.soak -> soak
+        environment = env_file.name[len(".env.") :]
         return EnvFileDetection(env_file, environment, "found")
 
-    if len(candidates) > 1:
+    if len(env_files) > 1:
         return EnvFileDetection(None, None, "multiple_found")
 
     return EnvFileDetection(None, None, "not_found")
@@ -151,9 +141,10 @@ def resolve_mapping_env_file(mapping: Any) -> EnvFileDetection:
     Resolution order:
     1. Explicit ``mapping.env_file`` relative to ``mapping.folder_path``.
     2. Exact ``.env.<effective_environment>``.
-    3. A custom-named file that encodes the environment, such as
-       ``service.env.<env>`` or ``service-<env>.env``.
-    4. Existing legacy auto-detection for ``.env`` or a single dotenv file.
+    3. A custom-named file that belongs to the environment, such as
+       ``service.env.<env>`` or ``service-<env>.env`` (and, for a default
+       environment, a plain ``service.env``).
+    4. Legacy auto-detection for ``.env`` or a single ``.env.*`` file.
 
     Custom filenames matched via steps 2-3 keep ``mapping.effective_environment``
     as the environment of record. This preserves canonical vault key names even

--- a/src/envdrift/integrations/dotenvx.py
+++ b/src/envdrift/integrations/dotenvx.py
@@ -113,6 +113,19 @@ _PUBLIC_KEY_NAME_RE = re.compile(r"\bDOTENV_PUBLIC_KEY_[A-Za-z0-9_-]+=")
 _PRIVATE_KEY_LINE_RE = re.compile(r"^DOTENV_PRIVATE_KEY_[A-Za-z0-9_-]+=(.*)$")
 
 
+def dotenvx_filename_needs_normalization(env_file: Path | str, environment: str) -> bool:
+    """Return True when a dotenvx file's metadata must be normalized to canonical.
+
+    dotenvx derives ``DOTENV_*_<NAME>`` from the filename, so only the canonical
+    ``.env`` and ``.env.<environment>`` names already map to the
+    ``DOTENV_*_<ENVIRONMENT>`` key envdrift uses. Any other name — service-prefixed
+    or infix custom files, whether configured via ``env_file`` or auto-detected —
+    yields a non-canonical key that :func:`normalize_dotenvx_metadata` must rewrite.
+    """
+    name = Path(env_file).name
+    return name != ".env" and name != f".env.{environment}"
+
+
 def normalize_dotenvx_metadata(
     env_file: Path | str,
     env_keys_file: Path | str,

--- a/tests/integration/test_encryption_tools.py
+++ b/tests/integration/test_encryption_tools.py
@@ -929,3 +929,120 @@ def test_full_lock_pull_merge_cycle(integration_env):
     # Verify .secret file is encrypted again
     secret_content = secret_file.read_text()
     assert "=encrypted:" in secret_content, "Secret file should be encrypted after lock"
+
+
+# --- Vault-sync auto-detection of custom dotenv filenames (end-to-end) ---
+
+# Each tuple: (folder, filename, environment-or-None, plaintext, canonical key suffix).
+# Covers every auto-detected convention with NO `env_file` configured:
+#   postgresql.env           -> <prefix>.env       (default -> production)
+#   svc.env.docker           -> <prefix>.env.<env> (suffix)
+#   app-local.env            -> <prefix>-<env>.env  (infix)
+_CUSTOM_FILENAME_CASES = [
+    ("secrets/postgresql", "postgresql.env", None, "DB_PASSWORD=pgsecret", "PRODUCTION"),
+    ("secrets/svc", "svc.env.docker", "docker", "TOKEN=dockersecret", "DOCKER"),
+    ("secrets/app", "app-local.env", "local", "APP_KEY=localsecret", "LOCAL"),
+]
+
+
+def _write_custom_filename_project(work_dir: Path) -> None:
+    """Lay down plaintext custom-named env files plus an envdrift.toml with no env_file."""
+    mappings = []
+    for folder, filename, environment, plaintext, _suffix in _CUSTOM_FILENAME_CASES:
+        (work_dir / folder).mkdir(parents=True, exist_ok=True)
+        (work_dir / folder / filename).write_text(plaintext + "\n")
+        env_line = f'\nenvironment = "{environment}"' if environment else ""
+        mappings.append(
+            textwrap.dedent(
+                f"""\
+                [[vault.sync.mappings]]
+                secret_name = "{folder.replace("/", "-")}-key"
+                folder_path = "{folder}"{env_line}
+                """
+            )
+        )
+    config = (
+        textwrap.dedent(
+            """\
+            [encryption]
+            backend = "dotenvx"
+
+            [encryption.dotenvx]
+            auto_install = true
+
+            [vault]
+            provider = "azure"
+
+            [vault.azure]
+            vault_url = "https://example.vault.azure.net/"
+
+            [vault.sync]
+            """
+        )
+        + "\n"
+        + "\n".join(mappings)
+    )
+    (work_dir / "envdrift.toml").write_text(config)
+
+
+@pytest.mark.integration
+def test_lock_autodetects_custom_dotenv_filenames(integration_env):
+    """`lock` auto-detects custom filenames and writes CANONICAL dotenvx keys.
+
+    Regression guard for vault-sync: without `env_file`, services named
+    `postgresql.env` / `svc.env.docker` / `app-local.env` must be detected,
+    encrypted, and have their `.env.keys` carry `DOTENV_PRIVATE_KEY_<ENV>` derived
+    from the mapping environment — not the non-canonical name dotenvx derives from
+    the filename (e.g. `DOTENV_PRIVATE_KEY_POSTGRESQLPRODUCTION`).
+    """
+    work_dir = integration_env["base_dir"] / "vault-sync-custom"
+    work_dir.mkdir()
+    env = integration_env["env"].copy()
+
+    _write_custom_filename_project(work_dir)
+
+    # check=True asserts a clean exit (no "No .env file found" skips, no errors).
+    result = _run_envdrift(["lock", "--force"], cwd=work_dir, env=env)
+    output = re.sub(r"\x1b\[[0-9;]*m", "", result.stdout + result.stderr)
+    assert "Encrypted: 3" in output, output
+
+    for folder, filename, _env, _plain, suffix in _CUSTOM_FILENAME_CASES:
+        encrypted = (work_dir / folder / filename).read_text()
+        assert "encrypted:" in encrypted, f"{filename} should be encrypted"
+        assert f"DOTENV_PUBLIC_KEY_{suffix}" in encrypted, f"{filename} public key not canonical"
+
+        keys = (work_dir / folder / ".env.keys").read_text()
+        private_keys = [
+            line.split("=", 1)[0]
+            for line in keys.splitlines()
+            if line.startswith("DOTENV_PRIVATE_KEY_")
+        ]
+        # Exactly one private key, and it is the canonical DOTENV_PRIVATE_KEY_<ENV>.
+        assert private_keys == [f"DOTENV_PRIVATE_KEY_{suffix}"], (
+            f"{folder}/.env.keys has non-canonical key(s): {private_keys}"
+        )
+
+
+@pytest.mark.integration
+def test_lock_custom_filename_decrypt_roundtrip(integration_env):
+    """A custom-named file locked via auto-detection decrypts back to plaintext.
+
+    Proves the normalized canonical key in `.env.keys` actually decrypts the file,
+    despite dotenvx deriving its key name from the (custom) filename.
+    """
+    work_dir = integration_env["base_dir"] / "vault-sync-roundtrip"
+    work_dir.mkdir()
+    env = integration_env["env"].copy()
+
+    _write_custom_filename_project(work_dir)
+    _run_envdrift(["lock", "--force"], cwd=work_dir, env=env)
+
+    for folder, filename, _env, plaintext, _suffix in _CUSTOM_FILENAME_CASES:
+        target = f"{folder}/{filename}"
+        assert "encrypted:" in (work_dir / target).read_text()
+
+        _run_envdrift(["decrypt", target], cwd=work_dir, env=env)
+
+        decrypted = (work_dir / target).read_text()
+        assert plaintext in decrypted, f"{target} did not round-trip to {plaintext!r}"
+        assert "encrypted:" not in decrypted

--- a/tests/unit/test_env_files.py
+++ b/tests/unit/test_env_files.py
@@ -230,16 +230,74 @@ def test_resolve_mapping_env_file_reports_ambiguous_environment_match(tmp_path: 
     assert detection.path is None
 
 
-def test_detect_env_file_finds_prefixed_plain_file(tmp_path: Path) -> None:
-    """``detect_env_file`` recognizes a single ``<prefix>.env`` file."""
+def test_resolve_mapping_env_file_default_ignores_other_environment_files(
+    tmp_path: Path,
+) -> None:
+    """A default mapping picks the plain file, not the env-specific neighbor.
+
+    Regression: a folder with ``service.env`` + ``service.env.staging`` must not
+    look ambiguous to a production mapping just because two dotenv files exist.
+    """
+    service_dir = tmp_path / "service"
+    service_dir.mkdir()
+    plain = service_dir / "service.env"
+    plain.write_text("SECRET=value\n")
+    (service_dir / "service.env.staging").write_text("SECRET=staging\n")
+
+    mapping = ServiceMapping(secret_name="dotenv-key", folder_path=service_dir)
+
+    detection = resolve_mapping_env_file(mapping)
+
+    assert detection.status == "found"
+    assert detection.path == plain
+    assert detection.environment == "production"
+
+
+def test_resolve_mapping_env_file_env_specific_ignores_plain_file(tmp_path: Path) -> None:
+    """An environment-specific mapping never grabs a plain ``<prefix>.env`` file."""
+    service_dir = tmp_path / "service"
+    service_dir.mkdir()
+    (service_dir / "service.env").write_text("SECRET=value\n")
+    docker = service_dir / "service.env.docker"
+    docker.write_text("SECRET=docker\n")
+
+    mapping = ServiceMapping(
+        secret_name="dotenv-key",
+        folder_path=service_dir,
+        environment="docker",
+    )
+
+    detection = resolve_mapping_env_file(mapping)
+
+    assert detection.status == "found"
+    assert detection.path == docker
+    assert detection.environment == "docker"
+
+
+def test_detect_env_file_ignores_prefixed_plain_file(tmp_path: Path) -> None:
+    """``detect_env_file`` stays narrow: ``<prefix>.env`` is resolve()'s job, not its."""
     (tmp_path / "keycloak.env").write_text("SECRET=value\n")
-    (tmp_path / "keycloak.env.example").write_text("SECRET=example\n")
 
     detection = detect_env_file(tmp_path)
 
-    assert detection.status == "found"
-    assert detection.path == tmp_path / "keycloak.env"
-    assert detection.environment == "production"
+    assert detection.status == "not_found"
+    assert detection.path is None
+
+
+@pytest.mark.parametrize("resolver", ["resolve", "detect"])
+def test_env_detection_handles_non_directory_path(tmp_path: Path, resolver: str) -> None:
+    """A folder_path that is a file must not crash on iterdir()."""
+    not_a_dir = tmp_path / "service"
+    not_a_dir.write_text("oops, a file\n")
+
+    if resolver == "detect":
+        detection = detect_env_file(not_a_dir)
+    else:
+        mapping = ServiceMapping(secret_name="dotenv-key", folder_path=not_a_dir)
+        detection = resolve_mapping_env_file(mapping)
+
+    assert detection.status == "folder_not_found"
+    assert detection.path is None
 
 
 def test_resolve_mapping_env_file_reports_folder_not_found(tmp_path: Path) -> None:

--- a/tests/unit/test_env_files.py
+++ b/tests/unit/test_env_files.py
@@ -6,7 +6,11 @@ from pathlib import Path
 
 import pytest
 
-from envdrift.env_files import resolve_custom_env_file, resolve_mapping_env_file
+from envdrift.env_files import (
+    detect_env_file,
+    resolve_custom_env_file,
+    resolve_mapping_env_file,
+)
 from envdrift.sync.config import ServiceMapping
 
 
@@ -118,6 +122,124 @@ def test_resolve_mapping_env_file_preserves_legacy_single_env_detection(
     assert detection.status == "found"
     assert detection.path == env_file
     assert detection.environment == "sqa"
+
+
+@pytest.mark.parametrize(
+    ("filename", "environment"),
+    [
+        ("dotnet-service-template.env.docker", "docker"),  # <prefix>.env.<env>
+        ("dotnet-service-template-local.env", "local"),  # <prefix>-<env>.env
+        ("app.staging.env", "staging"),  # <prefix>.<env>.env
+        ("app_prod.env", "prod"),  # <prefix>_<env>.env
+        ("docker.env", "docker"),  # <env>.env
+    ],
+)
+def test_resolve_mapping_env_file_auto_detects_custom_named_file(
+    tmp_path: Path,
+    filename: str,
+    environment: str,
+) -> None:
+    """Custom filenames encoding the environment are found without env_file config."""
+    service_dir = tmp_path / "service"
+    service_dir.mkdir()
+    (service_dir / filename).write_text("SECRET=value\n")
+
+    mapping = ServiceMapping(
+        secret_name="dotenv-key",
+        folder_path=service_dir,
+        environment=environment,
+    )
+
+    detection = resolve_mapping_env_file(mapping)
+
+    assert detection.status == "found"
+    assert detection.path == service_dir / filename
+    # Configured environment stays canonical, even with a custom filename.
+    assert detection.environment == environment
+
+
+def test_resolve_mapping_env_file_auto_detects_prefixed_plain_file(tmp_path: Path) -> None:
+    """A single ``<prefix>.env`` file is found for a default-environment mapping."""
+    service_dir = tmp_path / "postgresql"
+    service_dir.mkdir()
+    env_file = service_dir / "postgresql.env"
+    env_file.write_text("SECRET=value\n")
+    # Companion files must not interfere with detection.
+    (service_dir / "postgresql.env.example").write_text("SECRET=example\n")
+    (service_dir / "docker-entrypoint.sh").write_text("#!/bin/sh\n")
+
+    mapping = ServiceMapping(secret_name="dotenv-key", folder_path=service_dir)
+
+    detection = resolve_mapping_env_file(mapping)
+
+    assert detection.status == "found"
+    assert detection.path == env_file
+    assert detection.environment == "production"
+
+
+def test_resolve_mapping_env_file_picks_environment_from_multi_env_folder(
+    tmp_path: Path,
+) -> None:
+    """One folder holding several env files resolves each environment to its file."""
+    service_dir = tmp_path / "dotnet-service-template"
+    service_dir.mkdir()
+    for name in (
+        "dotnet-service-template.env.docker",
+        "dotnet-service-template.env.sqa",
+        "dotnet-service-template-local.env",
+        # Companion files for every environment must be ignored.
+        "dotnet-service-template.env.example",
+        "dotnet-service-template.env.sqa.example",
+        "dotnet-service-template-local.env.example",
+    ):
+        (service_dir / name).write_text("SECRET=value\n")
+
+    expected = {
+        "docker": "dotnet-service-template.env.docker",
+        "sqa": "dotnet-service-template.env.sqa",
+        "local": "dotnet-service-template-local.env",
+    }
+    for environment, filename in expected.items():
+        mapping = ServiceMapping(
+            secret_name=f"key-{environment}",
+            folder_path=service_dir,
+            environment=environment,
+        )
+        detection = resolve_mapping_env_file(mapping)
+        assert detection.status == "found", environment
+        assert detection.path == service_dir / filename
+        assert detection.environment == environment
+
+
+def test_resolve_mapping_env_file_reports_ambiguous_environment_match(tmp_path: Path) -> None:
+    """Two files encoding the same environment are ambiguous, not a silent guess."""
+    service_dir = tmp_path / "service"
+    service_dir.mkdir()
+    (service_dir / "app.env.staging").write_text("SECRET=value\n")
+    (service_dir / "app-staging.env").write_text("SECRET=value\n")
+
+    mapping = ServiceMapping(
+        secret_name="dotenv-key",
+        folder_path=service_dir,
+        environment="staging",
+    )
+
+    detection = resolve_mapping_env_file(mapping)
+
+    assert detection.status == "multiple_found"
+    assert detection.path is None
+
+
+def test_detect_env_file_finds_prefixed_plain_file(tmp_path: Path) -> None:
+    """``detect_env_file`` recognizes a single ``<prefix>.env`` file."""
+    (tmp_path / "keycloak.env").write_text("SECRET=value\n")
+    (tmp_path / "keycloak.env.example").write_text("SECRET=example\n")
+
+    detection = detect_env_file(tmp_path)
+
+    assert detection.status == "found"
+    assert detection.path == tmp_path / "keycloak.env"
+    assert detection.environment == "production"
 
 
 def test_resolve_mapping_env_file_reports_folder_not_found(tmp_path: Path) -> None:


### PR DESCRIPTION
## The problem

`envdrift vault-push --all` (and `pull`/`lock`/`sync`) silently skipped every service whose dotenv file uses a custom naming convention, even though the file was right there:

```
$ envdrift vault-push --all
Skipped secrets/dotnet-service-template: No .env file found
Skipped secrets/postgresql: No .env file found
Skipped secrets/keycloak: No .env file found

Done. Pushed: 0, Skipped: 5, Errors: 0
```

The folders contained, respectively:

```
secrets/postgresql/postgresql.env
secrets/keycloak/keycloak.env
secrets/dotnet-service-template/dotnet-service-template.env.docker
secrets/dotnet-service-template/dotnet-service-template.env.sqa
secrets/dotnet-service-template/dotnet-service-template-local.env
```

Detection only recognized `.env` and `.env.<environment>`. None of the conventions above matched, so all five were skipped.

PR #296 added an explicit per-mapping `env_file` field as a workaround, but that forces users to rename files or hand-configure every single service. Auto-detection should just handle the common conventions.

## The fix

Teach detection to recognize the conventions, matching against the environment the config **already knows** — no renaming, no `env_file` boilerplate required:

| filename pattern | example | environment |
|---|---|---|
| `.env` | `.env` | default |
| `.env.<env>` | `.env.docker` | `docker` |
| `<prefix>.env` | `postgresql.env` | default |
| `<prefix>.env.<env>` | `service.env.docker` | `docker` |
| `<prefix>-<env>.env` / `.<env>.env` / `_<env>.env` / `<env>.env` | `service-local.env` | `local` |

- `detect_env_file` now treats `<prefix>.env` and `<prefix>.env.<env>` as candidates. Plain `.env` still takes precedence; companion `.example`/`.sample`/`.template`/`.keys` files are excluded by suffix.
- `resolve_mapping_env_file` adds an environment-aware match step that finds files encoding the mapping's environment — including the infix `<prefix>-<env>.env` form that can't be parsed from the filename alone (you need the configured environment to disambiguate it).
- Matched custom filenames keep the **configured** environment as the canonical label, so vault/dotenvx key names stay config-driven (consistent with #296's design).
- Ambiguous matches (two files encoding the same environment) return `multiple_found` rather than silently guessing.

## Verification

Reproduced against the real reporting project — all five mappings that previously skipped now resolve to the right file with the correct canonical environment label:

```
docker     -> found  dotnet-service-template.env.docker   env=docker
sqa        -> found  dotnet-service-template.env.sqa      env=sqa
local      -> found  dotnet-service-template-local.env    env=local
postgres   -> found  postgresql.env                       env=production
keycloak   -> found  keycloak.env                         env=production
```

- Added 11 test cases covering each convention, the multi-env folder, ambiguity, and companion-file exclusion.
- `tests/unit/test_env_files.py`: 20 passed.
- Full unit suite: 1459 passed.
- ruff check / format clean, pyrefly 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto-detection of many additional dotenv naming conventions (e.g., prefixed or suffixed env names).
  * Automatic ignoring of companion/example dotenv files (e.g., `.example`, `.keys`).
  * Better selection of the intended env file when multiple variants exist.
* **Documentation**
  * Guides and reference updated to document auto-detection, resolution order, and when manual env_file is needed.
* **Tests**
  * Added unit and integration tests covering auto-detection, ambiguous matches, and encrypt/decrypt round-trips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR teaches envdrift's env-file auto-detection to recognize common service-prefixed naming conventions (`<prefix>.env`, `<prefix>.env.<env>`, `<prefix>-<env>.env`, etc.) so `vault-push --all` no longer silently skips services that don't use the canonical `.env` or `.env.<environment>` filenames. The previous reviewer's regression (infix files being mislabeled as the default environment) was properly addressed before this review by scoping all custom-name matching to the environment-aware `_match_env_files_for_environment` / `_name_encodes_environment` helpers.

- `env_files.py` adds a new step 3 in `resolve_mapping_env_file` that matches custom filenames against the mapping's configured environment, keeping the vault key name canonical while using whatever file is present.
- `dotenvx.py` adds `dotenvx_filename_needs_normalization`, replacing the old `mapping.env_file is not None` guard so normalization fires for any auto-detected non-canonical filename, not just explicitly configured ones.
- 11 new unit tests and 2 end-to-end integration tests (lock + decrypt round-trip) cover all documented conventions, ambiguity, and companion-file exclusion.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the custom-filename detection is well-isolated, thoroughly tested, and the previous infix-relabeling regression was already fixed before this review.

The change is self-contained in env_files.py, with all existing resolution paths preserved. The new _match_env_files_for_environment step only activates when the canonical .env.{env} exact check misses, so existing deployments using standard filenames are unaffected. The one subtle edge case — a folder holding both .env and a <prefix>.env for a production mapping now returns multiple_found instead of silently using .env — is unlikely in practice and produces a clear actionable error rather than silent misbehavior.

src/envdrift/env_files.py — specifically the last branch of _name_encodes_environment that includes the plain .env file in step-3 custom matching for the default environment.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/envdrift/env_files.py | Core change — adds _name_encodes_environment, _match_env_files_for_environment, and a new step 3 in resolve_mapping_env_file. Logic is correct for the stated conventions; one edge case where .env and <prefix>.env coexist in a production folder yields multiple_found instead of using .env. |
| src/envdrift/integrations/dotenvx.py | Adds dotenvx_filename_needs_normalization — correctly returns True for any filename that isn't .env or .env.<environment>, replacing the old mapping.env_file is not None guard. |
| src/envdrift/cli_commands/sync.py | Drops mapping parameter from _normalize_mapped_dotenvx_metadata and switches guard to dotenvx_filename_needs_normalization; all call sites updated consistently. |
| tests/unit/test_env_files.py | Adds 11 new parametrized and named unit tests covering each convention, multi-env folders, ambiguity, companion-file exclusion, and non-directory paths; comprehensive. |
| tests/integration/test_encryption_tools.py | Adds two integration tests — test_lock_autodetects_custom_dotenv_filenames and test_lock_custom_filename_decrypt_roundtrip — exercising the full lock→decrypt cycle for all three custom conventions. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[resolve_mapping_env_file] --> B{mapping.env_file set?}
    B -- Yes --> C[resolve_custom_env_file\nfolder_path / env_file]
    C --> D{File exists?}
    D -- Yes --> FOUND1[found · effective_environment]
    D -- No --> NF1[not_found]
    B -- No --> E{.env.effective_environment\nexists?}
    E -- Yes --> FOUND2[found · effective_environment]
    E -- No --> F[_match_env_files_for_environment\nStep 3: custom-named files]
    F --> G{How many\nmatches?}
    G -- 1 --> FOUND3[found · effective_environment]
    G -- >1 --> MF[multiple_found]
    G -- 0 --> H[detect_env_file fallback\nStep 4: plain .env / single .env.*]
    H --> I{Result?}
    I -- found --> FOUND4[found · environment from filename]
    I -- not_found --> NF2[not_found]
    I -- multiple_found --> MF2[multiple_found]
    FOUND1 --> N{dotenvx_filename_needs_normalization?}
    FOUND2 --> N
    FOUND3 --> N
    N -- Yes --> NORM[normalize_dotenvx_metadata\nrewrite DOTENV_*_ENV keys]
    N -- No --> SKIP[no normalization needed]
```

<sub>Reviews (3): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mai..."](https://github.com/jainal09/envdrift/commit/23fd8a39d5a00d65a7ab3edf6850b63053852895) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35708314)</sub>

<!-- /greptile_comment -->