### PR TITLE
test: add 123 real container/binary-backed e2e tests + surface 29 bugs/doc gaps

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -109,8 +109,20 @@ jobs:
       - name: Install dotenvx
         run: |
           mkdir -p "$HOME/.local/bin"
-          curl -sfS "https://dotenvx.sh?directory=$HOME/.local/bin" | sh -s -- --version=1.51.4
+          # Version is the single source of truth in constants.json (kept current by Renovate).
+          DOTENVX_VERSION=$(python -c "import json; print(json.load(open('src/envdrift/constants.json'))['dotenvx_version'])")
+          curl -sfS "https://dotenvx.sh?directory=$HOME/.local/bin" | sh -s -- --version="$DOTENVX_VERSION"
           echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Install sops
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          # Version + download URL come from constants.json (kept current by Renovate's sops_version manager).
+          read -r SOPS_URL < <(python -c "import json; c=json.load(open('src/envdrift/constants.json')); print(c['sops_download_urls']['linux_amd64'].format(version=c['sops_version']))")
+          curl -sfL "$SOPS_URL" -o "$HOME/.local/bin/sops"
+          chmod +x "$HOME/.local/bin/sops"
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          "$HOME/.local/bin/sops" --version
 
       - name: Verify services are accessible
         run: |

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -66,6 +66,12 @@ jobs:
           VAULT_DEV_ROOT_TOKEN_ID: test-root-token
           VAULT_DEV_LISTEN_ADDRESS: 0.0.0.0:8200
           VAULT_ADDR: http://0.0.0.0:8200
+          # The hashicorp/vault entrypoint calls `setcap` to grant mlock; recent
+          # image builds ship without the setcap binary, so the container dies with
+          # "setcap: not found". Dev mode doesn't need mlock — skip setcap and
+          # disable mlock so the service container starts reliably.
+          SKIP_SETCAP: "true"
+          VAULT_DISABLE_MLOCK: "true"
         options: >-
           --user root
           --cap-add=IPC_LOCK
@@ -110,7 +116,10 @@ jobs:
         run: |
           mkdir -p "$HOME/.local/bin"
           # Version is the single source of truth in constants.json (kept current by Renovate).
-          DOTENVX_VERSION=$(python -c "import json; print(json.load(open('src/envdrift/constants.json'))['dotenvx_version'])")
+          # Fail fast with a clear message if the file/key is missing or malformed.
+          DOTENVX_VERSION=$(python -c "import json,sys; sys.stdout.write(json.load(open('src/envdrift/constants.json'))['dotenvx_version'])") \
+            || { echo 'ERROR: could not read dotenvx_version from src/envdrift/constants.json' >&2; exit 1; }
+          test -n "$DOTENVX_VERSION" || { echo 'ERROR: dotenvx_version resolved empty' >&2; exit 1; }
           curl -sfS "https://dotenvx.sh?directory=$HOME/.local/bin" | sh -s -- --version="$DOTENVX_VERSION"
           echo "$HOME/.local/bin" >> $GITHUB_PATH
 
@@ -118,7 +127,11 @@ jobs:
         run: |
           mkdir -p "$HOME/.local/bin"
           # Version + download URL come from constants.json (kept current by Renovate's sops_version manager).
-          read -r SOPS_URL < <(python -c "import json; c=json.load(open('src/envdrift/constants.json')); print(c['sops_download_urls']['linux_amd64'].format(version=c['sops_version']))")
+          # Use $(...) (POSIX-portable, not bash-only process substitution) and fail
+          # fast with a clear message if the file/keys are missing or malformed.
+          SOPS_URL=$(python -c "import json,sys; c=json.load(open('src/envdrift/constants.json')); sys.stdout.write(c['sops_download_urls']['linux_amd64'].format(version=c['sops_version']))") \
+            || { echo 'ERROR: could not read sops config from src/envdrift/constants.json' >&2; exit 1; }
+          test -n "$SOPS_URL" || { echo 'ERROR: SOPS_URL resolved empty' >&2; exit 1; }
           curl -sfL "$SOPS_URL" -o "$HOME/.local/bin/sops"
           chmod +x "$HOME/.local/bin/sops"
           echo "$HOME/.local/bin" >> $GITHUB_PATH
@@ -276,6 +289,9 @@ jobs:
         run: |
           echo "$GCP_KEY_CONTENT" > gcp_key.json
           export GOOGLE_APPLICATION_CREDENTIALS=$(pwd)/gcp_key.json
+          # The real-backend GCP tests also gate on GOOGLE_CLOUD_PROJECT; derive it
+          # from the service-account key so the round-trip suite actually runs here.
+          export GOOGLE_CLOUD_PROJECT=$(python -c "import json; print(json.load(open('gcp_key.json'))['project_id'])")
           uv run pytest tests/integration/ -v -m gcp --timeout=120
           rm gcp_key.json
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -137,6 +137,26 @@ jobs:
           echo "$HOME/.local/bin" >> $GITHUB_PATH
           "$HOME/.local/bin/sops" --version
 
+      - name: Install secret scanners (talisman, trivy, infisical)
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          # Versions + download URLs come from constants.json (Renovate-maintained),
+          # so the real scanner e2e tests (tests/integration/test_scanner_external_binaries.py)
+          # actually run in CI instead of skipping.
+          get_url() { python -c "import json,sys; c=json.load(open('src/envdrift/constants.json')); sys.stdout.write(c['${1}_download_urls']['linux_amd64'].format(version=c['${1}_version']))"; }
+          TALISMAN_URL=$(get_url talisman) || { echo 'ERROR: talisman url from constants.json' >&2; exit 1; }
+          TRIVY_URL=$(get_url trivy) || { echo 'ERROR: trivy url from constants.json' >&2; exit 1; }
+          INFISICAL_URL=$(get_url infisical) || { echo 'ERROR: infisical url from constants.json' >&2; exit 1; }
+          # talisman: single static binary; trivy/infisical: tarballs with the binary at the root.
+          curl -sfL "$TALISMAN_URL" -o "$HOME/.local/bin/talisman"
+          curl -sfL "$TRIVY_URL" | tar -xzf - -C "$HOME/.local/bin" trivy
+          curl -sfL "$INFISICAL_URL" | tar -xzf - -C "$HOME/.local/bin" infisical
+          chmod +x "$HOME/.local/bin/talisman" "$HOME/.local/bin/trivy" "$HOME/.local/bin/infisical"
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          "$HOME/.local/bin/trivy" --version
+          "$HOME/.local/bin/infisical" --version || true
+          "$HOME/.local/bin/talisman" --version || true
+
       - name: Verify services are accessible
         run: |
           # Wait for services to fully start after health checks pass

--- a/renovate.json
+++ b/renovate.json
@@ -33,6 +33,53 @@
       "depNameTemplate": "getsops/sops",
       "datasourceTemplate": "github-releases",
       "extractVersionTemplate": "^v(?<version>.*)$"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^src/envdrift/constants\\.json$/"],
+      "matchStrings": ["\"trivy_version\":\\s*\"(?<currentValue>\\d+\\.\\d+\\.\\d+)\""],
+      "depNameTemplate": "aquasecurity/trivy",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.*)$"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^src/envdrift/constants\\.json$/"],
+      "matchStrings": ["\"gitleaks_version\":\\s*\"(?<currentValue>\\d+\\.\\d+\\.\\d+)\""],
+      "depNameTemplate": "gitleaks/gitleaks",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.*)$"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^src/envdrift/constants\\.json$/"],
+      "matchStrings": ["\"trufflehog_version\":\\s*\"(?<currentValue>\\d+\\.\\d+\\.\\d+)\""],
+      "depNameTemplate": "trufflesecurity/trufflehog",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.*)$"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^src/envdrift/constants\\.json$/"],
+      "matchStrings": ["\"talisman_version\":\\s*\"(?<currentValue>\\d+\\.\\d+\\.\\d+)\""],
+      "depNameTemplate": "thoughtworks/talisman",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.*)$"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^src/envdrift/constants\\.json$/"],
+      "matchStrings": ["\"infisical_version\":\\s*\"(?<currentValue>\\d+\\.\\d+\\.\\d+)\""],
+      "depNameTemplate": "Infisical/infisical",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^infisical-cli/v(?<version>.*)$"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^src/envdrift/constants\\.json$/"],
+      "matchStrings": ["\"detect_secrets_version\":\\s*\"(?<currentValue>\\d+\\.\\d+\\.\\d+)\""],
+      "depNameTemplate": "detect-secrets",
+      "datasourceTemplate": "pypi"
     }
   ],
   "packageRules": [

--- a/src/envdrift/constants.json
+++ b/src/envdrift/constants.json
@@ -40,7 +40,7 @@
         "linux_arm64": "https://github.com/thoughtworks/talisman/releases/download/v{version}/talisman_linux_arm64",
         "windows_amd64": "https://github.com/thoughtworks/talisman/releases/download/v{version}/talisman_windows_amd64.exe"
     },
-    "trivy_version": "0.58.0",
+    "trivy_version": "0.71.0",
     "trivy_download_urls": {
         "darwin_amd64": "https://github.com/aquasecurity/trivy/releases/download/v{version}/trivy_{version}_macOS-64bit.tar.gz",
         "darwin_arm64": "https://github.com/aquasecurity/trivy/releases/download/v{version}/trivy_{version}_macOS-ARM64.tar.gz",

--- a/tests/docker-compose.test.yml
+++ b/tests/docker-compose.test.yml
@@ -30,6 +30,10 @@ services:
       - VAULT_DEV_ROOT_TOKEN_ID=test-root-token
       - VAULT_DEV_LISTEN_ADDRESS=0.0.0.0:8200
       - VAULT_ADDR=http://0.0.0.0:8200
+      # Newer hashicorp/vault image builds ship without `setcap`; skip it and
+      # disable mlock so the dev container starts (matches integration-tests.yml).
+      - SKIP_SETCAP=true
+      - VAULT_DISABLE_MLOCK=true
     cap_add:
       - IPC_LOCK
     healthcheck:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -91,6 +91,21 @@ def pytest_configure(config: pytest.Config) -> None:
     config.addinivalue_line("markers", "slow: Tests that take >10 seconds")
 
 
+@pytest.fixture(autouse=True)
+def _deterministic_cli_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make envdrift CLI subprocesses emit un-colorized, parseable output.
+
+    CI exports ``FORCE_COLOR=1`` globally. Integration helpers pass
+    ``os.environ.copy()`` to the CLI, so without this the CLI would render
+    ANSI-colored stdout — breaking ``--format json`` parsing and exact-text
+    assertions. ``FORCE_COLOR`` overrides ``NO_COLOR`` in Rich, so we must
+    *remove* it (setting ``NO_COLOR`` alone is not enough). ``monkeypatch``
+    restores the original environment after each test.
+    """
+    monkeypatch.delenv("FORCE_COLOR", raising=False)
+    monkeypatch.setenv("NO_COLOR", "1")
+
+
 # --- LocalStack (AWS) Fixtures ---
 
 

--- a/tests/integration/test_aws_integration.py
+++ b/tests/integration/test_aws_integration.py
@@ -555,6 +555,17 @@ def _force_delete(aws_secrets_client, name: str) -> None:
         aws_secrets_client.delete_secret(SecretId=name, ForceDeleteWithoutRecovery=True)
 
 
+def _create_secret(aws_secrets_client, **kwargs):
+    """Create a secret, force-deleting any leftover of the same name first.
+
+    Makes every create rerun-safe: a secret left behind by a previously crashed
+    run (or a shared LocalStack instance) would otherwise raise
+    ``ResourceExistsException`` before the test's own ``finally`` cleanup runs.
+    """
+    _force_delete(aws_secrets_client, kwargs["Name"])
+    return aws_secrets_client.create_secret(**kwargs)
+
+
 def _dotenvx_available() -> bool:
     """Return True when the real dotenvx binary is on PATH."""
     import shutil
@@ -661,7 +672,7 @@ class TestAWSVaultPushPullCLIRealBackend:
         old_value = "DOTENV_PRIVATE_KEY_STAGING=OLDKEY-original"
 
         # Pre-create the secret with an OLD value so the first --all run skips it.
-        aws_secrets_client.create_secret(Name=secret_name, SecretString=old_value)
+        _create_secret(aws_secrets_client, Name=secret_name, SecretString=old_value)
         old_version = aws_secrets_client.get_secret_value(SecretId=secret_name)["VersionId"]
 
         config_content = f"""\
@@ -739,7 +750,8 @@ environment = "staging"
         """HP-10: vault-pull writes a single, non-doubled DOTENV_PRIVATE_KEY prefix."""
         secret_name = "envdrift-test/pull-strip-prefix"
         # Stored with the full KEY=value form (as vault-push would store it).
-        aws_secrets_client.create_secret(
+        _create_secret(
+            aws_secrets_client,
             Name=secret_name,
             SecretString="DOTENV_PRIVATE_KEY_PRODUCTION=ec-prefixed-1234",
         )
@@ -788,7 +800,8 @@ environment = "staging"
     ) -> None:
         """HP-02: first sync creates the key, immediate second sync reports SKIPPED."""
         secret_name = "envdrift-test/pull-idempotent"
-        aws_secrets_client.create_secret(
+        _create_secret(
+            aws_secrets_client,
             Name=secret_name,
             SecretString="DOTENV_PRIVATE_KEY_PRODUCTION=idem-key-abc",
         )
@@ -860,7 +873,8 @@ environment = "production"
     ) -> None:
         """BP-19: pulling --env production a secret stored as STAGING fails fast."""
         secret_name = "envdrift-test/pull-env-mismatch"
-        aws_secrets_client.create_secret(
+        _create_secret(
+            aws_secrets_client,
             Name=secret_name,
             SecretString="DOTENV_PRIVATE_KEY_STAGING=staging-secret-val",
         )
@@ -897,10 +911,14 @@ environment = "production"
             assert "DOTENV_PRIVATE_KEY_STAGING" in combined
             assert "DOTENV_PRIVATE_KEY_PRODUCTION" in combined
 
-            # .env.keys must not have been written with the production key.
+            # A fast-failed mismatch must not write .env.keys at all. Assert the
+            # file is absent (no pre-run snapshot existed) — this also catches a
+            # wrongly-written STAGING key, not just the production key.
             keys_path = work_dir / ".env.keys"
-            if keys_path.exists():
-                assert "DOTENV_PRIVATE_KEY_PRODUCTION" not in keys_path.read_text()
+            assert not keys_path.exists(), (
+                ".env.keys must not be written on a fast-failed env mismatch; "
+                f"found: {keys_path.read_text()}"
+            )
         finally:
             _force_delete(aws_secrets_client, secret_name)
 
@@ -925,7 +943,8 @@ environment = "production"
 
         # The value we actually pull is independent of the real key; we only
         # assert the key is written and the encrypted file stays byte-identical.
-        aws_secrets_client.create_secret(
+        _create_secret(
+            aws_secrets_client,
             Name=secret_name,
             SecretString=f"DOTENV_PRIVATE_KEY_PRODUCTION={real_key}",
         )
@@ -984,7 +1003,8 @@ environment = "production"
         env_prod = work_dir / ".env.production"
         assert b"encrypted:" in env_prod.read_bytes()
 
-        aws_secrets_client.create_secret(
+        _create_secret(
+            aws_secrets_client,
             Name=secret_name,
             SecretString=f"DOTENV_PRIVATE_KEY_PRODUCTION={real_key}",
         )
@@ -1068,7 +1088,7 @@ class TestAWSClientValueDecoding:
         import json
 
         name = "envdrift-test/get-secret-json-dict"
-        aws_secrets_client.create_secret(Name=name, SecretString=json.dumps({"a": "1", "b": "2"}))
+        _create_secret(aws_secrets_client, Name=name, SecretString=json.dumps({"a": "1", "b": "2"}))
 
         try:
             secret = aws_client_configured.get_secret(name)
@@ -1084,7 +1104,7 @@ class TestAWSClientValueDecoding:
         """HP-04: SecretBinary holding valid UTF-8 bytes decodes to the original string."""
         name = "envdrift-test/get-secret-utf8-binary"
         raw = "hello-utf8-é".encode()
-        aws_secrets_client.create_secret(Name=name, SecretBinary=raw)
+        _create_secret(aws_secrets_client, Name=name, SecretBinary=raw)
 
         try:
             secret = aws_client_configured.get_secret(name)
@@ -1097,7 +1117,7 @@ class TestAWSClientValueDecoding:
     ) -> None:
         """EC-02: a non-JSON secret value is returned verbatim."""
         name = "envdrift-test/get-secret-invalid-json"
-        aws_secrets_client.create_secret(Name=name, SecretString="not-json: {broken")
+        _create_secret(aws_secrets_client, Name=name, SecretString="not-json: {broken")
 
         try:
             secret = aws_client_configured.get_secret(name)
@@ -1136,7 +1156,8 @@ class TestAWSSyncEngineRealBackend:
         from envdrift.sync.result import SyncAction
 
         secret_name = "envdrift-test/force-update-backup"
-        aws_secrets_client.create_secret(
+        _create_secret(
+            aws_secrets_client,
             Name=secret_name,
             SecretString="DOTENV_PRIVATE_KEY_PRODUCTION=vault-new-value",
         )
@@ -1176,7 +1197,8 @@ class TestAWSSyncEngineRealBackend:
         from envdrift.sync.result import SyncAction
 
         secret_name = "envdrift-test/ephemeral-key"
-        aws_secrets_client.create_secret(
+        _create_secret(
+            aws_secrets_client,
             Name=secret_name,
             SecretString="DOTENV_PRIVATE_KEY_PRODUCTION=eph-real-key",
         )
@@ -1216,7 +1238,8 @@ class TestAWSSyncEngineRealBackend:
         from envdrift.sync.result import SyncAction
 
         secret_name = "envdrift-test/verify-drift-gate"
-        aws_secrets_client.create_secret(
+        _create_secret(
+            aws_secrets_client,
             Name=secret_name,
             SecretString="DOTENV_PRIVATE_KEY_PRODUCTION=vault-value-A",
         )

--- a/tests/integration/test_aws_integration.py
+++ b/tests/integration/test_aws_integration.py
@@ -536,3 +536,713 @@ class TestAWSRegionHandling:
         # Should still work with LocalStack
         secret = client.get_secret("envdrift-test/single-key")
         assert secret.value == "ec1234567890abcdef"
+
+
+# ---------------------------------------------------------------------------
+# Additional real-backend coverage (package: test_aws_integration.py)
+#
+# Every test below drives a REAL backend: the LocalStack AWS Secrets Manager
+# container on :4566, the real envdrift CLI as a subprocess, the real dotenvx
+# binary, and/or the SyncEngine driven directly against a live boto3 client.
+# Secret names are prefixed with the test name so concurrent/repeat runs never
+# collide, and every created secret is force-deleted in a finally block.
+# ---------------------------------------------------------------------------
+
+
+def _force_delete(aws_secrets_client, name: str) -> None:
+    """Force-delete a secret, ignoring any error (cleanup helper)."""
+    with contextlib.suppress(Exception):
+        aws_secrets_client.delete_secret(SecretId=name, ForceDeleteWithoutRecovery=True)
+
+
+def _dotenvx_available() -> bool:
+    """Return True when the real dotenvx binary is on PATH."""
+    import shutil
+
+    return shutil.which("dotenvx") is not None
+
+
+def _make_encrypted_project(folder: Path, environment: str) -> str:
+    """Create a real dotenvx-encrypted .env.<environment> file in *folder*.
+
+    Runs the real dotenvx binary to encrypt a plaintext file, then reads the
+    generated DOTENV_PRIVATE_KEY_<ENV> value out of the produced .env.keys and
+    removes the .env.keys (so tests start from a key-less state). Returns the
+    private key value (bare, no prefix).
+    """
+    import shutil
+
+    dotenvx = shutil.which("dotenvx")
+    assert dotenvx is not None, "dotenvx must be installed for this helper"
+
+    env_file = folder / f".env.{environment}"
+    env_file.write_text("FOO=bar\nBAZ=qux\n")
+
+    result = subprocess.run(
+        [dotenvx, "encrypt", "-f", str(env_file)],
+        cwd=str(folder),
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, f"dotenvx encrypt failed: {result.stderr}"
+
+    keys_file = folder / ".env.keys"
+    key_name = f"DOTENV_PRIVATE_KEY_{environment.upper()}"
+    from envdrift.sync.operations import EnvKeysFile
+
+    key_value = EnvKeysFile(keys_file).read_key(key_name)
+    assert key_value, f"{key_name} not found in generated .env.keys"
+
+    # Remove the generated keys file so the test exercises a fresh pull/sync.
+    keys_file.unlink()
+    return key_value
+
+
+# --- Category B: CLI vault-push / vault-pull against LocalStack (P0) ---
+
+
+class TestAWSVaultPushPullCLIRealBackend:
+    """End-to-end CLI vault-push / vault-pull flows against LocalStack."""
+
+    def test_vault_push_single_service_stores_key_value_in_vault(
+        self,
+        work_dir: Path,
+        aws_test_env: dict[str, str],
+        aws_secrets_client,
+        integration_pythonpath: str,
+        envdrift_cmd: list[str],
+    ) -> None:
+        """HP-16: single-service vault-push stores DOTENV_PRIVATE_KEY_<ENV>=<value>."""
+        secret_name = "envdrift-test/push-single-store"
+        (work_dir / ".env.keys").write_text("DOTENV_PRIVATE_KEY_STAGING=staging-key-xyz\n")
+
+        env = aws_test_env.copy()
+        env["PYTHONPATH"] = integration_pythonpath
+
+        try:
+            result = subprocess.run(
+                [
+                    *envdrift_cmd,
+                    "vault-push",
+                    str(work_dir),
+                    secret_name,
+                    "--env",
+                    "staging",
+                    "--provider",
+                    "aws",
+                    "--region",
+                    "us-east-1",
+                ],
+                cwd=work_dir,
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+
+            assert result.returncode == 0, f"stdout: {result.stdout}\nstderr: {result.stderr}"
+
+            stored = aws_secrets_client.get_secret_value(SecretId=secret_name)
+            assert stored["SecretString"] == "DOTENV_PRIVATE_KEY_STAGING=staging-key-xyz"
+        finally:
+            _force_delete(aws_secrets_client, secret_name)
+
+    def test_vault_push_all_skips_existing_then_force_overwrites(
+        self,
+        work_dir: Path,
+        aws_test_env: dict[str, str],
+        aws_secrets_client,
+        integration_pythonpath: str,
+        envdrift_cmd: list[str],
+    ) -> None:
+        """HP-17 + EC-17 + DOC-force: --all skips existing, --force overwrites."""
+        secret_name = "envdrift-test/push-all-force"
+        old_value = "DOTENV_PRIVATE_KEY_STAGING=OLDKEY-original"
+
+        # Pre-create the secret with an OLD value so the first --all run skips it.
+        aws_secrets_client.create_secret(Name=secret_name, SecretString=old_value)
+        old_version = aws_secrets_client.get_secret_value(SecretId=secret_name)["VersionId"]
+
+        config_content = f"""\
+[encryption]
+backend = "dotenvx"
+
+[encryption.dotenvx]
+auto_install = true
+
+[vault]
+provider = "aws"
+region = "us-east-1"
+
+[vault.sync]
+
+[[vault.sync.mappings]]
+secret_name = "{secret_name}"
+folder_path = "."
+environment = "staging"
+"""
+        (work_dir / "envdrift.toml").write_text(config_content)
+        # The new local key value, different from what is in the vault.
+        (work_dir / ".env.keys").write_text("DOTENV_PRIVATE_KEY_STAGING=NEWKEY-from-local\n")
+        (work_dir / ".env.staging").write_text(
+            'DOTENV_PUBLIC_KEY_STAGING="pub"\nSECRET="encrypted:abc"\n'
+        )
+
+        env = aws_test_env.copy()
+        env["PYTHONPATH"] = integration_pythonpath
+
+        try:
+            # First run: secret already exists -> skipped, value unchanged.
+            first = subprocess.run(
+                [*envdrift_cmd, "vault-push", "--all", "--skip-encrypt"],
+                cwd=work_dir,
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+            assert first.returncode == 0, f"stdout: {first.stdout}\nstderr: {first.stderr}"
+            first_out = (first.stdout + first.stderr).lower()
+            assert "skip" in first_out or "already exists" in first_out, first.stdout
+
+            after_first = aws_secrets_client.get_secret_value(SecretId=secret_name)
+            assert after_first["SecretString"] == old_value
+            assert "NEWKEY" not in after_first["SecretString"]
+
+            # Second run: --force overwrites with the new local value.
+            second = subprocess.run(
+                [*envdrift_cmd, "vault-push", "--all", "--skip-encrypt", "--force"],
+                cwd=work_dir,
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+            assert second.returncode == 0, f"stdout: {second.stdout}\nstderr: {second.stderr}"
+            assert "pushed" in (second.stdout + second.stderr).lower(), second.stdout
+
+            after_second = aws_secrets_client.get_secret_value(SecretId=secret_name)
+            assert after_second["SecretString"] == "DOTENV_PRIVATE_KEY_STAGING=NEWKEY-from-local"
+            assert after_second["VersionId"] != old_version
+        finally:
+            _force_delete(aws_secrets_client, secret_name)
+
+    def test_pull_strips_dotenv_private_key_prefix_end_to_end(
+        self,
+        work_dir: Path,
+        aws_test_env: dict[str, str],
+        aws_secrets_client,
+        integration_pythonpath: str,
+        envdrift_cmd: list[str],
+    ) -> None:
+        """HP-10: vault-pull writes a single, non-doubled DOTENV_PRIVATE_KEY prefix."""
+        secret_name = "envdrift-test/pull-strip-prefix"
+        # Stored with the full KEY=value form (as vault-push would store it).
+        aws_secrets_client.create_secret(
+            Name=secret_name,
+            SecretString="DOTENV_PRIVATE_KEY_PRODUCTION=ec-prefixed-1234",
+        )
+
+        env = aws_test_env.copy()
+        env["PYTHONPATH"] = integration_pythonpath
+
+        try:
+            result = subprocess.run(
+                [
+                    *envdrift_cmd,
+                    "vault-pull",
+                    str(work_dir),
+                    secret_name,
+                    "--env",
+                    "production",
+                    "--no-decrypt",
+                    "--provider",
+                    "aws",
+                    "--region",
+                    "us-east-1",
+                ],
+                cwd=work_dir,
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+            assert result.returncode == 0, f"stdout: {result.stdout}\nstderr: {result.stderr}"
+
+            keys_content = (work_dir / ".env.keys").read_text()
+            assert "DOTENV_PRIVATE_KEY_PRODUCTION=ec-prefixed-1234" in keys_content
+            # The prefix must NOT be doubled.
+            assert "DOTENV_PRIVATE_KEY_PRODUCTION=DOTENV_PRIVATE_KEY_PRODUCTION" not in keys_content
+            assert keys_content.count("DOTENV_PRIVATE_KEY_PRODUCTION=") == 1
+        finally:
+            _force_delete(aws_secrets_client, secret_name)
+
+    def test_pull_idempotent_second_run_skips_when_key_matches(
+        self,
+        work_dir: Path,
+        aws_test_env: dict[str, str],
+        aws_secrets_client,
+        integration_pythonpath: str,
+        envdrift_cmd: list[str],
+    ) -> None:
+        """HP-02: first sync creates the key, immediate second sync reports SKIPPED."""
+        secret_name = "envdrift-test/pull-idempotent"
+        aws_secrets_client.create_secret(
+            Name=secret_name,
+            SecretString="DOTENV_PRIVATE_KEY_PRODUCTION=idem-key-abc",
+        )
+
+        config_content = f"""\
+[encryption]
+backend = "dotenvx"
+
+[encryption.dotenvx]
+auto_install = true
+
+[vault]
+provider = "aws"
+region = "us-east-1"
+
+[vault.sync]
+
+[[vault.sync.mappings]]
+secret_name = "{secret_name}"
+folder_path = "."
+environment = "production"
+"""
+        (work_dir / "envdrift.toml").write_text(config_content)
+        (work_dir / ".env.production").write_text(
+            'DOTENV_PUBLIC_KEY_PRODUCTION="pub"\nSECRET="encrypted:abc"\n'
+        )
+
+        env = aws_test_env.copy()
+        env["PYTHONPATH"] = integration_pythonpath
+
+        try:
+            first = subprocess.run(
+                [*envdrift_cmd, "sync"],
+                cwd=work_dir,
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+            assert first.returncode == 0, f"stdout: {first.stdout}\nstderr: {first.stderr}"
+            keys_path = work_dir / ".env.keys"
+            assert keys_path.exists()
+            first_bytes = keys_path.read_bytes()
+            assert b"idem-key-abc" in first_bytes
+
+            second = subprocess.run(
+                [*envdrift_cmd, "sync"],
+                cwd=work_dir,
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+            assert second.returncode == 0, f"stdout: {second.stdout}\nstderr: {second.stderr}"
+            second_out = (second.stdout + second.stderr).lower()
+            assert "match" in second_out or "skip" in second_out, second.stdout
+            # The file must be byte-identical after the no-op second run.
+            assert keys_path.read_bytes() == first_bytes
+        finally:
+            _force_delete(aws_secrets_client, secret_name)
+
+    def test_vault_pull_env_mismatch_with_stored_key_name_exits_1(
+        self,
+        work_dir: Path,
+        aws_test_env: dict[str, str],
+        aws_secrets_client,
+        integration_pythonpath: str,
+        envdrift_cmd: list[str],
+    ) -> None:
+        """BP-19: pulling --env production a secret stored as STAGING fails fast."""
+        secret_name = "envdrift-test/pull-env-mismatch"
+        aws_secrets_client.create_secret(
+            Name=secret_name,
+            SecretString="DOTENV_PRIVATE_KEY_STAGING=staging-secret-val",
+        )
+
+        env = aws_test_env.copy()
+        env["PYTHONPATH"] = integration_pythonpath
+
+        try:
+            result = subprocess.run(
+                [
+                    *envdrift_cmd,
+                    "vault-pull",
+                    str(work_dir),
+                    secret_name,
+                    "--env",
+                    "production",
+                    "--no-decrypt",
+                    "--provider",
+                    "aws",
+                    "--region",
+                    "us-east-1",
+                ],
+                cwd=work_dir,
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+
+            assert result.returncode == 1, (
+                f"expected fast-fail exit 1\nstdout: {result.stdout}\nstderr: {result.stderr}"
+            )
+            combined = result.stdout + result.stderr
+            assert "DOTENV_PRIVATE_KEY_STAGING" in combined
+            assert "DOTENV_PRIVATE_KEY_PRODUCTION" in combined
+
+            # .env.keys must not have been written with the production key.
+            keys_path = work_dir / ".env.keys"
+            if keys_path.exists():
+                assert "DOTENV_PRIVATE_KEY_PRODUCTION" not in keys_path.read_text()
+        finally:
+            _force_delete(aws_secrets_client, secret_name)
+
+    def test_vault_pull_no_decrypt_writes_key_only(
+        self,
+        work_dir: Path,
+        aws_test_env: dict[str, str],
+        aws_secrets_client,
+        integration_pythonpath: str,
+        envdrift_cmd: list[str],
+    ) -> None:
+        """EC-18 + DOC-no-decrypt: --no-decrypt writes only .env.keys, file untouched."""
+        if not _dotenvx_available():
+            pytest.skip("dotenvx binary not available")
+
+        secret_name = "envdrift-test/pull-no-decrypt"
+        # Build a real encrypted .env.production and capture its bytes.
+        real_key = _make_encrypted_project(work_dir, "production")
+        env_prod = work_dir / ".env.production"
+        original_encrypted = env_prod.read_bytes()
+        assert b"encrypted:" in original_encrypted
+
+        # The value we actually pull is independent of the real key; we only
+        # assert the key is written and the encrypted file stays byte-identical.
+        aws_secrets_client.create_secret(
+            Name=secret_name,
+            SecretString=f"DOTENV_PRIVATE_KEY_PRODUCTION={real_key}",
+        )
+
+        env = aws_test_env.copy()
+        env["PYTHONPATH"] = integration_pythonpath
+
+        try:
+            result = subprocess.run(
+                [
+                    *envdrift_cmd,
+                    "vault-pull",
+                    str(work_dir),
+                    secret_name,
+                    "--env",
+                    "production",
+                    "--no-decrypt",
+                    "--provider",
+                    "aws",
+                    "--region",
+                    "us-east-1",
+                ],
+                cwd=work_dir,
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+            assert result.returncode == 0, f"stdout: {result.stdout}\nstderr: {result.stderr}"
+
+            keys_content = (work_dir / ".env.keys").read_text()
+            assert f"DOTENV_PRIVATE_KEY_PRODUCTION={real_key}" in keys_content
+
+            # The encrypted env file must be byte-for-byte unchanged.
+            assert env_prod.read_bytes() == original_encrypted
+            assert b"encrypted:" in env_prod.read_bytes()
+            assert "decrypt" not in result.stdout.lower() or "no" in result.stdout.lower()
+        finally:
+            _force_delete(aws_secrets_client, secret_name)
+
+    def test_sync_check_decryption_real_dotenvx_roundtrip(
+        self,
+        work_dir: Path,
+        aws_test_env: dict[str, str],
+        aws_secrets_client,
+        integration_pythonpath: str,
+        envdrift_cmd: list[str],
+    ) -> None:
+        """HP-12: sync --check-decryption runs a real dotenvx decrypt+re-encrypt."""
+        if not _dotenvx_available():
+            pytest.skip("dotenvx binary not available")
+
+        secret_name = "envdrift-test/check-decryption"
+        # Real encrypted file + the matching real private key.
+        real_key = _make_encrypted_project(work_dir, "production")
+        env_prod = work_dir / ".env.production"
+        assert b"encrypted:" in env_prod.read_bytes()
+
+        aws_secrets_client.create_secret(
+            Name=secret_name,
+            SecretString=f"DOTENV_PRIVATE_KEY_PRODUCTION={real_key}",
+        )
+
+        config_content = f"""\
+[encryption]
+backend = "dotenvx"
+
+[encryption.dotenvx]
+auto_install = true
+
+[vault]
+provider = "aws"
+region = "us-east-1"
+
+[vault.sync]
+
+[[vault.sync.mappings]]
+secret_name = "{secret_name}"
+folder_path = "."
+environment = "production"
+"""
+        (work_dir / "envdrift.toml").write_text(config_content)
+
+        env = aws_test_env.copy()
+        env["PYTHONPATH"] = integration_pythonpath
+
+        try:
+            result = subprocess.run(
+                [*envdrift_cmd, "sync", "--check-decryption"],
+                cwd=work_dir,
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=120,
+            )
+            assert result.returncode == 0, f"stdout: {result.stdout}\nstderr: {result.stderr}"
+
+            out = (result.stdout + result.stderr).lower()
+            assert "pass" in out, f"expected decryption PASSED\n{result.stdout}"
+
+            # The env file must be re-encrypted (left encrypted) afterward.
+            assert b"encrypted:" in env_prod.read_bytes()
+            # The key was synced locally.
+            keys_content = (work_dir / ".env.keys").read_text()
+            assert f"DOTENV_PRIVATE_KEY_PRODUCTION={real_key}" in keys_content
+        finally:
+            _force_delete(aws_secrets_client, secret_name)
+
+
+# --- Category B: Direct client JSON / binary decoding (P1/P2) ---
+
+
+class TestAWSClientValueDecoding:
+    """get_secret / set_secret value decoding against LocalStack."""
+
+    def test_set_secret_dict_stores_json_string(
+        self, aws_client_configured, aws_secrets_client
+    ) -> None:
+        """HP-09: set_secret_dict serializes a dict to a JSON string and stores it."""
+        import json
+
+        name = "envdrift-test/set-secret-dict"
+        value_dict = {"username": "admin", "password": "p@ss", "port": "5432"}
+
+        try:
+            result = aws_client_configured.set_secret_dict(name, value_dict)
+
+            assert result.name == name
+            assert result.value == json.dumps(value_dict)
+
+            raw = aws_secrets_client.get_secret_value(SecretId=name)["SecretString"]
+            assert json.loads(raw) == value_dict
+        finally:
+            _force_delete(aws_secrets_client, name)
+
+    def test_get_secret_parses_json_dict_returns_json_string(
+        self, aws_client_configured, aws_secrets_client
+    ) -> None:
+        """HP-03: a JSON-object secret is parsed and returned as canonical JSON."""
+        import json
+
+        name = "envdrift-test/get-secret-json-dict"
+        aws_secrets_client.create_secret(Name=name, SecretString=json.dumps({"a": "1", "b": "2"}))
+
+        try:
+            secret = aws_client_configured.get_secret(name)
+            assert json.loads(secret.value) == {"a": "1", "b": "2"}
+            assert secret.version is not None
+            assert secret.metadata.get("arn")
+        finally:
+            _force_delete(aws_secrets_client, name)
+
+    def test_get_secret_utf8_binary_decodes(
+        self, aws_client_configured, aws_secrets_client
+    ) -> None:
+        """HP-04: SecretBinary holding valid UTF-8 bytes decodes to the original string."""
+        name = "envdrift-test/get-secret-utf8-binary"
+        raw = "hello-utf8-é".encode()
+        aws_secrets_client.create_secret(Name=name, SecretBinary=raw)
+
+        try:
+            secret = aws_client_configured.get_secret(name)
+            assert secret.value == "hello-utf8-é"
+        finally:
+            _force_delete(aws_secrets_client, name)
+
+    def test_get_secret_invalid_json_returns_raw_string(
+        self, aws_client_configured, aws_secrets_client
+    ) -> None:
+        """EC-02: a non-JSON secret value is returned verbatim."""
+        name = "envdrift-test/get-secret-invalid-json"
+        aws_secrets_client.create_secret(Name=name, SecretString="not-json: {broken")
+
+        try:
+            secret = aws_client_configured.get_secret(name)
+            assert secret.value == "not-json: {broken"
+        finally:
+            _force_delete(aws_secrets_client, name)
+
+
+# --- Category B: SyncEngine driven directly against LocalStack (P1) ---
+
+
+class TestAWSSyncEngineRealBackend:
+    """Drive the SyncEngine directly against a live LocalStack vault client."""
+
+    @staticmethod
+    def _build_engine(work_dir: Path, aws_client_configured, secret_name: str, mode):
+        from envdrift.sync.config import ServiceMapping, SyncConfig
+        from envdrift.sync.engine import SyncEngine
+
+        config = SyncConfig(
+            mappings=[
+                ServiceMapping(
+                    secret_name=secret_name,
+                    folder_path=work_dir,
+                    environment="production",
+                )
+            ]
+        )
+        return SyncEngine(config=config, vault_client=aws_client_configured, mode=mode)
+
+    def test_force_update_mismatch_creates_backup_via_real_vault(
+        self, work_dir: Path, aws_client_configured, aws_secrets_client
+    ) -> None:
+        """HP-03 (sync): force_update on a mismatch backs up and rewrites .env.keys."""
+        from envdrift.sync.engine import SyncMode
+        from envdrift.sync.result import SyncAction
+
+        secret_name = "envdrift-test/force-update-backup"
+        aws_secrets_client.create_secret(
+            Name=secret_name,
+            SecretString="DOTENV_PRIVATE_KEY_PRODUCTION=vault-new-value",
+        )
+
+        # Local file holds an OLD, different value + an env file so the mapping resolves.
+        (work_dir / ".env.production").write_text(
+            'DOTENV_PUBLIC_KEY_PRODUCTION="pub"\nSECRET="encrypted:abc"\n'
+        )
+        keys_path = work_dir / ".env.keys"
+        keys_path.write_text("# .env.production\nDOTENV_PRIVATE_KEY_PRODUCTION=local-old-value\n")
+
+        try:
+            engine = self._build_engine(
+                work_dir,
+                aws_client_configured,
+                secret_name,
+                SyncMode(force_update=True),
+            )
+            result = engine.sync_all()
+            svc = result.services[0]
+
+            assert svc.action == SyncAction.UPDATED
+            assert svc.backup_path is not None
+            assert svc.backup_path.exists()
+            assert "local-old-value" in svc.backup_path.read_text()
+
+            assert "DOTENV_PRIVATE_KEY_PRODUCTION=vault-new-value" in keys_path.read_text()
+        finally:
+            _force_delete(aws_secrets_client, secret_name)
+
+    def test_ephemeral_mode_fetches_key_from_real_container_vault(
+        self, work_dir: Path, aws_client_configured, aws_secrets_client
+    ) -> None:
+        """HP-05 (sync): ephemeral mode fetches the key without writing .env.keys."""
+        from envdrift.sync.config import ServiceMapping, SyncConfig
+        from envdrift.sync.engine import SyncEngine, SyncMode
+        from envdrift.sync.result import SyncAction
+
+        secret_name = "envdrift-test/ephemeral-key"
+        aws_secrets_client.create_secret(
+            Name=secret_name,
+            SecretString="DOTENV_PRIVATE_KEY_PRODUCTION=eph-real-key",
+        )
+        (work_dir / ".env.production").write_text(
+            'DOTENV_PUBLIC_KEY_PRODUCTION="pub"\nSECRET="encrypted:abc"\n'
+        )
+
+        config = SyncConfig(
+            mappings=[
+                ServiceMapping(
+                    secret_name=secret_name,
+                    folder_path=work_dir,
+                    environment="production",
+                )
+            ],
+            ephemeral_keys=True,
+        )
+        engine = SyncEngine(config=config, vault_client=aws_client_configured, mode=SyncMode())
+
+        try:
+            result = engine.sync_all()
+            svc = result.services[0]
+
+            assert svc.action == SyncAction.EPHEMERAL
+            # Prefix stripped to the bare value.
+            assert svc.vault_key_value == "eph-real-key"
+            assert not (work_dir / ".env.keys").exists()
+            assert result.ephemeral_count == 1
+        finally:
+            _force_delete(aws_secrets_client, secret_name)
+
+    def test_verify_ci_key_mismatch_drift_gate_exits_nonzero(
+        self, work_dir: Path, aws_client_configured, aws_secrets_client
+    ) -> None:
+        """BP-14 (sync): verify_only surfaces a local-vs-vault mismatch (CI gate)."""
+        from envdrift.sync.engine import SyncMode
+        from envdrift.sync.result import SyncAction
+
+        secret_name = "envdrift-test/verify-drift-gate"
+        aws_secrets_client.create_secret(
+            Name=secret_name,
+            SecretString="DOTENV_PRIVATE_KEY_PRODUCTION=vault-value-A",
+        )
+        (work_dir / ".env.production").write_text(
+            'DOTENV_PUBLIC_KEY_PRODUCTION="pub"\nSECRET="encrypted:abc"\n'
+        )
+        keys_path = work_dir / ".env.keys"
+        original_keys = "# .env.production\nDOTENV_PRIVATE_KEY_PRODUCTION=local-value-B\n"
+        keys_path.write_text(original_keys)
+
+        try:
+            engine = self._build_engine(
+                work_dir,
+                aws_client_configured,
+                secret_name,
+                SyncMode(verify_only=True),
+            )
+            result = engine.sync_all()
+            svc = result.services[0]
+
+            assert svc.action == SyncAction.ERROR
+            mismatch_msg = f"{svc.message} {svc.error}"
+            assert "mismatch" in mismatch_msg.lower() or "differs" in mismatch_msg.lower()
+            assert result.has_errors is True
+
+            # verify_only must not mutate the local file.
+            assert keys_path.read_text() == original_keys
+        finally:
+            _force_delete(aws_secrets_client, secret_name)

--- a/tests/integration/test_azure_integration.py
+++ b/tests/integration/test_azure_integration.py
@@ -411,3 +411,526 @@ class TestAzureVaultPull:
                     f"{endpoint}/secrets/{secret_name}",
                     params={"api-version": "7.4"},
                 )
+
+
+# ---------------------------------------------------------------------------
+# Additional coverage: vault-push / vault-pull CLI behaviour and the real
+# Azure vault factory / client.  Authored from the test_azure_integration.py
+# package plan.  All tests are GREEN-OR-GATED:
+#   * path/argument validation tests fail fast inside the CLI (before any
+#     vault auth) and are deterministic PASS on this machine and in CI;
+#   * round-trip tests talk to the live Lowkey emulator and SKIP visibly when
+#     DefaultAzureCredential cannot authenticate against it.
+# Secret names are prefixed with the test name so concurrent / repeat runs
+# never collide, and every seeded secret is REST-deleted in a finally block.
+# ---------------------------------------------------------------------------
+
+
+def _run_cli(
+    envdrift_cmd: list[str],
+    args: list[str],
+    *,
+    cwd: Path,
+    env: dict[str, str],
+    integration_pythonpath: str,
+) -> subprocess.CompletedProcess[str]:
+    """Run the real envdrift console-script and return the completed process.
+
+    Uses the installed console entrypoint (``envdrift_cmd``) rather than
+    ``python -m envdrift`` because there is no ``envdrift.__main__`` and the
+    package cannot be executed directly.
+    """
+    run_env = env.copy()
+    run_env["PYTHONPATH"] = integration_pythonpath
+    # Lowkey Vault uses self-signed certs.
+    run_env["CURL_CA_BUNDLE"] = ""
+    run_env["REQUESTS_CA_BUNDLE"] = ""
+    return subprocess.run(
+        [*envdrift_cmd, *args],
+        cwd=cwd,
+        env=run_env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+
+def _assert_dispatched(combined: str) -> None:
+    """Fail loudly if the CLI never dispatched (import/packaging error)."""
+    assert "No module named" not in combined, combined
+    assert "is a package and cannot be directly executed" not in combined, combined
+
+
+def _seed_secret(session, endpoint: str, name: str, value: str) -> None:
+    """Seed a secret directly via the Lowkey REST API or skip on failure."""
+    put = session.put(
+        f"{endpoint}/secrets/{name}",
+        json={"value": value},
+        headers={"Content-Type": "application/json"},
+        params={"api-version": "7.4"},
+    )
+    if put.status_code not in (200, 201):
+        pytest.skip(f"Lowkey Vault returned {put.status_code} on seed of {name}")
+
+
+def _delete_secret(session, endpoint: str, name: str) -> None:
+    """Best-effort REST cleanup of a seeded secret."""
+    with contextlib.suppress(Exception):
+        session.delete(
+            f"{endpoint}/secrets/{name}",
+            params={"api-version": "7.4"},
+        )
+
+
+def _looks_like_auth_failure(combined: str) -> bool:
+    """Heuristic: did the command get to the vault and fail to authenticate?"""
+    low = combined.lower()
+    return "credential" in low or "vault" in low or "authentication" in low
+
+
+# --- CLI argument / path validation (deterministic, no vault auth) ---------
+
+
+class TestAzureVaultArgValidation:
+    """vault-push / vault-pull guard clauses that exit before any vault call."""
+
+    def test_vault_push_missing_provider_exits_1(
+        self,
+        work_dir: Path,
+        azure_test_env: dict,
+        integration_pythonpath: str,
+        envdrift_cmd: list[str],
+    ):
+        """BP-09: single-service push with no --provider and no config exits 1."""
+        env_keys = work_dir / ".env.keys"
+        env_keys.write_text("DOTENV_PRIVATE_KEY_PRODUCTION=somekey\n")
+
+        result = _run_cli(
+            envdrift_cmd,
+            [
+                "vault-push",
+                str(work_dir),
+                "test_vault_push_missing_provider_exits_1",
+                "--env",
+                "production",
+            ],
+            cwd=work_dir,
+            env=azure_test_env,
+            integration_pythonpath=integration_pythonpath,
+        )
+        combined = result.stdout + result.stderr
+        _assert_dispatched(combined)
+        assert result.returncode == 1, combined
+        assert "Vault provider required" in combined, combined
+
+    def test_vault_push_azure_missing_vault_url_exits_1(
+        self,
+        work_dir: Path,
+        azure_test_env: dict,
+        integration_pythonpath: str,
+        envdrift_cmd: list[str],
+    ):
+        """BP-08: -p azure without --vault-url and no config exits 1."""
+        env_keys = work_dir / ".env.keys"
+        env_keys.write_text("DOTENV_PRIVATE_KEY_PRODUCTION=somekey\n")
+
+        # azure_test_env sets AZURE_KEYVAULT_URL but the CLI only reads --vault-url
+        # / config for the *effective* vault url, so this still trips the guard.
+        result = _run_cli(
+            envdrift_cmd,
+            [
+                "vault-push",
+                str(work_dir),
+                "test_vault_push_azure_missing_vault_url_exits_1",
+                "--env",
+                "production",
+                "-p",
+                "azure",
+            ],
+            cwd=work_dir,
+            env=azure_test_env,
+            integration_pythonpath=integration_pythonpath,
+        )
+        combined = result.stdout + result.stderr
+        _assert_dispatched(combined)
+        assert result.returncode == 1, combined
+        assert "--vault-url required for azure" in combined, combined
+
+
+# --- Real Azure vault factory / client behaviour (no creds needed) ---------
+
+
+class TestAzureVaultFactory:
+    """The real get_vault_client factory and AzureKeyVaultClient.authenticate()."""
+
+    def test_get_vault_client_azure_without_vault_url_raises_value_error(self):
+        """BP-17: get_vault_client('azure') with no vault_url raises ValueError."""
+        pytest.importorskip("azure.keyvault.secrets")
+
+        from envdrift.vault import get_vault_client
+
+        with pytest.raises(ValueError, match="vault_url"):
+            get_vault_client("azure")
+
+    def test_authenticate_no_credentials_raises_authentication_error(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """BP-02: authenticate() with all Azure creds scrubbed surfaces an envdrift VaultError.
+
+        The raw azure.core ClientAuthenticationError must be mapped into envdrift's
+        VaultError hierarchy (AuthenticationError preferred) and never escape raw.
+        """
+        pytest.importorskip("azure.keyvault.secrets")
+
+        from envdrift.vault.azure import AzureKeyVaultClient
+        from envdrift.vault.base import AuthenticationError, VaultError
+
+        # Scrub every credential DefaultAzureCredential could pick up so that
+        # acquiring a token must fail. (monkeypatch on env vars only — the
+        # behaviour under test, the SDK auth + error mapping, stays real.)
+        for var in (
+            "AZURE_CLIENT_ID",
+            "AZURE_CLIENT_SECRET",
+            "AZURE_TENANT_ID",
+            "AZURE_CLIENT_CERTIFICATE_PATH",
+            "AZURE_USERNAME",
+            "AZURE_PASSWORD",
+            "MSI_ENDPOINT",
+            "IDENTITY_ENDPOINT",
+            "AZURE_FEDERATED_TOKEN_FILE",
+        ):
+            monkeypatch.delenv(var, raising=False)
+        # Force the managed-identity / IMDS and CLI probes to fail fast.
+        monkeypatch.setenv("AZURE_TOKEN_CREDENTIALS", "dev")
+        monkeypatch.setenv("MSI_ENDPOINT", "http://127.0.0.1:1/nope")
+        monkeypatch.setenv("PATH", "")
+
+        client = AzureKeyVaultClient(vault_url="https://nonexistent-vault.vault.azure.net/")
+        try:
+            with pytest.raises((AuthenticationError, VaultError)) as exc_info:
+                client.authenticate()
+        except Exception:  # pragma: no cover - environment-dependent
+            # If the local environment somehow has ambient Azure credentials
+            # (CI runners shouldn't), don't hard-fail the suite.
+            pytest.skip("Ambient Azure credentials available; cannot test auth failure")
+        # The raised exception must be an envdrift VaultError subclass, not a
+        # raw azure.core exception leaking through.
+        assert isinstance(exc_info.value, VaultError), exc_info.value
+
+
+# --- Round-trip against the live Lowkey emulator (GREEN-OR-GATED) ----------
+
+
+class TestAzureVaultRoundTrip:
+    """vault-push / vault-pull against the live Lowkey Vault emulator."""
+
+    def test_vault_push_single_service_round_trip_real_backend(
+        self,
+        lowkey_vault_endpoint: str,
+        azure_test_env: dict,
+        lowkey_vault_client,
+        work_dir: Path,
+        integration_pythonpath: str,
+        envdrift_cmd: list[str],
+    ):
+        """HP-06: single-service push reads .env.keys and set_secret against Lowkey."""
+        session, endpoint = lowkey_vault_client
+        secret_name = "test-push-single-roundtrip"
+
+        env_keys = work_dir / ".env.keys"
+        env_keys.write_text(
+            "#/ DOTENV_PRIVATE_KEYS /\n"
+            "# .env.production\n"
+            "DOTENV_PRIVATE_KEY_PRODUCTION=prodkey-xyz\n"
+        )
+
+        try:
+            result = _run_cli(
+                envdrift_cmd,
+                [
+                    "vault-push",
+                    str(work_dir),
+                    secret_name,
+                    "--env",
+                    "production",
+                    "-p",
+                    "azure",
+                    "--vault-url",
+                    lowkey_vault_endpoint,
+                ],
+                cwd=work_dir,
+                env=azure_test_env,
+                integration_pythonpath=integration_pythonpath,
+            )
+            combined = result.stdout + result.stderr
+            _assert_dispatched(combined)
+
+            if result.returncode == 0:
+                assert "Pushed" in combined, combined
+                # REST-verify the stored value round-tripped verbatim.
+                resp = session.get(
+                    f"{endpoint}/secrets/{secret_name}",
+                    params={"api-version": "7.4"},
+                )
+                assert resp.status_code == 200, resp.text
+                assert resp.json().get("value") == "DOTENV_PRIVATE_KEY_PRODUCTION=prodkey-xyz"
+            else:
+                assert _looks_like_auth_failure(combined), combined
+                pytest.skip(f"vault-push could not authenticate against Lowkey: {combined[:200]}")
+        finally:
+            _delete_secret(session, endpoint, secret_name)
+
+    def test_vault_push_direct_round_trip_real_backend(
+        self,
+        lowkey_vault_endpoint: str,
+        azure_test_env: dict,
+        lowkey_vault_client,
+        work_dir: Path,
+        integration_pythonpath: str,
+        envdrift_cmd: list[str],
+    ):
+        """HP-07: vault-push --direct stores a raw key=value verbatim in Lowkey."""
+        session, endpoint = lowkey_vault_client
+        secret_name = "test-direct-roundtrip"
+        raw_value = "DOTENV_PRIVATE_KEY_SOAK=abc123"
+
+        try:
+            result = _run_cli(
+                envdrift_cmd,
+                [
+                    "vault-push",
+                    "--direct",
+                    secret_name,
+                    raw_value,
+                    "-p",
+                    "azure",
+                    "--vault-url",
+                    lowkey_vault_endpoint,
+                ],
+                cwd=work_dir,
+                env=azure_test_env,
+                integration_pythonpath=integration_pythonpath,
+            )
+            combined = result.stdout + result.stderr
+            _assert_dispatched(combined)
+
+            if result.returncode == 0:
+                assert "Pushed" in combined, combined
+                resp = session.get(
+                    f"{endpoint}/secrets/{secret_name}",
+                    params={"api-version": "7.4"},
+                )
+                assert resp.status_code == 200, resp.text
+                assert resp.json().get("value") == raw_value
+            else:
+                assert _looks_like_auth_failure(combined), combined
+                pytest.skip(
+                    f"vault-push --direct could not authenticate against Lowkey: {combined[:200]}"
+                )
+        finally:
+            _delete_secret(session, endpoint, secret_name)
+
+    def test_vault_pull_no_decrypt_writes_key_only_real_backend(
+        self,
+        lowkey_vault_endpoint: str,
+        azure_test_env: dict,
+        lowkey_vault_client,
+        work_dir: Path,
+        integration_pythonpath: str,
+        envdrift_cmd: list[str],
+    ):
+        """HP-09: vault-pull --no-decrypt writes only .env.keys, never .env.production."""
+        session, endpoint = lowkey_vault_client
+        secret_name = "test-pull-nodecrypt-keyonly"
+        _seed_secret(
+            session,
+            endpoint,
+            secret_name,
+            "DOTENV_PRIVATE_KEY_PRODUCTION=pulledkey123",
+        )
+
+        try:
+            result = _run_cli(
+                envdrift_cmd,
+                [
+                    "vault-pull",
+                    str(work_dir),
+                    secret_name,
+                    "--env",
+                    "production",
+                    "--no-decrypt",
+                    "-p",
+                    "azure",
+                    "--vault-url",
+                    lowkey_vault_endpoint,
+                ],
+                cwd=work_dir,
+                env=azure_test_env,
+                integration_pythonpath=integration_pythonpath,
+            )
+            combined = result.stdout + result.stderr
+            _assert_dispatched(combined)
+
+            if result.returncode == 0:
+                keys_content = (work_dir / ".env.keys").read_text()
+                assert "DOTENV_PRIVATE_KEY_PRODUCTION=pulledkey123" in keys_content
+                # --no-decrypt must never touch the .env.production file.
+                assert not (work_dir / ".env.production").exists()
+            else:
+                assert _looks_like_auth_failure(combined), combined
+                pytest.skip(f"vault-pull could not authenticate against Lowkey: {combined[:200]}")
+        finally:
+            _delete_secret(session, endpoint, secret_name)
+
+    def test_vault_pull_accepts_bare_value_real_round_trip(
+        self,
+        lowkey_vault_endpoint: str,
+        azure_test_env: dict,
+        lowkey_vault_client,
+        work_dir: Path,
+        integration_pythonpath: str,
+        envdrift_cmd: list[str],
+    ):
+        """HP-17: bare value (no KEY= prefix) written under DOTENV_PRIVATE_KEY_PRODUCTION."""
+        session, endpoint = lowkey_vault_client
+        secret_name = "test-pull-bare-value"
+        # Stored WITHOUT a DOTENV_PRIVATE_KEY_ prefix -> taken verbatim as the value.
+        _seed_secret(session, endpoint, secret_name, "barekeyvalue123")
+
+        try:
+            result = _run_cli(
+                envdrift_cmd,
+                [
+                    "vault-pull",
+                    str(work_dir),
+                    secret_name,
+                    "--env",
+                    "production",
+                    "--no-decrypt",
+                    "-p",
+                    "azure",
+                    "--vault-url",
+                    lowkey_vault_endpoint,
+                ],
+                cwd=work_dir,
+                env=azure_test_env,
+                integration_pythonpath=integration_pythonpath,
+            )
+            combined = result.stdout + result.stderr
+            _assert_dispatched(combined)
+
+            if result.returncode == 0:
+                keys_content = (work_dir / ".env.keys").read_text()
+                assert "DOTENV_PRIVATE_KEY_PRODUCTION=barekeyvalue123" in keys_content
+            else:
+                assert _looks_like_auth_failure(combined), combined
+                pytest.skip(f"vault-pull could not authenticate against Lowkey: {combined[:200]}")
+        finally:
+            _delete_secret(session, endpoint, secret_name)
+
+    def test_vault_pull_value_with_equals_split_first_only_real_round_trip(
+        self,
+        lowkey_vault_endpoint: str,
+        azure_test_env: dict,
+        lowkey_vault_client,
+        work_dir: Path,
+        integration_pythonpath: str,
+        envdrift_cmd: list[str],
+    ):
+        """EC-08: 'DOTENV_PRIVATE_KEY_PRODUCTION=YWJj==/def==' split on the FIRST '=' only."""
+        session, endpoint = lowkey_vault_client
+        secret_name = "test-pull-equals-split"
+        # The value itself contains '=' characters; only the first one separates
+        # the key name from the value.
+        _seed_secret(
+            session,
+            endpoint,
+            secret_name,
+            "DOTENV_PRIVATE_KEY_PRODUCTION=YWJj==/def==",
+        )
+
+        try:
+            result = _run_cli(
+                envdrift_cmd,
+                [
+                    "vault-pull",
+                    str(work_dir),
+                    secret_name,
+                    "--env",
+                    "production",
+                    "--no-decrypt",
+                    "-p",
+                    "azure",
+                    "--vault-url",
+                    lowkey_vault_endpoint,
+                ],
+                cwd=work_dir,
+                env=azure_test_env,
+                integration_pythonpath=integration_pythonpath,
+            )
+            combined = result.stdout + result.stderr
+            _assert_dispatched(combined)
+
+            if result.returncode == 0:
+                keys_content = (work_dir / ".env.keys").read_text()
+                assert "DOTENV_PRIVATE_KEY_PRODUCTION=YWJj==/def==" in keys_content, keys_content
+            else:
+                assert _looks_like_auth_failure(combined), combined
+                pytest.skip(f"vault-pull could not authenticate against Lowkey: {combined[:200]}")
+        finally:
+            _delete_secret(session, endpoint, secret_name)
+
+    def test_vault_pull_env_prefix_mismatch_exits_1_real_backend(
+        self,
+        lowkey_vault_endpoint: str,
+        azure_test_env: dict,
+        lowkey_vault_client,
+        work_dir: Path,
+        integration_pythonpath: str,
+        envdrift_cmd: list[str],
+    ):
+        """BP-14: secret stored as STAGING but pulled --env production trips the mismatch guard."""
+        session, endpoint = lowkey_vault_client
+        secret_name = "test-pull-prefix-mismatch"
+        _seed_secret(
+            session,
+            endpoint,
+            secret_name,
+            "DOTENV_PRIVATE_KEY_STAGING=stagingkey",
+        )
+
+        try:
+            result = _run_cli(
+                envdrift_cmd,
+                [
+                    "vault-pull",
+                    str(work_dir),
+                    secret_name,
+                    "--env",
+                    "production",
+                    "--no-decrypt",
+                    "-p",
+                    "azure",
+                    "--vault-url",
+                    lowkey_vault_endpoint,
+                ],
+                cwd=work_dir,
+                env=azure_test_env,
+                integration_pythonpath=integration_pythonpath,
+            )
+            combined = result.stdout + result.stderr
+            _assert_dispatched(combined)
+
+            if result.returncode == 1 and "expects" in combined:
+                # The mismatch guard fired: it names the expected production key.
+                assert "DOTENV_PRIVATE_KEY_PRODUCTION" in combined, combined
+                # And it must NOT have written the staging key under production.
+                if (work_dir / ".env.keys").exists():
+                    assert "stagingkey" not in (work_dir / ".env.keys").read_text()
+            elif _looks_like_auth_failure(combined):
+                pytest.skip(f"vault-pull could not authenticate against Lowkey: {combined[:200]}")
+            else:
+                pytest.fail(f"Unexpected vault-pull result: rc={result.returncode}\n{combined}")
+        finally:
+            _delete_secret(session, endpoint, secret_name)

--- a/tests/integration/test_azure_integration.py
+++ b/tests/integration/test_azure_integration.py
@@ -483,9 +483,30 @@ def _delete_secret(session, endpoint: str, name: str) -> None:
 
 
 def _looks_like_auth_failure(combined: str) -> bool:
-    """Heuristic: did the command get to the vault and fail to authenticate?"""
+    """Heuristic: did the command fail specifically because of AUTHENTICATION?
+
+    Matches concrete auth signatures only. A blanket ``"vault"`` match would also
+    swallow non-auth regressions (``--vault-url`` handling bugs, Lowkey 4xx/5xx,
+    generic CLI errors that merely mention the vault), turning real failures into
+    skips. Keep this to explicit authentication signals.
+    """
     low = combined.lower()
-    return "credential" in low or "vault" in low or "authentication" in low
+    auth_signatures = (
+        "authentication failed",
+        "failed to authenticate",
+        "could not authenticate",
+        "unable to authenticate",
+        "authenticationerror",
+        "invalid credential",
+        "credential",
+        "defaultazurecredential",
+        "unauthorized",
+        "access denied",
+        "forbidden",
+        " 401",
+        " 403",
+    )
+    return any(sig in low for sig in auth_signatures)
 
 
 # --- CLI argument / path validation (deterministic, no vault auth) ---------
@@ -583,8 +604,10 @@ class TestAzureVaultFactory:
         """
         pytest.importorskip("azure.keyvault.secrets")
 
+        from azure.core.exceptions import ServiceRequestError, ServiceResponseError
+
         from envdrift.vault.azure import AzureKeyVaultClient
-        from envdrift.vault.base import AuthenticationError, VaultError
+        from envdrift.vault.base import VaultError
 
         # Scrub every credential DefaultAzureCredential could pick up so that
         # acquiring a token must fail. (monkeypatch on env vars only — the
@@ -607,16 +630,24 @@ class TestAzureVaultFactory:
         monkeypatch.setenv("PATH", "")
 
         client = AzureKeyVaultClient(vault_url="https://nonexistent-vault.vault.azure.net/")
+        # The raw azure.core ClientAuthenticationError must be mapped into envdrift's
+        # VaultError hierarchy. Catch ONLY VaultError so a leaked raw azure exception
+        # propagates and FAILS this test (that is exactly the regression being
+        # guarded). Skip only when authenticate() unexpectedly SUCCEEDS, which means
+        # ambient Azure credentials are present (CI runners shouldn't have any).
         try:
-            with pytest.raises((AuthenticationError, VaultError)) as exc_info:
-                client.authenticate()
-        except Exception:  # pragma: no cover - environment-dependent
-            # If the local environment somehow has ambient Azure credentials
-            # (CI runners shouldn't), don't hard-fail the suite.
-            pytest.skip("Ambient Azure credentials available; cannot test auth failure")
-        # The raised exception must be an envdrift VaultError subclass, not a
-        # raw azure.core exception leaking through.
-        assert isinstance(exc_info.value, VaultError), exc_info.value
+            client.authenticate()
+        except VaultError:
+            pass  # correct: the azure auth error was mapped into the VaultError hierarchy
+        except (ServiceRequestError, ServiceResponseError):
+            # Ambient Azure credentials (CI runners shouldn't have any) let auth
+            # proceed to a network call against the unreachable test host. That is a
+            # transport failure, not the auth-error-mapping regression under test, so
+            # we can't exercise it here. A raw ClientAuthenticationError (the actual
+            # regression) is NOT caught here and will correctly FAIL the test.
+            pytest.skip("Ambient Azure credentials present; auth reached a network call")
+        else:
+            pytest.skip("authenticate() unexpectedly succeeded (ambient Azure credentials)")
 
 
 # --- Round-trip against the live Lowkey emulator (GREEN-OR-GATED) ----------

--- a/tests/integration/test_cli_e2e.py
+++ b/tests/integration/test_cli_e2e.py
@@ -1,0 +1,360 @@
+"""End-to-end CLI integration tests for the real envdrift CLI subprocess.
+
+These tests drive the real ``envdrift`` CLI as a subprocess (via the
+``envdrift_cmd`` fixture). No mocking of behavior under test is used — the only
+environment manipulation is redirecting ``HOME``/``USERPROFILE`` to a temp dir
+so the agent project registry at ``~/.envdrift/projects.json`` is fully isolated
+per test (and concurrent/repeat runs never collide).
+
+No container is required for this module — it exercises the pure-CLI agent
+registry surface: ``agent register / unregister / list`` plus the registry's
+corruption-recovery and 0o600-permission guarantees, observed end-to-end through
+the CLI.
+
+Run from the repo root; the ``integration_pythonpath`` fixture makes the source
+tree importable for ``uv run`` fallbacks.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# Mark all tests in this module
+pytestmark = [pytest.mark.integration]
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+
+
+def _strip_ansi(text: str) -> str:
+    """Remove ANSI escape sequences from CLI output."""
+    return _ANSI_RE.sub("", text)
+
+
+def _base_env(integration_pythonpath: str, home_dir: Path) -> dict[str, str]:
+    """Build a subprocess env with HOME/USERPROFILE redirected and wide output.
+
+    ``COLUMNS`` is set wide so Rich does not truncate/wrap paths in tables or
+    panels (otherwise long temp paths get an ellipsis and assertions break).
+    """
+    env = os.environ.copy()
+    env["PYTHONPATH"] = integration_pythonpath
+    env["HOME"] = str(home_dir)
+    env["USERPROFILE"] = str(home_dir)
+    env["COLUMNS"] = "200"
+    return env
+
+
+def _registry_path(home_dir: Path) -> Path:
+    return home_dir / ".envdrift" / "projects.json"
+
+
+def _read_projects(home_dir: Path) -> list[dict]:
+    registry = _registry_path(home_dir)
+    if not registry.exists():
+        return []
+    return json.loads(registry.read_text(encoding="utf-8")).get("projects", [])
+
+
+def _run_agent(
+    envdrift_cmd: list[str],
+    env: dict[str, str],
+    *args: str,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [*envdrift_cmd, "agent", *args],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+
+class TestAgentRegistry:
+    """``envdrift agent`` registry lifecycle against an isolated HOME."""
+
+    def test_agent_register_adds_project_to_projects_json(
+        self,
+        work_dir: Path,
+        integration_pythonpath: str,
+        envdrift_cmd: list[str],
+        tmp_path: Path,
+    ):
+        """HP-16: register PATH writes the project into ~/.envdrift/projects.json."""
+        home_dir = tmp_path / "home"
+        home_dir.mkdir()
+        project_dir = work_dir / "myproject"
+        project_dir.mkdir()
+        env = _base_env(integration_pythonpath, home_dir)
+
+        result = _run_agent(envdrift_cmd, env, "register", str(project_dir))
+
+        assert result.returncode == 0, f"stderr={result.stderr}\nstdout={result.stdout}"
+        assert "Registered" in _strip_ansi(result.stdout)
+        assert _registry_path(home_dir).exists()
+
+        projects = _read_projects(home_dir)
+        assert len(projects) == 1
+        assert projects[0]["path"] == str(project_dir.resolve())
+
+    def test_agent_register_duplicate_warns_exit_zero(
+        self,
+        work_dir: Path,
+        integration_pythonpath: str,
+        envdrift_cmd: list[str],
+        tmp_path: Path,
+    ):
+        """EC-08: registering the same project twice warns and does not duplicate."""
+        home_dir = tmp_path / "home"
+        home_dir.mkdir()
+        project_dir = work_dir / "dupproject"
+        project_dir.mkdir()
+        env = _base_env(integration_pythonpath, home_dir)
+
+        first = _run_agent(envdrift_cmd, env, "register", str(project_dir))
+        assert first.returncode == 0, first.stderr
+
+        second = _run_agent(envdrift_cmd, env, "register", str(project_dir))
+        assert second.returncode == 0, second.stderr
+        assert "already registered" in _strip_ansi(second.stdout).lower()
+
+        assert len(_read_projects(home_dir)) == 1
+
+    def test_agent_register_nonexistent_path_exits_one(
+        self,
+        work_dir: Path,
+        integration_pythonpath: str,
+        envdrift_cmd: list[str],
+        tmp_path: Path,
+    ):
+        """BP-18: registering a nonexistent path exits 1 and adds nothing."""
+        home_dir = tmp_path / "home"
+        home_dir.mkdir()
+        missing = work_dir / "does_not_exist_here"
+        env = _base_env(integration_pythonpath, home_dir)
+
+        result = _run_agent(envdrift_cmd, env, "register", str(missing))
+
+        assert result.returncode == 1, f"stdout={result.stdout}\nstderr={result.stderr}"
+        combined = _strip_ansi(result.stdout + result.stderr).lower()
+        assert "does not exist" in combined
+        assert _read_projects(home_dir) == []
+
+    def test_agent_register_file_not_directory_exits_one(
+        self,
+        work_dir: Path,
+        integration_pythonpath: str,
+        envdrift_cmd: list[str],
+        tmp_path: Path,
+    ):
+        """BP-19: registering a file (not a directory) exits 1."""
+        home_dir = tmp_path / "home"
+        home_dir.mkdir()
+        a_file = work_dir / "afile.txt"
+        a_file.write_text("hello\n")
+        env = _base_env(integration_pythonpath, home_dir)
+
+        result = _run_agent(envdrift_cmd, env, "register", str(a_file))
+
+        assert result.returncode == 1, f"stdout={result.stdout}\nstderr={result.stderr}"
+        combined = _strip_ansi(result.stdout + result.stderr).lower()
+        assert "not a directory" in combined
+
+    def test_agent_register_invalid_toml_warns_exit_zero(
+        self,
+        work_dir: Path,
+        integration_pythonpath: str,
+        envdrift_cmd: list[str],
+        tmp_path: Path,
+    ):
+        """BP-20: a project with invalid envdrift.toml still registers (exit 0) with a warning."""
+        home_dir = tmp_path / "home"
+        home_dir.mkdir()
+        project_dir = work_dir / "badtomlproject"
+        project_dir.mkdir()
+        (project_dir / "envdrift.toml").write_text("this is not = valid toml [[[\n")
+        env = _base_env(integration_pythonpath, home_dir)
+
+        result = _run_agent(envdrift_cmd, env, "register", str(project_dir))
+
+        assert result.returncode == 0, f"stderr={result.stderr}\nstdout={result.stdout}"
+        assert "Failed to load envdrift config" in _strip_ansi(result.stdout)
+        # Despite the config-load failure, the project is still registered.
+        projects = _read_projects(home_dir)
+        assert len(projects) == 1
+        assert projects[0]["path"] == str(project_dir.resolve())
+
+    def test_agent_register_tilde_path_expands_home(
+        self,
+        work_dir: Path,
+        integration_pythonpath: str,
+        envdrift_cmd: list[str],
+        tmp_path: Path,
+    ):
+        """EC-07: a '~/...' path expands against the redirected HOME before registration."""
+        home_dir = tmp_path / "home"
+        home_dir.mkdir()
+        tilde_target = home_dir / "tildeproj"
+        tilde_target.mkdir()
+        env = _base_env(integration_pythonpath, home_dir)
+
+        result = _run_agent(envdrift_cmd, env, "register", "~/tildeproj")
+
+        assert result.returncode == 0, f"stderr={result.stderr}\nstdout={result.stdout}"
+        projects = _read_projects(home_dir)
+        assert len(projects) == 1
+        assert projects[0]["path"] == str(tilde_target.resolve())
+
+    def test_agent_unregister_removes_project(
+        self,
+        work_dir: Path,
+        integration_pythonpath: str,
+        envdrift_cmd: list[str],
+        tmp_path: Path,
+    ):
+        """HP-17: unregister removes a registered project."""
+        home_dir = tmp_path / "home"
+        home_dir.mkdir()
+        project_dir = work_dir / "toremove"
+        project_dir.mkdir()
+        env = _base_env(integration_pythonpath, home_dir)
+
+        reg = _run_agent(envdrift_cmd, env, "register", str(project_dir))
+        assert reg.returncode == 0, reg.stderr
+        assert len(_read_projects(home_dir)) == 1
+
+        unreg = _run_agent(envdrift_cmd, env, "unregister", str(project_dir))
+        assert unreg.returncode == 0, unreg.stderr
+        assert "Unregistered" in _strip_ansi(unreg.stdout)
+        assert _read_projects(home_dir) == []
+
+    def test_agent_unregister_not_registered_warns_exit_zero(
+        self,
+        work_dir: Path,
+        integration_pythonpath: str,
+        envdrift_cmd: list[str],
+        tmp_path: Path,
+    ):
+        """EC-09: unregistering a never-registered project exits 0 with a warning."""
+        home_dir = tmp_path / "home"
+        home_dir.mkdir()
+        project_dir = work_dir / "neverreg"
+        project_dir.mkdir()
+        env = _base_env(integration_pythonpath, home_dir)
+
+        result = _run_agent(envdrift_cmd, env, "unregister", str(project_dir))
+
+        assert result.returncode == 0, f"stderr={result.stderr}\nstdout={result.stdout}"
+        assert "not registered" in _strip_ansi(result.stdout).lower()
+
+    def test_agent_list_shows_registered_projects_table(
+        self,
+        work_dir: Path,
+        integration_pythonpath: str,
+        envdrift_cmd: list[str],
+        tmp_path: Path,
+    ):
+        """HP-18: list renders a table with registered project paths."""
+        home_dir = tmp_path / "home"
+        home_dir.mkdir()
+        env = _base_env(integration_pythonpath, home_dir)
+        alpha = work_dir / "alphaproj"
+        beta = work_dir / "betaproj"
+        for project in (alpha, beta):
+            project.mkdir()
+            reg = _run_agent(envdrift_cmd, env, "register", str(project))
+            assert reg.returncode == 0, reg.stderr
+
+        result = _run_agent(envdrift_cmd, env, "list")
+
+        assert result.returncode == 0, f"stderr={result.stderr}\nstdout={result.stdout}"
+        out = _strip_ansi(result.stdout)
+        assert "Registered Projects" in out
+        assert "Path" in out
+        assert "alphaproj" in out
+        assert "betaproj" in out
+        assert len(_read_projects(home_dir)) == 2
+
+    def test_agent_list_empty_shows_message(
+        self,
+        work_dir: Path,
+        integration_pythonpath: str,
+        envdrift_cmd: list[str],
+        tmp_path: Path,
+    ):
+        """EC-10: list with no registered projects prints the empty-state message."""
+        home_dir = tmp_path / "home"
+        home_dir.mkdir()
+        env = _base_env(integration_pythonpath, home_dir)
+
+        result = _run_agent(envdrift_cmd, env, "list")
+
+        assert result.returncode == 0, f"stderr={result.stderr}\nstdout={result.stdout}"
+        assert "No projects registered" in _strip_ansi(result.stdout)
+
+
+class TestRegistryDurability:
+    """Corruption recovery and 0o600 permissions, observed via the CLI."""
+
+    def test_registry_corrupt_json_starts_fresh_via_cli(
+        self,
+        work_dir: Path,
+        integration_pythonpath: str,
+        envdrift_cmd: list[str],
+        tmp_path: Path,
+    ):
+        """EC-13: a corrupt projects.json is treated as empty rather than crashing."""
+        home_dir = tmp_path / "home"
+        home_dir.mkdir()
+        env = _base_env(integration_pythonpath, home_dir)
+
+        registry = _registry_path(home_dir)
+        registry.parent.mkdir(parents=True, exist_ok=True)
+        registry.write_text("{ this is not valid json ]]]")
+
+        listed = _run_agent(envdrift_cmd, env, "list")
+        assert listed.returncode == 0, listed.stderr
+        assert "No projects registered" in _strip_ansi(listed.stdout)
+
+        project_dir = work_dir / "freshproj"
+        project_dir.mkdir()
+        reg = _run_agent(envdrift_cmd, env, "register", str(project_dir))
+        assert reg.returncode == 0, reg.stderr
+
+        projects = _read_projects(home_dir)
+        assert len(projects) == 1
+        assert projects[0]["path"] == str(project_dir.resolve())
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX file permissions")
+    def test_registry_save_creates_parent_dirs_and_0600_perms(
+        self,
+        work_dir: Path,
+        integration_pythonpath: str,
+        envdrift_cmd: list[str],
+        tmp_path: Path,
+    ):
+        """EC-14: first register creates ~/.envdrift and writes projects.json with 0o600."""
+        home_dir = tmp_path / "home"
+        home_dir.mkdir()
+        project_dir = work_dir / "permproj"
+        project_dir.mkdir()
+        env = _base_env(integration_pythonpath, home_dir)
+
+        result = _run_agent(envdrift_cmd, env, "register", str(project_dir))
+
+        assert result.returncode == 0, f"stderr={result.stderr}\nstdout={result.stdout}"
+        assert (home_dir / ".envdrift").is_dir()
+        registry = _registry_path(home_dir)
+        assert registry.exists()
+        mode = stat.S_IMODE(registry.stat().st_mode)
+        assert mode == 0o600, f"expected 0o600, got {oct(mode)}"
+        # Atomic tempfile+rename must leave no stray temp files behind.
+        leftovers = list((home_dir / ".envdrift").glob(".projects_*.json"))
+        assert leftovers == [], f"stray temp files: {leftovers}"

--- a/tests/integration/test_diff_cli.py
+++ b/tests/integration/test_diff_cli.py
@@ -1,0 +1,350 @@
+"""Diff CLI End-to-End Integration Tests.
+
+Real e2e coverage for ``envdrift diff`` over real ``.env`` files, exercising the
+JSON output contract, sensitive-value masking via ``--schema``, value
+normalization (whitespace / bool-alias / JSON-quote style), ``--strict`` raw
+compare, schema-driven type coercion, ``--include-unchanged`` and a handful of
+adversarial / unicode / duplicate-key edge cases.
+
+Every test runs the real CLI as a subprocess (``python -m envdrift.cli diff``)
+against files written to ``tmp_path`` — no mocks, no containers. ``sys.executable``
+is the project venv interpreter (with all deps), and ``PYTHONPATH`` points at the
+``src`` tree so the under-development package is imported.
+
+Requires: pydantic-settings installed (provided by the project venv).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+# Mark all tests in this module
+pytestmark = [pytest.mark.integration]
+
+
+# --- Local helpers (kept here so conftest.py is never modified) ---
+
+
+def _run_diff(
+    args: list[str],
+    cwd: Path,
+    integration_pythonpath: str,
+    timeout: float = 30.0,
+) -> subprocess.CompletedProcess[str]:
+    """Run ``envdrift diff`` as a real subprocess and return the completed process.
+
+    Mirrors the invocation style used by the other integration tests: the project
+    venv interpreter (``sys.executable``) with ``PYTHONPATH`` set to the ``src``
+    tree, so the real CLI and its dependencies are loaded.
+    """
+    env = {"PYTHONPATH": integration_pythonpath}
+    return subprocess.run(
+        [sys.executable, "-m", "envdrift.cli", "diff", *args],
+        cwd=str(cwd),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def _run_diff_json(
+    args: list[str],
+    cwd: Path,
+    integration_pythonpath: str,
+    timeout: float = 30.0,
+) -> tuple[subprocess.CompletedProcess[str], dict]:
+    """Run ``envdrift diff --format json`` and return (process, parsed-json)."""
+    result = _run_diff([*args, "--format", "json"], cwd, integration_pythonpath, timeout)
+    assert result.returncode == 0, (
+        f"diff exited {result.returncode}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    payload = json.loads(result.stdout)
+    return result, payload
+
+
+def _by_name(payload: dict, name: str) -> dict | None:
+    """Return the single difference entry with the given variable name, or None."""
+    matches = [d for d in payload["differences"] if d["name"] == name]
+    assert len(matches) <= 1, f"unexpected duplicate diff entries for {name!r}: {matches}"
+    return matches[0] if matches else None
+
+
+_SCHEMA_MODULE = textwrap.dedent('''
+    """Test schema for diff CLI integration tests."""
+    from typing import Any
+
+    from pydantic import Field
+    from pydantic_settings import BaseSettings
+
+
+    class Settings(BaseSettings):
+        API_KEY: str = Field(default="", json_schema_extra={"sensitive": True})
+        PUBLIC_URL: str = ""
+        DEBUG: bool = False
+        NUMS: list[int] = []
+        DATA: Any = None
+
+        model_config = {"extra": "ignore"}
+''')
+
+
+def _write_schema(tmp_path: Path) -> None:
+    """Write the shared Pydantic Settings schema module into ``tmp_path``."""
+    (tmp_path / "settings.py").write_text(_SCHEMA_MODULE)
+
+
+# --- Tests ---
+
+
+def test_diff_json_format_structure(tmp_path: Path, integration_pythonpath: str) -> None:
+    """HP-09: ``--format json`` emits a valid, well-shaped JSON document."""
+    (tmp_path / ".env.a").write_text("X=1\n")
+    (tmp_path / ".env.b").write_text("X=2\n")
+
+    _, payload = _run_diff_json([".env.a", ".env.b"], tmp_path, integration_pythonpath)
+
+    # Top-level contract.
+    assert set(payload) == {"env1", "env2", "summary", "differences"}
+    assert payload["env1"] == ".env.a"
+    assert payload["env2"] == ".env.b"
+
+    summary = payload["summary"]
+    assert set(summary) == {"added", "removed", "changed", "has_drift"}
+    assert summary["added"] == 0
+    assert summary["removed"] == 0
+    assert summary["changed"] == 1
+    assert summary["has_drift"] is True
+
+    entry = _by_name(payload, "X")
+    assert entry is not None
+    assert entry["type"] == "changed"
+    assert entry["value_env1"] == "1"
+    assert entry["value_env2"] == "2"
+    assert entry["sensitive"] is False
+
+
+def test_diff_mask_values_via_schema(tmp_path: Path, integration_pythonpath: str) -> None:
+    """HP-08: ``--schema`` marking API_KEY sensitive masks its values; PUBLIC_URL stays plaintext."""
+    _write_schema(tmp_path)
+    (tmp_path / "a.env").write_text("API_KEY=secret-a\nPUBLIC_URL=http://a\n")
+    (tmp_path / "b.env").write_text("API_KEY=secret-b\nPUBLIC_URL=http://b\n")
+
+    _, payload = _run_diff_json(
+        ["a.env", "b.env", "--schema", "settings:Settings", "--service-dir", str(tmp_path)],
+        tmp_path,
+        integration_pythonpath,
+    )
+
+    api_key = _by_name(payload, "API_KEY")
+    assert api_key is not None
+    assert api_key["sensitive"] is True
+    assert api_key["value_env1"] == "********"
+    assert api_key["value_env2"] == "********"
+
+    public_url = _by_name(payload, "PUBLIC_URL")
+    assert public_url is not None
+    assert public_url["sensitive"] is False
+    assert public_url["value_env1"] == "http://a"
+    assert public_url["value_env2"] == "http://b"
+
+
+def test_diff_normalization_default_treats_equivalent_values_equal(
+    tmp_path: Path, integration_pythonpath: str
+) -> None:
+    """HP-13: default ``--normalize`` treats bool-casing and JSON quote-style diffs as equal."""
+    (tmp_path / "n1.env").write_text('B=true\nC=["x","y"]\n')
+    (tmp_path / "n2.env").write_text("B=True\nC=['x', 'y']\n")
+
+    _, payload = _run_diff_json(["n1.env", "n2.env"], tmp_path, integration_pythonpath)
+
+    assert payload["summary"]["has_drift"] is False
+    assert payload["differences"] == []
+
+
+def test_diff_strict_disables_normalization(tmp_path: Path, integration_pythonpath: str) -> None:
+    """EC-14: ``--strict`` disables normalization; masking is independent of ``--strict``."""
+    _write_schema(tmp_path)
+    # DEBUG differs only by bool casing; C differs only by quote style — both equal under
+    # normalize, both CHANGED under --strict. API_KEY differs and must stay masked.
+    (tmp_path / "s1.env").write_text('API_KEY=secret-a\nDEBUG=1\nC=["x","y"]\n')
+    (tmp_path / "s2.env").write_text("API_KEY=secret-a\nDEBUG=true\nC=['x', 'y']\n")
+
+    _, payload = _run_diff_json(
+        [
+            "s1.env",
+            "s2.env",
+            "--schema",
+            "settings:Settings",
+            "--service-dir",
+            str(tmp_path),
+            "--strict",
+        ],
+        tmp_path,
+        integration_pythonpath,
+    )
+
+    # Only the two raw-string differences (DEBUG, C) count as changed; API_KEY is
+    # identical so it is unchanged (and omitted from the default output).
+    assert payload["summary"]["changed"] == 2
+
+    debug = _by_name(payload, "DEBUG")
+    assert debug is not None
+    assert debug["type"] == "changed"
+    assert debug["value_env1"] == "1"
+    assert debug["value_env2"] == "true"
+
+    # API_KEY is identical here, so to prove masking is still active under --strict we
+    # additionally diff differing secret values and confirm the mask.
+    (tmp_path / "s3.env").write_text("API_KEY=secret-b\n")
+    _, masked = _run_diff_json(
+        [
+            "s1.env",
+            "s3.env",
+            "--schema",
+            "settings:Settings",
+            "--service-dir",
+            str(tmp_path),
+            "--strict",
+        ],
+        tmp_path,
+        integration_pythonpath,
+    )
+    api_key = _by_name(masked, "API_KEY")
+    assert api_key is not None
+    assert api_key["sensitive"] is True
+    assert api_key["value_env1"] == "********"
+    assert api_key["value_env2"] == "********"
+
+
+def test_diff_schema_coercion_makes_bool_equal(tmp_path: Path, integration_pythonpath: str) -> None:
+    """HP-14: with ``--schema`` (DEBUG: bool), DEBUG=1 and DEBUG=true coerce equal."""
+    _write_schema(tmp_path)
+    (tmp_path / "c1.env").write_text("DEBUG=1\n")
+    (tmp_path / "c2.env").write_text("DEBUG=true\n")
+
+    _, payload = _run_diff_json(
+        ["c1.env", "c2.env", "--schema", "settings:Settings", "--service-dir", str(tmp_path)],
+        tmp_path,
+        integration_pythonpath,
+    )
+
+    assert payload["summary"]["has_drift"] is False
+    assert _by_name(payload, "DEBUG") is None
+
+
+def test_diff_include_unchanged_emits_unchanged_entries(
+    tmp_path: Path, integration_pythonpath: str
+) -> None:
+    """HP-20: ``--include-unchanged`` emits UNCHANGED entries alongside CHANGED ones."""
+    (tmp_path / "iu1.env").write_text("X=1\nY=same\n")
+    (tmp_path / "iu2.env").write_text("X=2\nY=same\n")
+
+    _, payload = _run_diff_json(
+        ["iu1.env", "iu2.env", "--include-unchanged"], tmp_path, integration_pythonpath
+    )
+
+    changed = _by_name(payload, "X")
+    assert changed is not None
+    assert changed["type"] == "changed"
+
+    unchanged = _by_name(payload, "Y")
+    assert unchanged is not None
+    assert unchanged["type"] == "unchanged"
+    assert unchanged["value_env1"] == "same"
+    assert unchanged["value_env2"] == "same"
+
+
+def test_diff_bool_aliases_equal_and_opposites_differ(
+    tmp_path: Path, integration_pythonpath: str
+) -> None:
+    """EC-16: yes/on/true normalize equal; false vs true report drift."""
+    # Equal case: yes vs on.
+    (tmp_path / "ba1.env").write_text("FLAG=yes\n")
+    (tmp_path / "ba2.env").write_text("FLAG=on\n")
+    _, equal = _run_diff_json(["ba1.env", "ba2.env"], tmp_path, integration_pythonpath)
+    assert equal["summary"]["has_drift"] is False
+    assert equal["differences"] == []
+
+    # Opposite case: false vs true.
+    (tmp_path / "bo1.env").write_text("FLAG=false\n")
+    (tmp_path / "bo2.env").write_text("FLAG=true\n")
+    _, opposite = _run_diff_json(["bo1.env", "bo2.env"], tmp_path, integration_pythonpath)
+    assert opposite["summary"]["has_drift"] is True
+    flag = _by_name(opposite, "FLAG")
+    assert flag is not None
+    assert flag["type"] == "changed"
+    assert flag["value_env1"] == "false"
+    assert flag["value_env2"] == "true"
+
+
+def test_diff_json_list_order_reports_drift_with_schema(
+    tmp_path: Path, integration_pythonpath: str
+) -> None:
+    """EC-23: a reordered JSON list (NUMS: list[int]) reports drift — order is significant."""
+    _write_schema(tmp_path)
+    (tmp_path / "l1.env").write_text("NUMS=[1,2,3]\n")
+    (tmp_path / "l2.env").write_text("NUMS=[3,2,1]\n")
+
+    _, payload = _run_diff_json(
+        ["l1.env", "l2.env", "--schema", "settings:Settings", "--service-dir", str(tmp_path)],
+        tmp_path,
+        integration_pythonpath,
+    )
+
+    assert payload["summary"]["has_drift"] is True
+    nums = _by_name(payload, "NUMS")
+    assert nums is not None
+    assert nums["type"] == "changed"
+
+
+def test_diff_adversarial_json_value_cannot_crash(
+    tmp_path: Path, integration_pythonpath: str
+) -> None:
+    """XC-02: a deeply-nested adversarial JSON value cannot crash diff (loose-parse is guarded)."""
+    depth = 2000
+    (tmp_path / "adv1.env").write_text("DATA=" + ("[" * depth) + ("]" * depth) + "\n")
+    (tmp_path / "adv2.env").write_text("DATA=" + ("[" * depth) + "1" + ("]" * depth) + "\n")
+
+    result, payload = _run_diff_json(["adv1.env", "adv2.env"], tmp_path, integration_pythonpath)
+
+    assert result.returncode == 0
+    assert "Traceback" not in result.stderr
+    # Loose-parse bails on the adversarial input and falls back to raw string compare,
+    # which differ, so DATA is reported as changed rather than crashing.
+    data = _by_name(payload, "DATA")
+    assert data is not None
+    assert data["type"] == "changed"
+
+
+def test_diff_unicode_values_survive(tmp_path: Path, integration_pythonpath: str) -> None:
+    """XC-06: unicode values round-trip through diff JSON without mojibake."""
+    original = "héllo-wörld-日本語-😀"
+    changed = "changed-héllo"
+    (tmp_path / "u1.env").write_text(f"GREETING={original}\n", encoding="utf-8")
+    (tmp_path / "u2.env").write_text(f"GREETING={changed}\n", encoding="utf-8")
+
+    _, payload = _run_diff_json(["u1.env", "u2.env"], tmp_path, integration_pythonpath)
+
+    greeting = _by_name(payload, "GREETING")
+    assert greeting is not None
+    assert greeting["type"] == "changed"
+    assert greeting["value_env1"] == original
+    assert greeting["value_env2"] == changed
+
+
+def test_diff_duplicate_keys_last_wins(tmp_path: Path, integration_pythonpath: str) -> None:
+    """EC-05: duplicate keys resolve last-one-wins; observable as no drift vs the single value."""
+    (tmp_path / "dup1.env").write_text("DUP=first\nDUP=second\n")
+    (tmp_path / "dup2.env").write_text("DUP=second\n")
+
+    _, payload = _run_diff_json(["dup1.env", "dup2.env"], tmp_path, integration_pythonpath)
+
+    assert payload["summary"]["has_drift"] is False
+    assert payload["differences"] == []

--- a/tests/integration/test_diff_cli.py
+++ b/tests/integration/test_diff_cli.py
@@ -17,6 +17,7 @@ Requires: pydantic-settings installed (provided by the project venv).
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 import textwrap
@@ -43,7 +44,8 @@ def _run_diff(
     venv interpreter (``sys.executable``) with ``PYTHONPATH`` set to the ``src``
     tree, so the real CLI and its dependencies are loaded.
     """
-    env = {"PYTHONPATH": integration_pythonpath}
+    env = os.environ.copy()
+    env["PYTHONPATH"] = integration_pythonpath
     return subprocess.run(
         [sys.executable, "-m", "envdrift.cli", "diff", *args],
         cwd=str(cwd),

--- a/tests/integration/test_encryption_dotenvx_binary.py
+++ b/tests/integration/test_encryption_dotenvx_binary.py
@@ -1,0 +1,237 @@
+"""Integration tests for the dotenvx binary installer/wrapper.
+
+These exercise the real ``DotenvxWrapper`` / ``DotenvxInstaller`` code paths in
+``envdrift.integrations.dotenvx`` against the real ``dotenvx`` binary (when on
+PATH) and against real archive files on disk. No mocking of the behavior under
+test: archives are built with the real ``tarfile`` / ``zipfile`` modules and
+extracted by the real installer code.
+
+Tests that require the ``dotenvx`` binary skip (rather than fail) when it is not
+installed on this machine.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import tarfile
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from envdrift.integrations import dotenvx as dotenvx_mod
+from envdrift.integrations.dotenvx import (
+    DotenvxInstaller,
+    DotenvxInstallError,
+    DotenvxWrapper,
+)
+
+# Mark all tests in this module
+pytestmark = [pytest.mark.integration]
+
+_SEMVER_RE = re.compile(r"\d+\.\d+\.\d+")
+
+
+@pytest.fixture
+def real_dotenvx_on_path() -> str:
+    """Return the path to a real ``dotenvx`` binary or skip the test."""
+    path = shutil.which("dotenvx")
+    if path is None:
+        pytest.skip("dotenvx binary not found on PATH")
+    return path
+
+
+def test_get_version_returns_real_dotenvx_version_string(
+    real_dotenvx_on_path: str,
+) -> None:
+    """HP-11: get_version() returns the real ``--version`` string and is stable."""
+    wrapper = DotenvxWrapper(auto_install=False)
+
+    version = wrapper.get_version()
+
+    assert isinstance(version, str)
+    assert version, "version string must be non-empty"
+    assert _SEMVER_RE.search(version), f"expected a semver in {version!r}"
+
+    # Two calls return the same value (binary path is cached on first lookup).
+    second = wrapper.get_version()
+    assert second == version
+
+
+def test_binary_discovery_uses_system_path_when_venv_absent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    real_dotenvx_on_path: str,
+) -> None:
+    """HP-14: with an empty venv bin, ``_find_binary`` falls back to PATH."""
+    # Build an empty venv whose bin dir contains NO dotenvx binary.
+    venv = tmp_path / "venv"
+    bin_dir = venv / "bin"
+    bin_dir.mkdir(parents=True)
+    monkeypatch.setenv("VIRTUAL_ENV", str(venv))
+
+    wrapper = DotenvxWrapper(auto_install=False)
+    resolved = wrapper.binary_path
+
+    which_dotenvx = shutil.which("dotenvx")
+    assert which_dotenvx is not None, "dotenvx must be on PATH for this test"
+    expected = Path(which_dotenvx)
+    assert resolved == expected
+    assert resolved.exists()
+    # Resolution did NOT come from the empty venv we created.
+    assert str(venv) not in str(resolved)
+
+
+def test_get_download_url_unsupported_platform_raises_install_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """BP-09: get_download_url() rejects an unsupported platform tuple."""
+    monkeypatch.setattr(
+        dotenvx_mod,
+        "get_platform_info",
+        lambda: ("Plan9", "sparc"),
+    )
+
+    installer = DotenvxInstaller()
+    with pytest.raises(DotenvxInstallError) as exc_info:
+        installer.get_download_url()
+
+    message = str(exc_info.value)
+    assert "Unsupported platform" in message
+    assert "Plan9" in message
+    assert "sparc" in message
+
+
+def test_download_failure_unreachable_url_raises_install_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """BP-10: a download against an unreachable URL raises a clear error."""
+    # Port 1 is privileged and never listening -> urlretrieve fails fast.
+    unreachable = "http://127.0.0.1:1/dotenvx.tar.gz"
+    monkeypatch.setattr(
+        DotenvxInstaller,
+        "get_download_url",
+        lambda self: unreachable,
+    )
+
+    target = tmp_path / "bin" / "dotenvx"
+    installer = DotenvxInstaller()
+    with pytest.raises(DotenvxInstallError) as exc_info:
+        installer.download_and_extract(target)
+
+    assert str(exc_info.value).startswith("Download failed:")
+    # Nothing was installed at the target.
+    assert not target.exists()
+
+
+def test_extract_archive_missing_binary_raises_install_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """BP-11: a real tar.gz lacking the dotenvx binary is rejected after extract."""
+    # Build a real .tar.gz containing only a README (no dotenvx binary).
+    src = tmp_path / "src"
+    src.mkdir()
+    readme = src / "README.txt"
+    readme.write_text("no binary here\n", encoding="utf-8")
+
+    archive = tmp_path / "dotenvx.tar.gz"
+    with tarfile.open(archive, "w:gz") as tar:
+        tar.add(readme, arcname="README.txt")
+
+    # Serve the local archive via file:// so the real download path runs.
+    monkeypatch.setattr(
+        DotenvxInstaller,
+        "get_download_url",
+        lambda self: archive.as_uri(),
+    )
+
+    target = tmp_path / "out" / "dotenvx"
+    installer = DotenvxInstaller()
+    with pytest.raises(DotenvxInstallError) as exc_info:
+        installer.download_and_extract(target)
+
+    assert "not found in archive" in str(exc_info.value)
+    # The binary was never produced at the target path.
+    assert not target.exists()
+
+
+def test_extract_tar_gz_path_traversal_member_rejected(tmp_path: Path) -> None:
+    """BP-12: a tar member escaping the target dir is rejected."""
+    target_dir = tmp_path / "extract"
+    target_dir.mkdir()
+    parent = tmp_path  # member '../evil.txt' would land here if not guarded
+
+    # Build a malicious tar.gz with a traversal member name.
+    payload = tmp_path / "payload.txt"
+    payload.write_text("pwned\n", encoding="utf-8")
+    archive = tmp_path / "evil.tar.gz"
+    with tarfile.open(archive, "w:gz") as tar:
+        tar.add(payload, arcname="../evil.txt")
+
+    installer = DotenvxInstaller()
+    with pytest.raises(DotenvxInstallError) as exc_info:
+        installer._extract_tar_gz(archive, target_dir)
+
+    message = str(exc_info.value)
+    assert "Unsafe path in archive" in message
+    assert "../evil" in message
+    # The guard fired BEFORE any extraction, so nothing escaped.
+    assert not (parent / "evil.txt").exists()
+
+
+def test_extract_zip_path_traversal_member_rejected(tmp_path: Path) -> None:
+    """BP-12 (zip): a zip member escaping the target dir is rejected."""
+    target_dir = tmp_path / "extract"
+    target_dir.mkdir()
+    parent = tmp_path
+
+    archive = tmp_path / "evil.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("../evil.txt", "pwned\n")
+
+    installer = DotenvxInstaller()
+    with pytest.raises(DotenvxInstallError) as exc_info:
+        installer._extract_zip(archive, target_dir)
+
+    assert "Unsafe path in archive" in str(exc_info.value)
+    # Nothing escaped the target directory.
+    assert not (parent / "evil.txt").exists()
+
+
+def test_tar_extraction_fallback_when_filter_unsupported(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """XC-06: tar fallback runs when ``filter=`` kwarg is unsupported (Py<3.12)."""
+    # Build a real, safe tar.gz that contains a dotenvx binary.
+    src = tmp_path / "src"
+    src.mkdir()
+    binary = src / "dotenvx"
+    binary.write_text("#!/bin/sh\necho fake\n", encoding="utf-8")
+    archive = tmp_path / "dotenvx.tar.gz"
+    with tarfile.open(archive, "w:gz") as tar:
+        tar.add(binary, arcname="dotenvx")
+
+    target_dir = tmp_path / "extract"
+    target_dir.mkdir()
+
+    # Simulate the Python<3.12 tarfile API: extractall rejects the
+    # ``filter`` keyword with TypeError, forcing the documented fallback.
+    real_extractall = tarfile.TarFile.extractall
+
+    def extractall_no_filter(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+        if "filter" in kwargs:
+            raise TypeError("extractall() got an unexpected keyword argument 'filter'")
+        return real_extractall(self, *args, **kwargs)
+
+    monkeypatch.setattr(tarfile.TarFile, "extractall", extractall_no_filter)
+
+    installer = DotenvxInstaller()
+    # Must not raise: the fallback (unfiltered extractall) handles it.
+    installer._extract_tar_gz(archive, target_dir)
+
+    assert (target_dir / "dotenvx").exists()
+    assert (target_dir / "dotenvx").read_text(encoding="utf-8").startswith("#!/bin/sh")

--- a/tests/integration/test_gcp_integration.py
+++ b/tests/integration/test_gcp_integration.py
@@ -64,13 +64,6 @@ GCP_REAL_BACKEND = (
 )
 
 
-def pytest_configure(config: pytest.Config) -> None:
-    """Register the gcp marker so ``-m gcp`` works and there are no warnings."""
-    config.addinivalue_line(
-        "markers", "gcp: Tests requiring GCP Secret Manager SDK / real GCP creds"
-    )
-
-
 # --- CLI guard tests (no credentials required) ---
 
 

--- a/tests/integration/test_gcp_integration.py
+++ b/tests/integration/test_gcp_integration.py
@@ -1,0 +1,352 @@
+"""GCP Secret Manager integration tests.
+
+Tests the GCPSecretManagerClient + the real envdrift CLI subprocess against the
+GCP Secret Manager backend.
+
+There is no GCP emulator, so this module is split into two tiers:
+
+1. CLI / factory guard tests (run anywhere the GCP SDK is importable). These
+   exercise the ``--project-id required for gcp`` CLI guard and the
+   ``get_vault_client('gcp')`` config-validation branch using the *real*
+   envdrift entrypoint and the *real* vault factory — no auth ever happens, so
+   no credentials are needed.
+
+2. A real-backend round-trip test that is skip-gated behind
+   ``ENVDRIFT_TEST_GCP == "1"`` plus Application Default Credentials and a
+   ``GOOGLE_CLOUD_PROJECT``. It is not CI-runnable without real GCP creds and
+   documents the intended real coverage.
+
+Mirrors the BOTO3_AVAILABLE / AZURE_AVAILABLE module-gating pattern used by the
+AWS and Azure integration suites.
+
+Requires (for the real-backend tier): a real GCP project with Secret Manager
+enabled and ADC configured.
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# Check if the GCP Secret Manager SDK is importable (mirrors BOTO3_AVAILABLE /
+# AZURE_AVAILABLE in the AWS/Azure suites).
+try:
+    GCP_AVAILABLE = importlib.util.find_spec("google.cloud.secretmanager") is not None
+except ModuleNotFoundError:
+    GCP_AVAILABLE = False
+
+# Mark all tests in this module - skip if the GCP SDK is not installed.
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.gcp,
+    pytest.mark.slow,
+    pytest.mark.skipif(
+        not GCP_AVAILABLE,
+        reason="GCP SDK not installed - install with: pip install envdrift[gcp]",
+    ),
+]
+
+# Real-backend gate: only run round-trip tests when explicitly opted in and ADC
+# + project are present. Not CI-runnable without real GCP creds.
+GCP_REAL_BACKEND = (
+    os.environ.get("ENVDRIFT_TEST_GCP") == "1"
+    and bool(os.environ.get("GOOGLE_CLOUD_PROJECT"))
+    and (
+        bool(os.environ.get("GOOGLE_APPLICATION_CREDENTIALS"))
+        or Path("~/.config/gcloud/application_default_credentials.json").expanduser().exists()
+    )
+)
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Register the gcp marker so ``-m gcp`` works and there are no warnings."""
+    config.addinivalue_line(
+        "markers", "gcp: Tests requiring GCP Secret Manager SDK / real GCP creds"
+    )
+
+
+# --- CLI guard tests (no credentials required) ---
+
+
+class TestGCPCLIProjectIdGuard:
+    """The CLI must reject ``-p gcp`` without ``--project-id`` *before* it ever
+    tries to authenticate to GCP.
+
+    These use the real ``envdrift`` console-script entrypoint as a subprocess.
+    """
+
+    def test_gcp_vault_push_without_project_id_exits_1(
+        self,
+        envdrift_cmd: list[str],
+        integration_pythonpath: str,
+        work_dir: Path,
+    ):
+        """BP-12: ``vault-push -p gcp`` with no ``--project-id`` fails the
+        ``_resolve_vault_settings`` guard with exit code 1 and a precise message,
+        without attempting any GCP auth.
+        """
+        # A real .env.keys so we don't bail on a missing-file error first; the
+        # provider guard runs before the .env.keys is read anyway.
+        (work_dir / ".env.keys").write_text("DOTENV_PRIVATE_KEY_PROD=abc123\n")
+
+        env = os.environ.copy()
+        env["PYTHONPATH"] = integration_pythonpath
+
+        result = subprocess.run(
+            [
+                *envdrift_cmd,
+                "vault-push",
+                str(work_dir),
+                "test_gcp_vault_push_without_project_id_exits_1-secret",
+                "--env",
+                "prod",
+                "-p",
+                "gcp",
+            ],
+            cwd=work_dir,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+
+        combined = result.stdout + result.stderr
+
+        # The CLI must actually dispatch — a missing entrypoint / import error
+        # would make this assertion vacuous.
+        assert "No module named" not in combined, combined
+        assert "is a package and cannot be directly executed" not in combined, combined
+
+        assert result.returncode == 1, combined
+        assert "--project-id required for gcp" in combined, combined
+        # The guard must fire BEFORE any GCP authentication is attempted.
+        assert "authentication failed" not in combined.lower(), combined
+        assert "credential" not in combined.lower(), combined
+
+    def test_gcp_vault_pull_without_project_id_exits_1(
+        self,
+        envdrift_cmd: list[str],
+        integration_pythonpath: str,
+        work_dir: Path,
+    ):
+        """BP-13: ``vault-pull -p gcp`` with no ``--project-id`` hits the same
+        guard, exit code 1, before any auth.
+        """
+        env = os.environ.copy()
+        env["PYTHONPATH"] = integration_pythonpath
+
+        result = subprocess.run(
+            [
+                *envdrift_cmd,
+                "vault-pull",
+                str(work_dir),
+                "test_gcp_vault_pull_without_project_id_exits_1-secret",
+                "--env",
+                "prod",
+                "--no-decrypt",
+                "-p",
+                "gcp",
+            ],
+            cwd=work_dir,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+
+        combined = result.stdout + result.stderr
+
+        assert "No module named" not in combined, combined
+        assert "is a package and cannot be directly executed" not in combined, combined
+
+        assert result.returncode == 1, combined
+        assert "--project-id required for gcp" in combined, combined
+        assert "authentication failed" not in combined.lower(), combined
+        assert "credential" not in combined.lower(), combined
+
+
+# --- Real vault factory tests (SDK installed, no auth) ---
+
+
+class TestGCPFactory:
+    """Exercise the real ``get_vault_client('gcp')`` factory branch."""
+
+    def test_get_vault_client_gcp_without_project_id_raises_value_error(self):
+        """BP-14: with the SDK installed, ``get_vault_client('gcp')`` with a
+        missing/empty ``project_id`` raises ValueError from the config-validation
+        branch; a non-empty project_id returns a bound GCPSecretManagerClient.
+        """
+        from envdrift.vault import get_vault_client
+        from envdrift.vault.gcp import GCPSecretManagerClient
+
+        # Missing project_id -> ValueError with the documented message.
+        with pytest.raises(ValueError) as exc_no_id:
+            get_vault_client("gcp")
+        assert "project_id" in str(exc_no_id.value)
+        assert "GCP Secret Manager requires" in str(exc_no_id.value)
+
+        # Empty-string project_id is falsy -> same guard fires.
+        with pytest.raises(ValueError) as exc_empty:
+            get_vault_client("gcp", project_id="")
+        assert "project_id" in str(exc_empty.value)
+        assert "GCP Secret Manager requires" in str(exc_empty.value)
+
+        # A real project_id constructs a real client (no network / no auth).
+        client = get_vault_client("gcp", project_id="p")
+        assert isinstance(client, GCPSecretManagerClient)
+        assert client.project_id == "p"
+        # Construction alone must not authenticate.
+        assert client.is_authenticated() is False
+
+    def test_gcp_sdk_not_installed_import_error_has_pip_hint(self):
+        """BP-11: when the GCP SDK is hidden, the real import guards raise
+        ImportError with the ``pip install envdrift[gcp]`` hint.
+
+        We hide ``google.cloud.secretmanager`` / ``google.api_core`` by inserting
+        ``None`` sentinels into ``sys.modules`` and reloading the gcp module so its
+        module-level ``try/except ImportError`` re-runs with GCP_AVAILABLE=False.
+        Everything is restored on teardown.
+        """
+        import envdrift.vault.gcp as gcp_mod
+
+        hidden = [
+            "google.cloud.secretmanager",
+            "google.api_core",
+            "google.api_core.exceptions",
+            "google.auth.exceptions",
+        ]
+        saved = {name: sys.modules.get(name) for name in hidden}
+        try:
+            # ``None`` in sys.modules makes ``import x`` raise ImportError.
+            for name in hidden:
+                sys.modules[name] = None  # type: ignore[assignment]
+
+            reloaded = importlib.reload(gcp_mod)
+            assert reloaded.GCP_AVAILABLE is False
+
+            expected_msg = "GCP Secret Manager support requires"
+            expected_hint = "pip install envdrift[gcp]"
+
+            # 1. Direct module-accessor guard.
+            with pytest.raises(ImportError) as exc_mod:
+                reloaded._get_gcp_modules()
+            assert expected_msg in str(exc_mod.value)
+            assert expected_hint in str(exc_mod.value)
+
+            # 2. Client constructor calls the guard.
+            with pytest.raises(ImportError) as exc_client:
+                reloaded.GCPSecretManagerClient(project_id="p")
+            assert expected_msg in str(exc_client.value)
+            assert expected_hint in str(exc_client.value)
+
+            # 3. Factory path: reload the factory so it imports the reloaded gcp
+            #    module, then assert the same hint surfaces.
+            import envdrift.vault as vault_pkg
+
+            vault_pkg = importlib.reload(vault_pkg)
+            with pytest.raises(ImportError) as exc_factory:
+                vault_pkg.get_vault_client("gcp", project_id="p")
+            assert expected_msg in str(exc_factory.value)
+            assert expected_hint in str(exc_factory.value)
+        finally:
+            # Restore hidden modules and reload back to the real implementations.
+            for name, mod in saved.items():
+                if mod is None:
+                    sys.modules.pop(name, None)
+                else:
+                    sys.modules[name] = mod
+            importlib.reload(gcp_mod)
+            import envdrift.vault as vault_pkg
+
+            importlib.reload(vault_pkg)
+            assert gcp_mod.GCP_AVAILABLE is True
+
+
+# --- Real-backend round-trip (skip-gated; needs real GCP creds) ---
+
+
+@pytest.mark.skipif(
+    not GCP_REAL_BACKEND,
+    reason=(
+        "real GCP backend not enabled - set ENVDRIFT_TEST_GCP=1, "
+        "GOOGLE_CLOUD_PROJECT, and configure Application Default Credentials"
+    ),
+)
+class TestGCPRealBackend:
+    """Real GCP Secret Manager round-trips. Skipped unless explicitly opted in.
+
+    Covers HP-01..HP-13 / BP-04/05/09 / EC-07/08/10 / EX-03/07: set/get/list
+    round-trips, version increment, unicode/multiline payloads, prefix filtering,
+    NotFound -> SecretNotFoundError, plus a CLI vault-push/vault-pull round-trip.
+
+    Every secret created is prefixed with the test function name and deleted in
+    teardown so concurrent/repeat runs never collide.
+    """
+
+    @pytest.fixture()
+    def gcp_client(self):
+        """A real, authenticated GCPSecretManagerClient bound to the test project."""
+        from envdrift.vault import get_vault_client
+
+        project_id = os.environ["GOOGLE_CLOUD_PROJECT"]
+        client = get_vault_client("gcp", project_id=project_id)
+        try:
+            client.authenticate()
+        except Exception as e:  # pragma: no cover - depends on live creds
+            pytest.skip(f"GCP authentication failed against real backend: {e}")
+        assert client.is_authenticated()
+        return client
+
+    def _delete_secret(self, client, secret_id: str) -> None:
+        """Best-effort delete of a created secret via the raw SDK client."""
+        import contextlib
+
+        with contextlib.suppress(Exception):
+            client._client.delete_secret(request={"name": client._secret_path(secret_id)})
+
+    def test_gcp_roundtrip_real_backend(self, gcp_client):
+        """set_secret then get_secret returns the stored value, and a second
+        set_secret produces a new version. Unicode/multiline survive the trip.
+        """
+        prefix = "test_gcp_roundtrip_real_backend"
+        plain_id = f"{prefix}-plain"
+        unicode_id = f"{prefix}-unicode"
+        try:
+            # Plain round-trip + version increment.
+            stored = gcp_client.set_secret(plain_id, "hello-world")
+            assert stored.name == plain_id
+            assert stored.value == "hello-world"
+            assert stored.version is not None
+
+            fetched = gcp_client.get_secret(plain_id)
+            assert fetched.name == plain_id
+            assert fetched.value == "hello-world"
+
+            second = gcp_client.set_secret(plain_id, "hello-world-v2")
+            assert second.version != stored.version
+            assert gcp_client.get_secret(plain_id).value == "hello-world-v2"
+
+            # Unicode + multiline payload survives the round-trip.
+            unicode_value = "café\nline2\tπ=3.14"
+            gcp_client.set_secret(unicode_id, unicode_value)
+            assert gcp_client.get_secret(unicode_id).value == unicode_value
+
+            # Prefix filtering returns the created secrets.
+            listed = gcp_client.list_secrets(prefix=prefix)
+            assert plain_id in listed
+            assert unicode_id in listed
+
+            # NotFound surfaces as SecretNotFoundError.
+            from envdrift.vault.base import SecretNotFoundError
+
+            with pytest.raises(SecretNotFoundError):
+                gcp_client.get_secret(f"{prefix}-does-not-exist")
+        finally:
+            self._delete_secret(gcp_client, plain_id)
+            self._delete_secret(gcp_client, unicode_id)

--- a/tests/integration/test_guard_cli_e2e.py
+++ b/tests/integration/test_guard_cli_e2e.py
@@ -1,0 +1,442 @@
+"""End-to-end integration tests for the ``envdrift guard`` CLI.
+
+These tests drive the real ``envdrift guard`` command as a subprocess against a
+real git repository and the native scanner only (``--native-only``). No external
+scanner binaries are required, so every test runs both locally and in CI.
+
+Coverage (highest value first):
+- HP-03  test_pr_base_scan_catches_leak_with_fake_remote (P0)
+- HP-12  test_ci_fail_on_high_suppresses_medium_finding_exit_zero (P0)
+- BP-16  test_critical_finding_exit_code_one_non_ci (P0)
+- BP-16  test_committed_private_key_exit_code_one (P0)
+- BP-17  test_high_unencrypted_env_file_exit_code_two_non_ci (P0)
+- BUG    test_staged_secret_dropped_when_run_from_subdirectory (P0)
+- HP-17  test_allowed_clear_file_exempt_from_unencrypted_but_secrets_still_scanned (P0)
+- HP-10  test_entropy_flag_enables_high_entropy_detection (P1)
+- BP-01  test_path_not_found_exits_one (P1)
+- EC-21  test_skip_clear_overrides_allowed_clear_files_allowlist (P1)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.integration]
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PYTHONPATH = str(REPO_ROOT / "src")
+
+# A canonical 40-char AWS secret access key (same shape AWS itself documents).
+# Placed after an ``aws_secret_access_key`` key so the native CRITICAL pattern
+# ``aws-secret-access-key`` matches deterministically.
+_AWS_SECRET = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+
+
+def _run_envdrift(
+    args: list[str], *, cwd: Path, env: dict[str, str] | None = None, check: bool = False
+) -> subprocess.CompletedProcess:
+    """Run the envdrift CLI as a subprocess (native scanner, real process)."""
+    run_env = os.environ.copy()
+    run_env["PYTHONPATH"] = f"{PYTHONPATH}{os.pathsep}{run_env.get('PYTHONPATH', '')}"
+    if env:
+        run_env.update(env)
+    cmd = [sys.executable, "-m", "envdrift.cli", *args]
+    result = subprocess.run(
+        cmd,
+        cwd=str(cwd),
+        env=run_env,
+        capture_output=True,
+        text=True,
+    )
+    if check and result.returncode != 0:
+        raise AssertionError(
+            f"envdrift failed\ncmd: {' '.join(cmd)}\n"
+            f"cwd: {cwd}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+    return result
+
+
+def _run_git(
+    args: list[str], *, cwd: Path, env: dict[str, str] | None = None, check: bool = True
+) -> subprocess.CompletedProcess:
+    """Run a git command, gating cleanly if git is unavailable."""
+    git_path = shutil.which("git")
+    if git_path is None:
+        pytest.skip("git is not available")
+
+    git_env = os.environ.copy()
+    for key in ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_COMMON_DIR"):
+        git_env.pop(key, None)
+    if env:
+        git_env.update(env)
+
+    result = subprocess.run(
+        [git_path, *args],
+        cwd=str(cwd),
+        env=git_env,
+        capture_output=True,
+        text=True,
+    )
+    if check and result.returncode != 0:
+        raise AssertionError(
+            f"git failed\ncmd: git {' '.join(args)}\n"
+            f"cwd: {cwd}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+    return result
+
+
+def _guard_json(result: subprocess.CompletedProcess) -> dict:
+    """Parse the JSON document printed by ``guard --json``.
+
+    ``--json`` prints one JSON document on stdout. In ``--staged``/``--pr-base``
+    modes a one-line progress notice ("Scanning N staged file(s)...") is printed
+    ahead of it, so slice from the first ``{`` to the last ``}`` before decoding.
+    """
+    out = result.stdout
+    start = out.index("{")
+    end = out.rindex("}") + 1
+    return json.loads(out[start:end])
+
+
+def _rule_ids(payload: dict) -> list[str]:
+    return [f["rule_id"] for f in payload["findings"]]
+
+
+# --- HP-03 (P0): --pr-base diffs a fake remote, scans only changed files -------
+
+
+def test_pr_base_scan_catches_leak_with_fake_remote(git_repo: Path) -> None:
+    """``guard --pr-base origin/main`` scans only files changed since the base.
+
+    A benign ``readme.txt`` lives on the base branch; the feature branch adds a
+    single ``leak.py`` carrying an AWS secret. Only that one changed file must be
+    scanned, the leak must fail the run (exit 1), and the untouched/benign
+    ``readme.txt`` must never appear in the diff set.
+    """
+    work_dir = git_repo
+    # Recreate the repo on an explicit ``main`` branch so origin/main is stable.
+    shutil.rmtree(work_dir / ".git")
+    _run_git(["init", "-b", "main"], cwd=work_dir)
+    _run_git(["config", "user.email", "test@test.com"], cwd=work_dir)
+    _run_git(["config", "user.name", "Test User"], cwd=work_dir)
+
+    (work_dir / "readme.txt").write_text("hello world\n")
+    _run_git(["add", "readme.txt"], cwd=work_dir)
+    _run_git(["commit", "-m", "init"], cwd=work_dir)
+
+    # Fake bare remote that origin/main can point at.
+    remote = work_dir.parent / f"{work_dir.name}_remote.git"
+    _run_git(["init", "--bare", str(remote)], cwd=work_dir.parent)
+    _run_git(["remote", "add", "origin", str(remote)], cwd=work_dir)
+    _run_git(["push", "origin", "main"], cwd=work_dir)
+
+    # Feature branch: add exactly one new file with a leak.
+    _run_git(["checkout", "-b", "feature"], cwd=work_dir)
+    (work_dir / "leak.py").write_text(f'aws_secret_access_key = "{_AWS_SECRET}"\n')
+    _run_git(["add", "leak.py"], cwd=work_dir)
+    _run_git(["commit", "-m", "add leak"], cwd=work_dir)
+
+    result = _run_envdrift(["guard", "--native-only", "--pr-base", "origin/main"], cwd=work_dir)
+    combined = result.stdout + result.stderr
+
+    assert result.returncode == 1, f"expected critical exit 1, got {result.returncode}\n{combined}"
+    assert "Scanning 1 file(s) changed since origin/main" in combined, combined
+    assert "critical" in combined.lower()
+    # readme.txt is on the base, unchanged — it must not be in the diff/scan set.
+    assert "readme.txt" not in combined, combined
+
+    # Confirm the precise finding via JSON.
+    json_result = _run_envdrift(
+        ["guard", "--native-only", "--pr-base", "origin/main", "--json"], cwd=work_dir
+    )
+    payload = _guard_json(json_result)
+    assert "aws-secret-access-key" in _rule_ids(payload)
+    assert payload["summary"]["by_severity"]["critical"] >= 1
+
+
+# --- HP-12 (P0): CI --fail-on high suppresses a below-threshold MEDIUM ----------
+
+
+def test_ci_fail_on_high_suppresses_medium_finding_exit_zero(git_repo: Path) -> None:
+    """``--ci --fail-on high`` downgrades a MEDIUM-only run to exit 0.
+
+    A high-entropy string in a non-env file is a MEDIUM finding. With ``--ci
+    --fail-on high`` it is below threshold and the run exits 0; the identical scan
+    without ``--ci`` keeps the native exit code 3 (medium).
+    """
+    work_dir = git_repo
+    target = work_dir / "settings.py"
+    target.write_text('SESSION_TOKEN = "Xq7Lp2Vz9Kw4Nt8Rb3Yc6Hd1Mf5Gj0Sa"\n')
+    _run_git(["add", "settings.py"], cwd=work_dir)
+
+    # Sanity: the finding really is MEDIUM-only.
+    json_result = _run_envdrift(
+        ["guard", "--native-only", "--entropy", "--json", "settings.py"], cwd=work_dir
+    )
+    payload = _guard_json(json_result)
+    assert "high-entropy-string" in _rule_ids(payload)
+    by_sev = payload["summary"]["by_severity"]
+    assert by_sev["medium"] >= 1
+    assert by_sev["critical"] == 0 and by_sev["high"] == 0
+
+    # Without --ci: medium -> native exit code 3.
+    non_ci = _run_envdrift(["guard", "--native-only", "--entropy", "settings.py"], cwd=work_dir)
+    assert non_ci.returncode == 3, f"expected 3, got {non_ci.returncode}\n{non_ci.stdout}"
+
+    # With --ci --fail-on high: medium is below threshold -> exit 0.
+    ci = _run_envdrift(
+        ["guard", "--native-only", "--entropy", "--ci", "--fail-on", "high", "settings.py"],
+        cwd=work_dir,
+    )
+    assert ci.returncode == 0, f"expected 0, got {ci.returncode}\n{ci.stdout}\n{ci.stderr}"
+
+
+# --- BP-16 (P0): an AWS secret in a tracked file -> exit 1 (non-CI) -------------
+
+
+def test_critical_finding_exit_code_one_non_ci(git_repo: Path) -> None:
+    """A tracked AWS secret yields a CRITICAL finding and exit 1 in a non-CI run."""
+    work_dir = git_repo
+    target = work_dir / "config.py"
+    target.write_text(f'aws_secret_access_key = "{_AWS_SECRET}"\n')
+    _run_git(["add", "config.py"], cwd=work_dir)
+
+    result = _run_envdrift(["guard", "--native-only", "config.py"], cwd=work_dir)
+    assert result.returncode == 1, f"expected 1, got {result.returncode}\n{result.stdout}"
+    assert "critical" in (result.stdout + result.stderr).lower()
+
+    payload = _guard_json(
+        _run_envdrift(["guard", "--native-only", "--json", "config.py"], cwd=work_dir)
+    )
+    assert "aws-secret-access-key" in _rule_ids(payload)
+    assert payload["summary"]["by_severity"]["critical"] >= 1
+    assert payload["exit_code"] == 1
+
+
+# --- BP-16 (P0, second vector): tracked .env.keys -> committed-private-key ------
+
+
+def test_committed_private_key_exit_code_one(git_repo: Path) -> None:
+    """A tracked ``.env.keys`` private-key file is CRITICAL and exits 1."""
+    work_dir = git_repo
+    keys = work_dir / ".env.keys"
+    keys.write_text("DOTENV_PRIVATE_KEY_PRODUCTION=abc123def456\n")
+    # The rule only fires when git tracks/stages the key file.
+    _run_git(["add", "-f", ".env.keys"], cwd=work_dir)
+
+    result = _run_envdrift(["guard", "--native-only", ".env.keys"], cwd=work_dir)
+    assert result.returncode == 1, f"expected 1, got {result.returncode}\n{result.stdout}"
+    assert "critical" in (result.stdout + result.stderr).lower()
+
+    payload = _guard_json(
+        _run_envdrift(["guard", "--native-only", "--json", ".env.keys"], cwd=work_dir)
+    )
+    assert "committed-private-key" in _rule_ids(payload)
+    assert payload["summary"]["by_severity"]["critical"] >= 1
+    assert payload["exit_code"] == 1
+
+
+# --- BP-17 (P0): plaintext .env.production -> unencrypted-env-file HIGH, exit 2 --
+
+
+def test_high_unencrypted_env_file_exit_code_two_non_ci(git_repo: Path) -> None:
+    """A plaintext ``.env.production`` is a HIGH unencrypted-env-file (exit 2)."""
+    work_dir = git_repo
+    env_file = work_dir / ".env.production"
+    env_file.write_text("API_KEY=plainvalue123\nDB_PASSWORD=hunter2\n")
+    _run_git(["add", "-f", ".env.production"], cwd=work_dir)
+
+    result = _run_envdrift(["guard", "--native-only", ".env.production"], cwd=work_dir)
+    assert result.returncode == 2, f"expected 2, got {result.returncode}\n{result.stdout}"
+
+    payload = _guard_json(
+        _run_envdrift(["guard", "--native-only", "--json", ".env.production"], cwd=work_dir)
+    )
+    assert "unencrypted-env-file" in _rule_ids(payload)
+    by_sev = payload["summary"]["by_severity"]
+    assert by_sev["high"] >= 1
+    assert by_sev["critical"] == 0
+    assert payload["exit_code"] == 2
+
+
+# --- BUG-SUBDIR-STAGED (P0): --staged from a subdirectory must catch the leak ---
+
+
+def test_staged_secret_dropped_when_run_from_subdirectory(git_repo: Path) -> None:
+    """``guard --staged`` must catch a staged leak regardless of the run cwd.
+
+    From the repo root the staged AWS secret is correctly caught (exit 1). The
+    desired behaviour is identical from a repo subdirectory: ``git diff --cached``
+    yields repo-relative paths, so running from ``sub/`` currently makes
+    ``Path(f).exists()`` false and the whole staged set is silently dropped to
+    "No staged files to scan." (exit 0) — a real leak slips through. That
+    subdirectory expectation is asserted under xfail so the bug is documented and
+    will flip the test to a hard failure once the code resolves staged paths
+    against the repo root.
+    """
+    work_dir = git_repo
+    (work_dir / "sub").mkdir()
+    leak = work_dir / "sub" / "leak.py"
+    leak.write_text(f'aws_secret_access_key = "{_AWS_SECRET}"\n')
+    _run_git(["add", "sub/leak.py"], cwd=work_dir)
+
+    # From the repo root: the staged leak is caught.
+    root_result = _run_envdrift(["guard", "--staged", "--native-only"], cwd=work_dir)
+    assert root_result.returncode == 1, (
+        f"staged scan from root must catch the leak, got {root_result.returncode}\n"
+        f"{root_result.stdout}\n{root_result.stderr}"
+    )
+    root_json = _guard_json(
+        _run_envdrift(["guard", "--staged", "--native-only", "--json"], cwd=work_dir)
+    )
+    assert "aws-secret-access-key" in _rule_ids(root_json)
+
+    # From a subdirectory: desired behaviour is the SAME leak detection (exit 1).
+    sub_dir = work_dir / "sub"
+    sub_result = _run_envdrift(["guard", "--staged", "--native-only"], cwd=sub_dir)
+    combined = sub_result.stdout + sub_result.stderr
+    if sub_result.returncode == 0 and "No staged files to scan." in combined:
+        pytest.xfail(
+            "Known bug (#302): guard --staged from a repo subdirectory drops staged files "
+            "(repo-relative paths fail Path.exists() against the subdir cwd) and "
+            "exits 0 instead of catching the staged leak."
+        )
+    assert sub_result.returncode == 1, (
+        f"staged scan from a subdir must catch the leak, got {sub_result.returncode}\n{combined}"
+    )
+
+
+# --- HP-17 (P0): allowed clear_file exempt from unencrypted, secrets still found -
+
+
+_PARTIAL_CONFIG = textwrap.dedent(
+    """\
+    [partial_encryption]
+    enabled = true
+
+    [[partial_encryption.environments]]
+    name = "production"
+    clear_file = ".env.production.clear"
+    secret_file = ".env.production.secret"
+    combined_file = ".env.production"
+    """
+)
+
+
+def test_allowed_clear_file_exempt_from_unencrypted_but_secrets_still_scanned(
+    git_repo: Path,
+) -> None:
+    """A declared ``clear_file`` is exempt from unencrypted-env-file, not from secrets.
+
+    The partial_encryption ``clear_file`` is intentionally plaintext, so it must
+    NOT be flagged as ``unencrypted-env-file`` (HIGH). But an AWS secret embedded
+    in it is still a real leak and must be reported as CRITICAL.
+    """
+    work_dir = git_repo
+    (work_dir / "envdrift.toml").write_text(_PARTIAL_CONFIG)
+    clear = work_dir / ".env.production.clear"
+    clear.write_text(f"LOG_LEVEL=info\naws_secret_access_key={_AWS_SECRET}\n")
+    _run_git(["add", "-f", ".env.production.clear", "envdrift.toml"], cwd=work_dir)
+
+    result = _run_envdrift(["guard", "--native-only", ".env.production.clear"], cwd=work_dir)
+    assert result.returncode == 1, f"expected 1, got {result.returncode}\n{result.stdout}"
+
+    payload = _guard_json(
+        _run_envdrift(["guard", "--native-only", "--json", ".env.production.clear"], cwd=work_dir)
+    )
+    rule_ids = _rule_ids(payload)
+    assert "aws-secret-access-key" in rule_ids
+    assert "unencrypted-env-file" not in rule_ids
+    by_sev = payload["summary"]["by_severity"]
+    assert by_sev["high"] == 0
+    assert by_sev["critical"] >= 1
+
+
+# --- HP-10 (P1): --entropy enables high-entropy detection on a non-env file -----
+
+
+def test_entropy_flag_enables_high_entropy_detection(git_repo: Path) -> None:
+    """``--entropy`` turns on high-entropy MEDIUM detection for non-env files.
+
+    Without the flag, a high-entropy string in a ``.py`` file produces no findings;
+    with ``--entropy`` it produces a MEDIUM ``high-entropy-string`` finding (exit 3).
+    """
+    work_dir = git_repo
+    target = work_dir / "settings.py"
+    target.write_text('SESSION_TOKEN = "Xq7Lp2Vz9Kw4Nt8Rb3Yc6Hd1Mf5Gj0Sa"\n')
+    _run_git(["add", "settings.py"], cwd=work_dir)
+
+    # Off by default for non-env files.
+    off = _run_envdrift(["guard", "--native-only", "--json", "settings.py"], cwd=work_dir)
+    off_payload = _guard_json(off)
+    assert off_payload["findings"] == []
+    assert off_payload["exit_code"] == 0
+
+    # On with --entropy: a MEDIUM high-entropy finding (exit 3).
+    on = _run_envdrift(
+        ["guard", "--native-only", "--entropy", "--json", "settings.py"], cwd=work_dir
+    )
+    on_payload = _guard_json(on)
+    high_entropy = [f for f in on_payload["findings"] if f["rule_id"] == "high-entropy-string"]
+    assert high_entropy, on_payload["findings"]
+    assert all(f["severity"] == "medium" for f in high_entropy)
+    assert on_payload["exit_code"] == 3
+
+    on_cli = _run_envdrift(["guard", "--native-only", "--entropy", "settings.py"], cwd=work_dir)
+    assert on_cli.returncode == 3, f"expected 3, got {on_cli.returncode}\n{on_cli.stdout}"
+
+
+# --- BP-01 (P1): scanning a nonexistent path exits 1 ----------------------------
+
+
+def test_path_not_found_exits_one(git_repo: Path) -> None:
+    """Scanning a path that does not exist exits 1 with a 'Path not found' message."""
+    work_dir = git_repo
+    result = _run_envdrift(["guard", "--native-only", "./does_not_exist.py"], cwd=work_dir)
+    assert result.returncode == 1, f"expected 1, got {result.returncode}\n{result.stdout}"
+    assert "Path not found" in (result.stdout + result.stderr)
+
+
+# --- EC-21 (P1): --skip-clear overrides the allowed_clear_files allowlist --------
+
+
+def test_skip_clear_overrides_allowed_clear_files_allowlist(git_repo: Path) -> None:
+    """``--skip-clear`` skips a declared ``clear_file`` entirely (no findings at all).
+
+    With the partial_encryption allowlist, the embedded AWS secret is normally
+    reported. ``--skip-clear`` takes precedence and the ``.clear`` file is skipped
+    outright, so the secret is never reported and the run exits 0.
+    """
+    work_dir = git_repo
+    (work_dir / "envdrift.toml").write_text(_PARTIAL_CONFIG)
+    clear = work_dir / ".env.production.clear"
+    clear.write_text(f"LOG_LEVEL=info\naws_secret_access_key={_AWS_SECRET}\n")
+    _run_git(["add", "-f", ".env.production.clear", "envdrift.toml"], cwd=work_dir)
+
+    # Without --skip-clear: the embedded secret is reported (exit 1).
+    without = _guard_json(
+        _run_envdrift(["guard", "--native-only", "--json", ".env.production.clear"], cwd=work_dir)
+    )
+    assert "aws-secret-access-key" in _rule_ids(without)
+
+    # With --skip-clear: the file is skipped entirely, no findings, exit 0.
+    result = _run_envdrift(
+        ["guard", "--native-only", "--skip-clear", ".env.production.clear"], cwd=work_dir
+    )
+    assert result.returncode == 0, f"expected 0, got {result.returncode}\n{result.stdout}"
+    skipped = _guard_json(
+        _run_envdrift(
+            ["guard", "--native-only", "--skip-clear", "--json", ".env.production.clear"],
+            cwd=work_dir,
+        )
+    )
+    assert skipped["findings"] == []
+    assert skipped["exit_code"] == 0

--- a/tests/integration/test_hashicorp_integration.py
+++ b/tests/integration/test_hashicorp_integration.py
@@ -13,6 +13,8 @@ Test categories:
 from __future__ import annotations
 
 import contextlib
+import json
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -30,6 +32,7 @@ import importlib.util
 from tests.integration.conftest import VAULT_ROOT_TOKEN
 
 HVAC_AVAILABLE = importlib.util.find_spec("hvac") is not None
+DOTENVX_AVAILABLE = shutil.which("dotenvx") is not None
 
 # Mark all tests in this module - skip if hvac not installed
 pytestmark = [
@@ -276,3 +279,691 @@ vault_key_path = "test/pushed-secret"
                 path="test/pushed-secret",
                 mount_point="secret",
             )
+
+
+# ===========================================================================
+# Extended HashiCorp Vault integration tests (generated test package)
+#
+# All tests below are gated on the live Vault container (via vault_endpoint /
+# vault_client / vault_test_env), hvac (module pytestmark skipif), and dotenvx
+# (DOTENVX_AVAILABLE) where the CLI must encrypt/decrypt. They assert the
+# documented contract and clean up every path they create.
+# ===========================================================================
+
+
+def _delete_vault_path(vault_client, path: str, mount_point: str = "secret") -> None:
+    """Best-effort cleanup of a KV v2 secret path."""
+    with contextlib.suppress(Exception):
+        vault_client.secrets.kv.v2.delete_metadata_and_all_versions(
+            path=path,
+            mount_point=mount_point,
+        )
+
+
+def _run_envdrift_cli(
+    args: list[str],
+    cwd: Path,
+    env: dict,
+    integration_pythonpath: str,
+    timeout: int = 60,
+) -> subprocess.CompletedProcess:
+    """Run the envdrift CLI as a real subprocess against the live container."""
+    run_env = env.copy()
+    run_env["PYTHONPATH"] = integration_pythonpath
+    return subprocess.run(
+        [sys.executable, "-m", "envdrift.cli", *args],
+        cwd=cwd,
+        env=run_env,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+# --- P0: authenticate() with an invalid token -----------------------------
+
+
+# The documented contract is that an invalid token surfaces as
+# AuthenticationError("Vault token is invalid or expired"). A known bug
+# (src/envdrift/vault/hashicorp.py:86-91) re-wraps that AuthenticationError as a
+# VaultError via the broad `except Exception`, so the assertion below currently
+# fails on a real container. xfail(strict=False) keeps the test green while
+# encoding the correct, documented behavior (it will XPASS once the bug is fixed).
+@pytest.mark.xfail(
+    reason="hashicorp.authenticate() re-wraps AuthenticationError as VaultError "
+    "(broad except Exception at hashicorp.py:90) — see #305",
+    strict=False,
+)
+def test_hcv_invalid_token_raises_authentication_error(vault_endpoint: str):
+    """BP-02: an invalid token must raise AuthenticationError on authenticate()."""
+    from envdrift.vault.base import AuthenticationError
+    from envdrift.vault.hashicorp import HashiCorpVaultClient
+
+    client = HashiCorpVaultClient(
+        url=vault_endpoint,
+        token="definitely-not-a-valid-token",
+    )
+
+    assert client.is_authenticated() is False
+    with pytest.raises(AuthenticationError, match="invalid or expired"):
+        client.authenticate()
+    assert client.is_authenticated() is False
+
+
+# --- P0: CLI vault-push single-service mode -------------------------------
+
+
+def test_hcv_cli_vault_push_single_service_stores_key_and_reports_version(
+    vault_endpoint: str,
+    vault_test_env: dict,
+    vault_client,
+    work_dir: Path,
+    integration_pythonpath: str,
+    envdrift_cmd: list[str],
+):
+    """HP-11: single-service vault-push stores the key and reports a version."""
+    secret_path = "test/cli-push-single"
+    env_keys = work_dir / ".env.keys"
+    env_keys.write_text("DOTENV_PRIVATE_KEY_PRODUCTION=prod-key-abc123\n")
+
+    try:
+        result = _run_envdrift_cli(
+            [
+                "vault-push",
+                ".",
+                secret_path,
+                "--env",
+                "production",
+                "-p",
+                "hashicorp",
+                "--vault-url",
+                vault_endpoint,
+            ],
+            cwd=work_dir,
+            env=vault_test_env,
+            integration_pythonpath=integration_pythonpath,
+        )
+
+        assert result.returncode == 0, (
+            f"push failed: {result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+        )
+        combined = result.stdout + result.stderr
+        assert "Pushed" in combined
+        assert "Version" in combined
+
+        read_back = vault_client.secrets.kv.v2.read_secret_version(
+            path=secret_path,
+            mount_point="secret",
+        )
+        assert read_back["data"]["data"]["value"] == "DOTENV_PRIVATE_KEY_PRODUCTION=prod-key-abc123"
+    finally:
+        _delete_vault_path(vault_client, secret_path)
+
+
+# --- P0: CLI vault-pull default writes keys AND decrypts ------------------
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(
+    not DOTENVX_AVAILABLE, reason="dotenvx binary required to encrypt/decrypt .env files"
+)
+def test_hcv_cli_vault_pull_default_writes_keys_and_decrypts(
+    vault_endpoint: str,
+    vault_test_env: dict,
+    vault_client,
+    work_dir: Path,
+    integration_pythonpath: str,
+    envdrift_cmd: list[str],
+):
+    """HP-12: vault-pull (default) recreates .env.keys and decrypts .env.production."""
+    secret_path = "test/cli-pull-decrypt"
+    plaintext = "API_URL=https://example.com\nSECRET_TOKEN=plaintext-value-123\n"
+    env_file = work_dir / ".env.production"
+    env_file.write_text(plaintext)
+
+    # Use the real envdrift CLI to generate a dotenvx keypair and encrypt the file.
+    encrypt_result = _run_envdrift_cli(
+        ["encrypt", ".env.production"],
+        cwd=work_dir,
+        env=vault_test_env,
+        integration_pythonpath=integration_pythonpath,
+    )
+    assert encrypt_result.returncode == 0, (
+        f"encrypt failed: {encrypt_result.stdout}\n{encrypt_result.stderr}"
+    )
+    encrypted = env_file.read_text()
+    assert "encrypted:" in encrypted
+
+    # Extract the generated private key from .env.keys.
+    env_keys = work_dir / ".env.keys"
+    from envdrift.sync.operations import EnvKeysFile
+
+    priv = EnvKeysFile(env_keys).read_key("DOTENV_PRIVATE_KEY_PRODUCTION")
+    assert priv, "dotenvx did not write DOTENV_PRIVATE_KEY_PRODUCTION"
+
+    # Push the key into Vault, then delete the local keys so pull must recreate it.
+    vault_client.secrets.kv.v2.create_or_update_secret(
+        path=secret_path,
+        secret={"value": f"DOTENV_PRIVATE_KEY_PRODUCTION={priv}"},
+        mount_point="secret",
+    )
+    env_keys.unlink()
+
+    try:
+        result = _run_envdrift_cli(
+            [
+                "vault-pull",
+                ".",
+                secret_path,
+                "--env",
+                "production",
+                "-p",
+                "hashicorp",
+                "--vault-url",
+                vault_endpoint,
+            ],
+            cwd=work_dir,
+            env=vault_test_env,
+            integration_pythonpath=integration_pythonpath,
+        )
+
+        assert result.returncode == 0, (
+            f"pull failed: {result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+        )
+        combined = result.stdout + result.stderr
+        assert "Decrypted" in combined
+
+        keys_content = env_keys.read_text()
+        assert f"DOTENV_PRIVATE_KEY_PRODUCTION={priv}" in keys_content
+
+        decrypted = env_file.read_text()
+        assert "SECRET_TOKEN=plaintext-value-123" in decrypted
+        assert "encrypted:" not in decrypted
+    finally:
+        _delete_vault_path(vault_client, secret_path)
+
+
+# --- P0: CLI vault-pull env-prefix mismatch -------------------------------
+
+
+def test_hcv_cli_vault_pull_env_prefix_mismatch_exits_1(
+    vault_endpoint: str,
+    vault_test_env: dict,
+    vault_client,
+    work_dir: Path,
+    integration_pythonpath: str,
+    envdrift_cmd: list[str],
+):
+    """BP-13: secret stored for STAGING but pulled --env production fails fast."""
+    secret_path = "test/cli-pull-mismatch"
+    vault_client.secrets.kv.v2.create_or_update_secret(
+        path=secret_path,
+        secret={"value": "DOTENV_PRIVATE_KEY_STAGING=staging-priv-key"},
+        mount_point="secret",
+    )
+    env_keys = work_dir / ".env.keys"
+
+    try:
+        result = _run_envdrift_cli(
+            [
+                "vault-pull",
+                ".",
+                secret_path,
+                "--env",
+                "production",
+                "--no-decrypt",
+                "-p",
+                "hashicorp",
+                "--vault-url",
+                vault_endpoint,
+            ],
+            cwd=work_dir,
+            env=vault_test_env,
+            integration_pythonpath=integration_pythonpath,
+        )
+
+        assert result.returncode == 1, (
+            f"expected rc=1, got {result.returncode}\n{result.stdout}\n{result.stderr}"
+        )
+        combined = result.stdout + result.stderr
+        assert "DOTENV_PRIVATE_KEY_STAGING" in combined
+        assert "DOTENV_PRIVATE_KEY_PRODUCTION" in combined
+        # .env.keys must NOT be written when the prefix mismatch is detected.
+        assert not env_keys.exists()
+    finally:
+        _delete_vault_path(vault_client, secret_path)
+
+
+# --- P0: CLI vault-pull --no-decrypt of a bare value ----------------------
+
+
+def test_hcv_cli_vault_pull_bare_value_stored_as_key_value(
+    vault_endpoint: str,
+    vault_test_env: dict,
+    vault_client,
+    work_dir: Path,
+    integration_pythonpath: str,
+    envdrift_cmd: list[str],
+):
+    """EC-05: a bare (no-prefix) value is stored verbatim under the env key name."""
+    secret_path = "test/cli-pull-bare"
+    bare = "just-a-raw-private-key-no-prefix"
+    vault_client.secrets.kv.v2.create_or_update_secret(
+        path=secret_path,
+        secret={"value": bare},
+        mount_point="secret",
+    )
+    env_keys = work_dir / ".env.keys"
+
+    try:
+        result = _run_envdrift_cli(
+            [
+                "vault-pull",
+                ".",
+                secret_path,
+                "--env",
+                "production",
+                "--no-decrypt",
+                "-p",
+                "hashicorp",
+                "--vault-url",
+                vault_endpoint,
+            ],
+            cwd=work_dir,
+            env=vault_test_env,
+            integration_pythonpath=integration_pythonpath,
+        )
+
+        assert result.returncode == 0, (
+            f"pull failed: {result.returncode}\n{result.stdout}\n{result.stderr}"
+        )
+        assert f"DOTENV_PRIVATE_KEY_PRODUCTION={bare}" in env_keys.read_text()
+    finally:
+        _delete_vault_path(vault_client, secret_path)
+
+
+# --- P0: CLI vault-pull --no-decrypt writes key only ----------------------
+
+
+def test_hcv_cli_vault_pull_no_decrypt_writes_key_only(
+    vault_endpoint: str,
+    vault_test_env: dict,
+    vault_client,
+    work_dir: Path,
+    integration_pythonpath: str,
+    envdrift_cmd: list[str],
+):
+    """HP-13: vault-pull --no-decrypt writes only the key, skipping decryption."""
+    secret_path = "test/cli-pull-nodecrypt"
+    vault_client.secrets.kv.v2.create_or_update_secret(
+        path=secret_path,
+        secret={"value": "DOTENV_PRIVATE_KEY_PRODUCTION=abc-priv-key"},
+        mount_point="secret",
+    )
+    env_keys = work_dir / ".env.keys"
+
+    try:
+        result = _run_envdrift_cli(
+            [
+                "vault-pull",
+                ".",
+                secret_path,
+                "--env",
+                "production",
+                "--no-decrypt",
+                "-p",
+                "hashicorp",
+                "--vault-url",
+                vault_endpoint,
+            ],
+            cwd=work_dir,
+            env=vault_test_env,
+            integration_pythonpath=integration_pythonpath,
+        )
+
+        assert result.returncode == 0, (
+            f"pull failed: {result.returncode}\n{result.stdout}\n{result.stderr}"
+        )
+        assert env_keys.exists()
+        assert "DOTENV_PRIVATE_KEY_PRODUCTION=abc-priv-key" in env_keys.read_text()
+        assert "Decrypted" not in (result.stdout + result.stderr)
+    finally:
+        _delete_vault_path(vault_client, secret_path)
+
+
+# --- P0: CLI vault-pull default with missing target .env file -------------
+
+
+def test_hcv_cli_vault_pull_missing_target_env_file_message_no_error(
+    vault_endpoint: str,
+    vault_test_env: dict,
+    vault_client,
+    work_dir: Path,
+    integration_pythonpath: str,
+    envdrift_cmd: list[str],
+):
+    """EC-06: default pull with no .env.production prints a notice and exits 0."""
+    secret_path = "test/cli-pull-no-target"
+    vault_client.secrets.kv.v2.create_or_update_secret(
+        path=secret_path,
+        secret={"value": "DOTENV_PRIVATE_KEY_PRODUCTION=abc-priv-key"},
+        mount_point="secret",
+    )
+    env_keys = work_dir / ".env.keys"
+
+    try:
+        result = _run_envdrift_cli(
+            [
+                "vault-pull",
+                ".",
+                secret_path,
+                "--env",
+                "production",
+                "-p",
+                "hashicorp",
+                "--vault-url",
+                vault_endpoint,
+            ],
+            cwd=work_dir,
+            env=vault_test_env,
+            integration_pythonpath=integration_pythonpath,
+        )
+
+        assert result.returncode == 0, (
+            f"pull failed: {result.returncode}\n{result.stdout}\n{result.stderr}"
+        )
+        combined = (result.stdout + result.stderr).lower()
+        assert "no" in combined
+        assert "to decrypt" in combined
+        assert env_keys.exists()
+        assert "DOTENV_PRIVATE_KEY_PRODUCTION=abc-priv-key" in env_keys.read_text()
+    finally:
+        _delete_vault_path(vault_client, secret_path)
+
+
+# --- P0: vault-push hashicorp without --vault-url --------------------------
+
+
+def test_hcv_cli_vault_push_missing_vault_url_exits_1(
+    vault_test_env: dict,
+    work_dir: Path,
+    integration_pythonpath: str,
+    envdrift_cmd: list[str],
+):
+    """BP-09: hashicorp provider without --vault-url and no config exits 1."""
+    env_keys = work_dir / ".env.keys"
+    env_keys.write_text("DOTENV_PRIVATE_KEY_PRODUCTION=prod-key\n")
+
+    result = _run_envdrift_cli(
+        [
+            "vault-push",
+            ".",
+            "test/no-url",
+            "--env",
+            "production",
+            "-p",
+            "hashicorp",
+        ],
+        cwd=work_dir,
+        env=vault_test_env,
+        integration_pythonpath=integration_pythonpath,
+    )
+
+    assert result.returncode == 1, (
+        f"expected rc=1, got {result.returncode}\n{result.stdout}\n{result.stderr}"
+    )
+    assert "--vault-url required for hashicorp" in (result.stdout + result.stderr)
+
+
+# --- P0: vault-push normal mode missing --env -----------------------------
+
+
+def test_hcv_cli_vault_push_normal_mode_missing_env_exits_1(
+    vault_endpoint: str,
+    vault_test_env: dict,
+    work_dir: Path,
+    integration_pythonpath: str,
+    envdrift_cmd: list[str],
+):
+    """BP-10: vault-push normal mode without --env exits 1."""
+    env_keys = work_dir / ".env.keys"
+    env_keys.write_text("DOTENV_PRIVATE_KEY_PRODUCTION=prod-key\n")
+
+    result = _run_envdrift_cli(
+        [
+            "vault-push",
+            ".",
+            "test/missing-env",
+            "-p",
+            "hashicorp",
+            "--vault-url",
+            vault_endpoint,
+        ],
+        cwd=work_dir,
+        env=vault_test_env,
+        integration_pythonpath=integration_pythonpath,
+    )
+
+    assert result.returncode == 1, (
+        f"expected rc=1, got {result.returncode}\n{result.stdout}\n{result.stderr}"
+    )
+    combined = result.stdout + result.stderr
+    assert "Required:" in combined
+    assert "--env" in combined
+
+
+# --- P0: vault-push normal mode missing .env.keys -------------------------
+
+
+def test_hcv_cli_vault_push_missing_env_keys_file_exits_1(
+    vault_endpoint: str,
+    vault_test_env: dict,
+    work_dir: Path,
+    integration_pythonpath: str,
+    envdrift_cmd: list[str],
+):
+    """BP-11: vault-push normal mode with absent .env.keys exits 1."""
+    result = _run_envdrift_cli(
+        [
+            "vault-push",
+            ".",
+            "test/no-keys",
+            "--env",
+            "production",
+            "-p",
+            "hashicorp",
+            "--vault-url",
+            vault_endpoint,
+        ],
+        cwd=work_dir,
+        env=vault_test_env,
+        integration_pythonpath=integration_pythonpath,
+    )
+
+    assert result.returncode == 1, (
+        f"expected rc=1, got {result.returncode}\n{result.stdout}\n{result.stderr}"
+    )
+    combined = result.stdout + result.stderr
+    assert "File not found" in combined
+    assert ".env.keys" in combined
+
+
+# --- P0: vault-push key not present in .env.keys --------------------------
+
+
+def test_hcv_cli_vault_push_key_not_in_env_keys_exits_1(
+    vault_endpoint: str,
+    vault_test_env: dict,
+    work_dir: Path,
+    integration_pythonpath: str,
+    envdrift_cmd: list[str],
+):
+    """BP-12: .env.keys lacks the requested env key -> exit 1."""
+    env_keys = work_dir / ".env.keys"
+    env_keys.write_text("DOTENV_PRIVATE_KEY_STAGING=staging-only\n")
+
+    result = _run_envdrift_cli(
+        [
+            "vault-push",
+            ".",
+            "test/wrong-env",
+            "--env",
+            "production",
+            "-p",
+            "hashicorp",
+            "--vault-url",
+            vault_endpoint,
+        ],
+        cwd=work_dir,
+        env=vault_test_env,
+        integration_pythonpath=integration_pythonpath,
+    )
+
+    assert result.returncode == 1, (
+        f"expected rc=1, got {result.returncode}\n{result.stdout}\n{result.stderr}"
+    )
+    combined = result.stdout + result.stderr
+    assert "DOTENV_PRIVATE_KEY_PRODUCTION" in combined
+    assert "not found" in combined
+
+
+# --- P0: vault-push --direct missing positional value ---------------------
+
+
+def test_hcv_cli_vault_push_direct_missing_positional_args_exits_1(
+    vault_endpoint: str,
+    vault_test_env: dict,
+    work_dir: Path,
+    integration_pythonpath: str,
+    envdrift_cmd: list[str],
+):
+    """BP-16: --direct with only a secret name (no value) exits 1."""
+    result = _run_envdrift_cli(
+        [
+            "vault-push",
+            "--direct",
+            "some-secret-name",
+            "-p",
+            "hashicorp",
+            "--vault-url",
+            vault_endpoint,
+        ],
+        cwd=work_dir,
+        env=vault_test_env,
+        integration_pythonpath=integration_pythonpath,
+    )
+
+    assert result.returncode == 1, (
+        f"expected rc=1, got {result.returncode}\n{result.stdout}\n{result.stderr}"
+    )
+    assert "Direct mode requires" in (result.stdout + result.stderr)
+
+
+# --- P0: --skip-encrypt without --all warns and continues -----------------
+
+
+def test_hcv_cli_skip_encrypt_without_all_warns_and_continues(
+    vault_endpoint: str,
+    vault_test_env: dict,
+    vault_client,
+    work_dir: Path,
+    integration_pythonpath: str,
+    envdrift_cmd: list[str],
+):
+    """BP-17: --skip-encrypt without --all warns but still pushes (single-service)."""
+    secret_path = "test/cli-skip-encrypt-warn"
+    env_keys = work_dir / ".env.keys"
+    env_keys.write_text("DOTENV_PRIVATE_KEY_PRODUCTION=prod-key-skip\n")
+
+    try:
+        result = _run_envdrift_cli(
+            [
+                "vault-push",
+                ".",
+                secret_path,
+                "--env",
+                "production",
+                "--skip-encrypt",
+                "-p",
+                "hashicorp",
+                "--vault-url",
+                vault_endpoint,
+            ],
+            cwd=work_dir,
+            env=vault_test_env,
+            integration_pythonpath=integration_pythonpath,
+        )
+
+        combined = result.stdout + result.stderr
+        assert "--skip-encrypt is only applicable with --all" in combined
+        assert result.returncode == 0, f"expected rc=0, got {result.returncode}\n{combined}"
+        assert "Pushed" in combined
+    finally:
+        _delete_vault_path(vault_client, secret_path)
+
+
+# --- P0: --force without --all warns and continues ------------------------
+
+
+def test_hcv_cli_force_without_all_warns_and_continues(
+    vault_endpoint: str,
+    vault_test_env: dict,
+    vault_client,
+    work_dir: Path,
+    integration_pythonpath: str,
+    envdrift_cmd: list[str],
+):
+    """BP-18: --force without --all warns but still pushes (single-service)."""
+    secret_path = "test/cli-force-warn"
+    env_keys = work_dir / ".env.keys"
+    env_keys.write_text("DOTENV_PRIVATE_KEY_PRODUCTION=prod-key-force\n")
+
+    try:
+        result = _run_envdrift_cli(
+            [
+                "vault-push",
+                ".",
+                secret_path,
+                "--env",
+                "production",
+                "--force",
+                "-p",
+                "hashicorp",
+                "--vault-url",
+                vault_endpoint,
+            ],
+            cwd=work_dir,
+            env=vault_test_env,
+            integration_pythonpath=integration_pythonpath,
+        )
+
+        combined = result.stdout + result.stderr
+        assert "--force is only applicable with --all" in combined
+        assert result.returncode == 0, f"expected rc=0, got {result.returncode}\n{combined}"
+        assert "Pushed" in combined
+    finally:
+        _delete_vault_path(vault_client, secret_path)
+
+
+# --- P1: multi-key secret returns JSON ------------------------------------
+
+
+def test_hcv_get_secret_multikey_returns_json(
+    vault_endpoint: str,
+    vault_client,
+    populated_vault_secrets: dict,
+):
+    """HP-04: a multi-key secret is returned as a JSON-encoded string."""
+    from envdrift.vault.hashicorp import HashiCorpVaultClient
+
+    client = HashiCorpVaultClient(url=vault_endpoint, token=VAULT_ROOT_TOKEN)
+    client.authenticate()
+
+    secret = client.get_secret("shared/api-keys")
+
+    assert secret.value.startswith("{")
+    assert json.loads(secret.value) == {
+        "API_KEY": "secret123",
+        "API_SECRET": "secret456",
+    }
+    assert secret.version is not None

--- a/tests/integration/test_partial_encryption_e2e.py
+++ b/tests/integration/test_partial_encryption_e2e.py
@@ -1,0 +1,547 @@
+"""Partial encryption end-to-end integration tests (real dotenvx binary + real git).
+
+These tests exercise the ``envdrift push`` / ``envdrift pull-partial`` commands
+as real subprocesses against the **real dotenvx binary** and **real git**. No
+mocking of the behavior under test: encryption/decryption is performed by the
+actual dotenvx CLI and the combined-file / secrets-only logic runs end to end.
+
+Test categories:
+- Secrets-only push/pull-partial (HP-05/06/07, BP-09/13)
+- Combine-mode push --check staleness (BP-12) and combined-file structure (HP-01, EC-07)
+- Full lock/pull/lock cycle (HP-11) and .env.keys exclusion (EC-09)
+
+Gating:
+- The dotenvx binary is required; tests skip if it is absent (CI installs it).
+- git is required and is provided by the ``git_repo`` fixture (skips if absent).
+
+Resource isolation: each test uses its own ``tmp_path``-backed ``work_dir`` and
+secrets directory, so concurrent / repeated runs never collide.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+# Mark all tests in this module. No container needed: real dotenvx + real git.
+pytestmark = [pytest.mark.integration]
+
+# dotenvx is the encryption backend used by partial encryption. Skip the whole
+# module locally when it is not installed (CI installs it). git is gated per-test
+# via the ``git_repo`` fixture.
+pytestmark.append(
+    pytest.mark.skipif(
+        shutil.which("dotenvx") is None,
+        reason="dotenvx binary not installed (required for real partial-encryption e2e)",
+    )
+)
+
+
+# --- Local helpers (defined here so conftest.py is never modified) ---
+
+
+def _run_envdrift(
+    args: list[str],
+    *,
+    cwd: Path,
+    integration_pythonpath: str,
+    envdrift_cmd: list[str],
+    timeout: int = 60,
+) -> subprocess.CompletedProcess[str]:
+    """Run the real envdrift CLI as a subprocess and capture its output."""
+    env = os.environ.copy()
+    env["PYTHONPATH"] = integration_pythonpath
+    return subprocess.run(
+        [*envdrift_cmd, *args],
+        cwd=cwd,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def _write_secrets_only_config(work_dir: Path, *, name: str, secrets_dir: str) -> None:
+    """Write a secrets-only envdrift.toml for one environment."""
+    (work_dir / "envdrift.toml").write_text(
+        "[partial_encryption]\n"
+        "enabled = true\n\n"
+        "[[partial_encryption.environments]]\n"
+        f'name = "{name}"\n'
+        "secrets_only = true\n"
+        f'secrets_dir = "{secrets_dir}"\n'
+    )
+
+
+def _write_combine_config(
+    work_dir: Path,
+    *,
+    name: str,
+    clear_file: str,
+    secret_file: str,
+    combined_file: str,
+) -> None:
+    """Write a combine-mode envdrift.toml for one environment."""
+    (work_dir / "envdrift.toml").write_text(
+        "[partial_encryption]\n"
+        "enabled = true\n\n"
+        "[[partial_encryption.environments]]\n"
+        f'name = "{name}"\n'
+        f'clear_file = "{clear_file}"\n'
+        f'secret_file = "{secret_file}"\n'
+        f'combined_file = "{combined_file}"\n'
+    )
+
+
+def _out(result: subprocess.CompletedProcess[str]) -> str:
+    """Combined stdout+stderr for substring assertions."""
+    return result.stdout + result.stderr
+
+
+# ---------------------------------------------------------------------------
+# P0 tests
+# ---------------------------------------------------------------------------
+
+
+class TestSecretsOnlyPushPull:
+    """Secrets-only push/pull-partial against the real dotenvx binary."""
+
+    def test_secrets_only_push_encrypts_all_matching_files_real_binary(
+        self,
+        git_repo: Path,
+        integration_pythonpath: str,
+        envdrift_cmd: list[str],
+    ):
+        """HP-06: push encrypts every matching file in secrets_dir in place."""
+        work_dir = git_repo
+        secrets = work_dir / "secrets"
+        secrets.mkdir()
+        _write_secrets_only_config(work_dir, name="prod", secrets_dir="secrets")
+
+        api = secrets / ".env.api"
+        web = secrets / ".env.web"
+        api.write_text("STRIPE_KEY=sk_live_fake\nDB=postgres://x\n")
+        web.write_text("TOKEN=abc123\n")
+
+        result = _run_envdrift(
+            ["push"],
+            cwd=work_dir,
+            integration_pythonpath=integration_pythonpath,
+            envdrift_cmd=envdrift_cmd,
+        )
+
+        assert result.returncode == 0, _out(result)
+        assert "Encrypted 2 file(s)" in _out(result), _out(result)
+
+        for f in (api, web):
+            content = f.read_text()
+            assert "encrypted:" in content, f"{f} not encrypted:\n{content}"
+            assert "DOTENV_PUBLIC_KEY" in content, f"{f} missing public-key header:\n{content}"
+
+        # dotenvx writes the private key file next to the encrypted files.
+        assert (secrets / ".env.keys").exists(), "private key file (.env.keys) was not created"
+
+    def test_secrets_only_pull_decrypts_all_matching_files_real_binary(
+        self,
+        git_repo: Path,
+        integration_pythonpath: str,
+        envdrift_cmd: list[str],
+    ):
+        """HP-07: pull-partial decrypts every encrypted file back to plaintext."""
+        work_dir = git_repo
+        secrets = work_dir / "secrets"
+        secrets.mkdir()
+        _write_secrets_only_config(work_dir, name="prod", secrets_dir="secrets")
+
+        api = secrets / ".env.api"
+        web = secrets / ".env.web"
+        api.write_text("STRIPE_KEY=sk_live_fake\n")
+        web.write_text("TOKEN=abc123\n")
+
+        push = _run_envdrift(
+            ["push"],
+            cwd=work_dir,
+            integration_pythonpath=integration_pythonpath,
+            envdrift_cmd=envdrift_cmd,
+        )
+        assert push.returncode == 0, _out(push)
+        assert "encrypted:" in api.read_text()
+
+        pull = _run_envdrift(
+            ["pull-partial"],
+            cwd=work_dir,
+            integration_pythonpath=integration_pythonpath,
+            envdrift_cmd=envdrift_cmd,
+        )
+
+        assert pull.returncode == 0, _out(pull)
+        assert "Decrypted 2 file(s)" in _out(pull), _out(pull)
+
+        api_content = api.read_text()
+        assert "STRIPE_KEY=sk_live_fake" in api_content, api_content
+        # No encrypted value lines should remain after a real decrypt.
+        assert "encrypted:" not in api_content, api_content
+        assert "TOKEN=abc123" in web.read_text()
+
+    def test_secrets_only_push_check_reports_in_sync_when_all_encrypted(
+        self,
+        git_repo: Path,
+        integration_pythonpath: str,
+        envdrift_cmd: list[str],
+    ):
+        """HP-05: push --check is a dry run reporting in_sync (exit 0), mutating nothing."""
+        work_dir = git_repo
+        secrets = work_dir / "secrets"
+        secrets.mkdir()
+        _write_secrets_only_config(work_dir, name="prod", secrets_dir="secrets")
+
+        api = secrets / ".env.api"
+        api.write_text("STRIPE_KEY=sk_live_fake\n")
+
+        push = _run_envdrift(
+            ["push"],
+            cwd=work_dir,
+            integration_pythonpath=integration_pythonpath,
+            envdrift_cmd=envdrift_cmd,
+        )
+        assert push.returncode == 0, _out(push)
+
+        before = api.read_bytes()
+
+        check = _run_envdrift(
+            ["push", "--check"],
+            cwd=work_dir,
+            integration_pythonpath=integration_pythonpath,
+            envdrift_cmd=envdrift_cmd,
+        )
+
+        assert check.returncode == 0, _out(check)
+        out = _out(check)
+        assert "up to date" in out, out
+        assert "Out of date: 0" in out, out
+        # Dry run must not touch the encrypted file.
+        assert api.read_bytes() == before, "push --check mutated the encrypted file"
+
+    def test_secrets_only_push_check_fails_when_files_unencrypted(
+        self,
+        git_repo: Path,
+        integration_pythonpath: str,
+        envdrift_cmd: list[str],
+    ):
+        """BP-13: push --check exits non-zero when a secrets-only file is still plaintext."""
+        work_dir = git_repo
+        secrets = work_dir / "secrets"
+        secrets.mkdir()
+        _write_secrets_only_config(work_dir, name="prod", secrets_dir="secrets")
+
+        api = secrets / ".env.api"
+        api.write_text("STRIPE_KEY=sk_live_fake\n")
+
+        check = _run_envdrift(
+            ["push", "--check"],
+            cwd=work_dir,
+            integration_pythonpath=integration_pythonpath,
+            envdrift_cmd=envdrift_cmd,
+        )
+
+        assert check.returncode == 1, _out(check)
+        out = _out(check).lower()
+        assert "not encrypted" in out or "out of date" in out, _out(check)
+        # Dry run leaves the file plaintext.
+        assert "encrypted:" not in api.read_text(), api.read_text()
+        # secrets-only mode never produces a combined file.
+        assert "combined file" not in out, _out(check)
+
+    def test_secrets_only_pull_partial_missing_keys_surfaces_error_real_binary(
+        self,
+        git_repo: Path,
+        integration_pythonpath: str,
+        envdrift_cmd: list[str],
+    ):
+        """BP-09: pull-partial with .env.keys removed surfaces MISSING_PRIVATE_KEY, exits non-zero."""
+        work_dir = git_repo
+        secrets = work_dir / "secrets"
+        secrets.mkdir()
+        _write_secrets_only_config(work_dir, name="prod", secrets_dir="secrets")
+
+        api = secrets / ".env.api"
+        api.write_text("STRIPE_KEY=sk_live_fake\n")
+
+        push = _run_envdrift(
+            ["push"],
+            cwd=work_dir,
+            integration_pythonpath=integration_pythonpath,
+            envdrift_cmd=envdrift_cmd,
+        )
+        assert push.returncode == 0, _out(push)
+        assert "encrypted:" in api.read_text()
+
+        # Remove every private-key file so dotenvx cannot decrypt.
+        for keys in (secrets / ".env.keys", work_dir / ".env.keys"):
+            if keys.exists():
+                keys.unlink()
+
+        pull = _run_envdrift(
+            ["pull-partial"],
+            cwd=work_dir,
+            integration_pythonpath=integration_pythonpath,
+            envdrift_cmd=envdrift_cmd,
+        )
+
+        assert pull.returncode == 1, _out(pull)
+        out = _out(pull)
+        assert "Failed to decrypt" in out, out
+        assert "MISSING_PRIVATE_KEY" in out or "private key" in out.lower(), out
+        assert "Errors: 1" in out, out
+        # File must remain encrypted (no partial/half-written state).
+        assert "encrypted:" in api.read_text(), api.read_text()
+
+
+class TestCombineModePush:
+    """Combine-mode push --check staleness and combined-file structure (real binary)."""
+
+    def test_combine_push_check_fails_when_combined_stale_real_binary(
+        self,
+        git_repo: Path,
+        integration_pythonpath: str,
+        envdrift_cmd: list[str],
+    ):
+        """BP-12: push --check exits non-zero when the combined file is stale after a manual edit."""
+        work_dir = git_repo
+        _write_combine_config(
+            work_dir,
+            name="production",
+            clear_file=".env.production.clear",
+            secret_file=".env.production.secret",
+            combined_file=".env.production",
+        )
+        (work_dir / ".env.production.clear").write_text("APP_NAME=myapp\n")
+        secret = work_dir / ".env.production.secret"
+        secret.write_text("STRIPE_KEY=sk_live_x\n")
+
+        push = _run_envdrift(
+            ["push", "--env", "production"],
+            cwd=work_dir,
+            integration_pythonpath=integration_pythonpath,
+            envdrift_cmd=envdrift_cmd,
+        )
+        assert push.returncode == 0, _out(push)
+        assert "encrypted:" in secret.read_text()
+
+        # Manually corrupt the generated combined file so it is now stale.
+        combined = work_dir / ".env.production"
+        combined.write_text(combined.read_text() + "STALE=yes\n")
+
+        check = _run_envdrift(
+            ["push", "--check", "--env", "production"],
+            cwd=work_dir,
+            integration_pythonpath=integration_pythonpath,
+            envdrift_cmd=envdrift_cmd,
+        )
+
+        assert check.returncode == 1, _out(check)
+        assert "out of date" in _out(check).lower(), _out(check)
+        # Dry run must not regenerate the combined file: manual edit survives.
+        assert "STALE=yes" in combined.read_text(), combined.read_text()
+        # Secret source stays encrypted.
+        assert "encrypted:" in secret.read_text(), secret.read_text()
+
+    def test_combine_push_strips_public_key_border_and_excludes_it_from_count_real_binary(
+        self,
+        git_repo: Path,
+        integration_pythonpath: str,
+        envdrift_cmd: list[str],
+    ):
+        """EC-07: dotenvx public-key border lines are stripped and the public key is not counted."""
+        work_dir = git_repo
+        _write_combine_config(
+            work_dir,
+            name="production",
+            clear_file=".env.production.clear",
+            secret_file=".env.production.secret",
+            combined_file=".env.production",
+        )
+        (work_dir / ".env.production.clear").write_text("APP_NAME=myapp\n")
+        secret = work_dir / ".env.production.secret"
+        secret.write_text("STRIPE_KEY=sk_live_x\nDB_PASS=hunter2\n")
+
+        push = _run_envdrift(
+            ["push", "--env", "production"],
+            cwd=work_dir,
+            integration_pythonpath=integration_pythonpath,
+            envdrift_cmd=envdrift_cmd,
+        )
+
+        assert push.returncode == 0, _out(push)
+
+        combined = (work_dir / ".env.production").read_text()
+        # Both real secrets land in the combined file as encrypted values.
+        assert combined.count("encrypted:") == 2, combined
+        # dotenvx's own public-key block border is stripped (it starts with "#/---").
+        assert "[DOTENV_PUBLIC_KEY]" not in combined, combined
+        # The public key is excluded from the reported secret-var count: 2 (not 3).
+        assert "2 encrypted" in _out(push), _out(push)
+        assert "Encrypted vars: 2" in _out(push), _out(push)
+
+
+# ---------------------------------------------------------------------------
+# P1 tests
+# ---------------------------------------------------------------------------
+
+
+class TestSecretsOnlyLifecycle:
+    """Full lock/pull/lock cycle and .env.keys exclusion (real binary)."""
+
+    def test_secrets_only_full_lock_pull_lock_cycle_real_binary(
+        self,
+        git_repo: Path,
+        integration_pythonpath: str,
+        envdrift_cmd: list[str],
+    ):
+        """HP-11: secrets-only push -> pull-partial -> push round-trips losslessly."""
+        work_dir = git_repo
+        secrets = work_dir / "secrets"
+        secrets.mkdir()
+        _write_secrets_only_config(work_dir, name="prod", secrets_dir="secrets")
+
+        api = secrets / ".env.api"
+        web = secrets / ".env.web"
+        api.write_text("STRIPE_KEY=sk_live_fake\nDB=postgres://x\n")
+        web.write_text("TOKEN=abc123\n")
+
+        # Step 1: encrypt
+        push1 = _run_envdrift(
+            ["push"],
+            cwd=work_dir,
+            integration_pythonpath=integration_pythonpath,
+            envdrift_cmd=envdrift_cmd,
+        )
+        assert push1.returncode == 0, _out(push1)
+        assert "encrypted:" in api.read_text()
+        assert "encrypted:" in web.read_text()
+
+        # Step 2: decrypt — original plaintext secret values are restored.
+        # (dotenvx keeps its public-key header in the file, so we assert on the
+        # restored values + absence of ciphertext, not byte-for-byte equality.)
+        pull = _run_envdrift(
+            ["pull-partial"],
+            cwd=work_dir,
+            integration_pythonpath=integration_pythonpath,
+            envdrift_cmd=envdrift_cmd,
+        )
+        assert pull.returncode == 0, _out(pull)
+        api_decrypted = api.read_text()
+        assert "STRIPE_KEY=sk_live_fake" in api_decrypted, api_decrypted
+        assert "DB=postgres://x" in api_decrypted, api_decrypted
+        assert "encrypted:" not in api_decrypted, api_decrypted
+        web_decrypted = web.read_text()
+        assert "TOKEN=abc123" in web_decrypted, web_decrypted
+        assert "encrypted:" not in web_decrypted, web_decrypted
+
+        # Step 3: re-encrypt
+        push2 = _run_envdrift(
+            ["push"],
+            cwd=work_dir,
+            integration_pythonpath=integration_pythonpath,
+            envdrift_cmd=envdrift_cmd,
+        )
+        assert push2.returncode == 0, _out(push2)
+        assert "encrypted:" in api.read_text()
+        assert "encrypted:" in web.read_text()
+
+    def test_secrets_only_excludes_env_keys_from_encrypt_decrypt_real_binary(
+        self,
+        git_repo: Path,
+        integration_pythonpath: str,
+        envdrift_cmd: list[str],
+    ):
+        """EC-09: .env.keys is never encrypted/decrypted even though it matches .env*."""
+        work_dir = git_repo
+        secrets = work_dir / "secrets"
+        secrets.mkdir()
+        _write_secrets_only_config(work_dir, name="prod", secrets_dir="secrets")
+
+        api = secrets / ".env.api"
+        web = secrets / ".env.web"
+        api.write_text("A=1\n")
+        web.write_text("B=2\n")
+
+        push = _run_envdrift(
+            ["push"],
+            cwd=work_dir,
+            integration_pythonpath=integration_pythonpath,
+            envdrift_cmd=envdrift_cmd,
+        )
+        assert push.returncode == 0, _out(push)
+        # Keys file not counted: only the two real files are reported encrypted.
+        assert "Encrypted 2 file(s)" in _out(push), _out(push)
+
+        env_keys = secrets / ".env.keys"
+        assert env_keys.exists(), "dotenvx did not create .env.keys"
+        keys_bytes = env_keys.read_bytes()
+        # It must never itself be encrypted.
+        assert "encrypted:" not in env_keys.read_text(), env_keys.read_text()
+        assert "encrypted:" in api.read_text()
+        assert "encrypted:" in web.read_text()
+
+        # A pull-partial must leave .env.keys byte-identical.
+        pull = _run_envdrift(
+            ["pull-partial"],
+            cwd=work_dir,
+            integration_pythonpath=integration_pythonpath,
+            envdrift_cmd=envdrift_cmd,
+        )
+        assert pull.returncode == 0, _out(pull)
+        assert env_keys.read_bytes() == keys_bytes, ".env.keys changed across pull-partial"
+
+
+class TestCombineModeStructure:
+    """Combined-file structure assertions (real binary)."""
+
+    def test_combine_push_produces_correct_combined_file_strong_assertions(
+        self,
+        git_repo: Path,
+        integration_pythonpath: str,
+        envdrift_cmd: list[str],
+    ):
+        """HP-01: combine push produces a combined file with header, clear lines, encrypted values."""
+        work_dir = git_repo
+        _write_combine_config(
+            work_dir,
+            name="production",
+            clear_file=".env.production.clear",
+            secret_file=".env.production.secret",
+            combined_file=".env.production",
+        )
+        (work_dir / ".env.production.clear").write_text("APP_NAME=myapp\nDEBUG=false\n")
+        secret = work_dir / ".env.production.secret"
+        secret.write_text("STRIPE_KEY=sk_live_supersecret\nDB_PASS=hunter2\n")
+
+        push = _run_envdrift(
+            ["push", "--env", "production"],
+            cwd=work_dir,
+            integration_pythonpath=integration_pythonpath,
+            envdrift_cmd=envdrift_cmd,
+        )
+
+        assert push.returncode == 0, _out(push)
+
+        combined = (work_dir / ".env.production").read_text()
+        # Auto-generated warning header.
+        assert "WARNING: AUTO-GENERATED FILE" in combined, combined
+        # Verbatim clear section, with its provenance comment.
+        assert "# From .env.production.clear" in combined, combined
+        assert "APP_NAME=myapp" in combined, combined
+        assert "DEBUG=false" in combined, combined
+        # Encrypted secret section with two encrypted values.
+        assert "# From .env.production.secret (encrypted)" in combined, combined
+        assert combined.count("encrypted:") == 2, combined
+        # Raw secret values must never appear in the combined (committed) artifact.
+        assert "sk_live_supersecret" not in combined, "plaintext secret leaked into combined file"
+        assert "hunter2" not in combined, "plaintext secret leaked into combined file"
+        # The .secret source is now encrypted in place.
+        assert "encrypted:" in secret.read_text(), secret.read_text()

--- a/tests/integration/test_scanner_external_binaries.py
+++ b/tests/integration/test_scanner_external_binaries.py
@@ -249,7 +249,10 @@ def test_scan_engine_parallel_multi_real_scanner_aggregation(git_repo):
     assert len(result.unique_findings) >= 1
     assert result.total_findings >= len(result.unique_findings)
     # Findings should come from more than one scanner (native + trivy at minimum).
-    scanners_with_findings = {f.scanner for f in result.unique_findings}
+    # Use the per-scanner results, NOT unique_findings: ScanEngine deduplicates
+    # after aggregation, so two scanners finding the same secret would collapse to
+    # one entry in unique_findings and understate scanner participation.
+    scanners_with_findings = {r.scanner_name for r in result.results if r.findings}
     assert len(scanners_with_findings) >= 2, (
         f"expected findings from >=2 scanners, got {scanners_with_findings}"
     )
@@ -302,6 +305,12 @@ def test_scan_engine_skip_encrypted_files_filters_real_scanner_findings(tmp_path
 def test_scan_engine_filters_dotenvx_public_keys_from_real_output(tmp_path):
     """EC-12: ScanEngine filters dotenvx EC secp256k1 public keys (66 hex, 02/03)."""
     _write_secret_file(tmp_path, "creds.env")
+    # Plant a real dotenvx-style EC public key (66 hex, starts with 03) in the
+    # scanned tree so the real ScanEngine.scan() path below has an actual public
+    # key to filter — without this the real-output loop is vacuous and only the
+    # synthetic control at the end exercises _filter_public_keys.
+    real_pubkey = "03" + "cd" * 32  # 66 hex chars
+    (tmp_path / "keys.env").write_text(f"DOTENV_PUBLIC_KEY_PRODUCTION={real_pubkey}\n")
 
     config = GuardConfig(
         use_native=True,

--- a/tests/integration/test_scanner_external_binaries.py
+++ b/tests/integration/test_scanner_external_binaries.py
@@ -1,0 +1,351 @@
+"""Integration tests for external-binary secret scanners.
+
+These tests exercise the REAL scanner binaries (talisman, trivy, infisical) and
+the ScanEngine orchestration/filtering against real subprocess output. Each test
+is gated on the binary being installed via ``shutil.which`` / ``is_installed()``
+so it SKIPs cleanly when a tool is absent (e.g. in a minimal local env) and runs
+in CI where the tools are provisioned.
+
+No mocking of scanner behavior: findings come from running the actual tools on
+real files in temporary directories / git repos.
+"""
+
+from __future__ import annotations
+
+import shutil
+from dataclasses import replace
+
+import pytest
+
+from envdrift.scanner.base import AggregatedScanResult, ScanFinding, ScanResult
+from envdrift.scanner.engine import GuardConfig, ScanEngine
+from envdrift.scanner.infisical import InfisicalScanner
+from envdrift.scanner.talisman import TalismanScanner
+from envdrift.scanner.trivy import TrivyScanner
+
+pytestmark = [pytest.mark.integration, pytest.mark.slow]
+
+
+# --- Skip helpers ---------------------------------------------------------
+
+_HAS_TALISMAN = TalismanScanner(auto_install=False).is_installed()
+_HAS_TRIVY = TrivyScanner(auto_install=False).is_installed()
+_HAS_INFISICAL = InfisicalScanner(auto_install=False).is_installed()
+
+requires_talisman = pytest.mark.skipif(
+    not _HAS_TALISMAN, reason="talisman not installed (brew install talisman)"
+)
+requires_trivy = pytest.mark.skipif(
+    not _HAS_TRIVY, reason="trivy not installed (brew install trivy)"
+)
+requires_infisical = pytest.mark.skipif(
+    not _HAS_INFISICAL,
+    reason="infisical not installed (brew install infisical/get-cli/infisical)",
+)
+
+
+# A realistic GitHub PAT + Stripe live key so trivy/talisman/infisical detect
+# them as real secrets. Assembled from fragments at runtime so the full secret
+# pattern never appears as a contiguous literal in source — this keeps GitHub
+# push-protection from blocking the commit, while the scanners still see the
+# complete value in the temp files the tests write.
+GITHUB_TOKEN = "ghp_" + "016C7eX9bQ2vYwN3kLmZpRtUaScDfGhJkL01"
+STRIPE_KEY = "sk_live_" + "4eC39HqLyjWDarjtT1zdp7dc" + "ABCDEFGH"
+
+
+def _write_secret_file(directory, name: str = "creds.env") -> None:
+    """Write a file containing real-format secrets that scanners detect."""
+    (directory / name).write_text(f"GITHUB_TOKEN={GITHUB_TOKEN}\nSTRIPE_KEY={STRIPE_KEY}\n")
+
+
+# --- Talisman (P0) --------------------------------------------------------
+
+
+@requires_talisman
+def test_talisman_scans_committed_repo_and_parses_real_report_json(git_repo, tmp_path):
+    """HP-12/EC-21: talisman scans a committed repo, writes report.json, scanner parses it.
+
+    The real talisman binary exits non-zero when it finds (or even just runs a)
+    scan, but it ALSO writes ``talisman_reports/data/report.json``. The scanner
+    must resolve+parse that report and therefore NOT surface an error.
+    """
+    secret_file = git_repo / "app.env"
+    secret_file.write_text(f"GITHUB_TOKEN={GITHUB_TOKEN}\n")
+    # Talisman requires committed content; the git_repo fixture configures git.
+    import subprocess  # nosec B404
+
+    subprocess.run(["git", "add", "-A"], cwd=git_repo, capture_output=True, check=True)
+    subprocess.run(
+        ["git", "commit", "-m", "add secret"],
+        cwd=git_repo,
+        capture_output=True,
+        check=True,
+    )
+
+    scanner = TalismanScanner(auto_install=False)
+    result = scanner.scan([git_repo])
+
+    assert isinstance(result, ScanResult)
+    assert result.scanner_name == "talisman"
+    # Report was found and parsed -> no error even though talisman rc != 0.
+    assert result.error is None, f"unexpected error: {result.error}"
+    assert result.duration_ms >= 0
+    assert isinstance(result.findings, list)
+
+
+@requires_talisman
+def test_talisman_no_commit_repo_returns_error_not_findings(git_repo, tmp_path):
+    """BP-15: on a repo with NO commits talisman exits 128 and writes no report.
+
+    With no parseable report and a non-zero exit code, the scanner must surface
+    ``ScanResult.error`` (a non-empty string) and report zero findings rather
+    than silently succeeding.
+    """
+    # git_repo is initialized but has NO commits.
+    (git_repo / "app.env").write_text(f"GITHUB_TOKEN={GITHUB_TOKEN}\n")
+
+    scanner = TalismanScanner(auto_install=False)
+    result = scanner.scan([git_repo])
+
+    assert result.scanner_name == "talisman"
+    assert result.findings == []
+    assert isinstance(result.error, str)
+    assert result.error, "expected a non-empty error message on a no-commit repo"
+
+
+# --- Trivy (P0) -----------------------------------------------------------
+
+
+@requires_trivy
+def test_trivy_detects_secrets_via_real_fs_secret_scanner(tmp_path):
+    """HP-13: trivy fs --scanners secret parses Results[].Secrets[] into findings."""
+    _write_secret_file(tmp_path, "creds.env")
+
+    scanner = TrivyScanner(auto_install=False)
+    result = scanner.scan([tmp_path])
+
+    assert result.error is None, f"unexpected error: {result.error}"
+    assert result.scanner_name == "trivy"
+    assert len(result.findings) >= 1
+    for finding in result.findings:
+        assert finding.scanner == "trivy"
+        assert finding.rule_id.startswith("trivy-")
+    # The relative target "creds.env" must resolve under the scanned directory.
+    assert any(f.file_path.name == "creds.env" for f in result.findings)
+    # Trivy redacts the matched secret -> preview contains the masking char.
+    assert any("*" in f.secret_preview for f in result.findings)
+
+
+@requires_trivy
+def test_trivy_nonzero_exit_with_stdout_is_parsed_anyway(tmp_path):
+    """EC-26/BP-17: trivy may exit non-zero but still emit valid JSON on stdout.
+
+    The scanner only treats a non-zero exit as an error when stdout is empty.
+    Here we (a) verify scanner.scan succeeds, and (b) run real trivy with
+    ``--exit-code 1`` to confirm the non-zero-rc-with-findings shape, then feed
+    that JSON through the scanner's own ``_parse_output`` to confirm findings.
+    """
+    import json
+    import subprocess  # nosec B404
+
+    _write_secret_file(tmp_path, "creds.env")
+
+    scanner = TrivyScanner(auto_install=False)
+    result = scanner.scan([tmp_path])
+    assert result.error is None
+    assert isinstance(result.findings, list)
+
+    # Force the non-zero-exit branch with the real binary.
+    binary = shutil.which("trivy")
+    assert binary is not None
+    proc = subprocess.run(  # nosec B603
+        [
+            binary,
+            "fs",
+            "--scanners",
+            "secret",
+            "--format",
+            "json",
+            "--quiet",
+            "--exit-code",
+            "1",
+            str(tmp_path),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    assert proc.returncode != 0, "expected non-zero rc when secrets are found"
+    assert proc.stdout.strip(), "trivy still emits JSON on stdout despite non-zero rc"
+    scan_data = json.loads(proc.stdout)
+    findings, _ = scanner._parse_output(scan_data, tmp_path)
+    assert len(findings) >= 1
+    assert all(f.rule_id.startswith("trivy-") for f in findings)
+
+
+# --- Infisical (P1) -------------------------------------------------------
+
+
+@requires_infisical
+def test_infisical_scan_no_git_parses_real_json_report(tmp_path):
+    """HP-11/BP-17: infisical scan --no-git parses its JSON report (no login needed).
+
+    Infisical exits non-zero when it finds leaks; because a non-empty report is
+    written, the scanner treats that as success (error is None).
+    """
+    _write_secret_file(tmp_path, "app.env")
+
+    scanner = InfisicalScanner(auto_install=False)
+    result = scanner.scan([tmp_path])
+
+    assert result.error is None, f"unexpected error: {result.error}"
+    assert result.scanner_name == "infisical"
+    assert isinstance(result.findings, list)
+    # Infisical reliably flags the GitHub PAT; assert the parsed shape.
+    assert len(result.findings) >= 1
+    for finding in result.findings:
+        assert finding.scanner == "infisical"
+        assert finding.rule_id.startswith("infisical-")
+        # Secret value is redacted (never the raw secret).
+        assert GITHUB_TOKEN not in finding.secret_preview
+        assert STRIPE_KEY not in finding.secret_preview
+
+
+# --- ScanEngine orchestration / filtering (P1) ----------------------------
+
+
+@pytest.mark.skipif(
+    not (_HAS_TRIVY and _HAS_TALISMAN),
+    reason="needs BOTH trivy and talisman installed",
+)
+def test_scan_engine_parallel_multi_real_scanner_aggregation(git_repo):
+    """HP-04: ScanEngine runs native+trivy+talisman in parallel and aggregates them."""
+    import subprocess  # nosec B404
+
+    (git_repo / "app.env").write_text(f"GITHUB_TOKEN={GITHUB_TOKEN}\nSTRIPE_KEY={STRIPE_KEY}\n")
+    subprocess.run(["git", "add", "-A"], cwd=git_repo, capture_output=True, check=True)
+    subprocess.run(
+        ["git", "commit", "-m", "secrets"],
+        cwd=git_repo,
+        capture_output=True,
+        check=True,
+    )
+
+    config = GuardConfig(
+        use_native=True,
+        use_gitleaks=False,
+        use_trivy=True,
+        use_talisman=True,
+        auto_install=False,
+        skip_encrypted_files=False,
+    )
+    engine = ScanEngine(config)
+    result = engine.scan([git_repo])
+
+    assert isinstance(result, AggregatedScanResult)
+    assert {"native", "trivy", "talisman"}.issubset(set(result.scanners_used))
+    assert len(result.results) == 3
+    # At least one real secret should be found and aggregation/dedup is consistent.
+    assert len(result.unique_findings) >= 1
+    assert result.total_findings >= len(result.unique_findings)
+    # Findings should come from more than one scanner (native + trivy at minimum).
+    scanners_with_findings = {f.scanner for f in result.unique_findings}
+    assert len(scanners_with_findings) >= 2, (
+        f"expected findings from >=2 scanners, got {scanners_with_findings}"
+    )
+
+
+@requires_trivy
+def test_scan_engine_skip_encrypted_files_filters_real_scanner_findings(tmp_path):
+    """HP-14: skip_encrypted_files drops findings on dotenvx ciphertext lines.
+
+    A combined partial-encryption file interleaves a dotenvx-encrypted secret
+    line ("encrypted:") with a cleartext secret line. With skip_encrypted_files
+    on, findings on the ciphertext line are dropped but the cleartext finding
+    survives; with it off, the unfiltered count is >= the filtered count.
+    """
+    combined = tmp_path / "combined.env"
+    # Line 1: dotenvx marker forces the whole file to be "encrypted-aware".
+    # Line 2: a ciphertext line (a real-format secret embedded after encrypted:).
+    # Line 3: a cleartext secret on its own line that must survive filtering.
+    combined.write_text(f"API_KEY=encrypted:BEx{GITHUB_TOKEN}\nGITHUB_TOKEN={GITHUB_TOKEN}\n")
+
+    base = GuardConfig(
+        use_native=True,
+        use_gitleaks=False,
+        use_trivy=True,
+        auto_install=False,
+    )
+
+    filtered_cfg = replace(base, skip_encrypted_files=True)
+    unfiltered_cfg = replace(base, skip_encrypted_files=False)
+
+    filtered = ScanEngine(filtered_cfg).scan([tmp_path])
+    unfiltered = ScanEngine(unfiltered_cfg).scan([tmp_path])
+
+    # No surviving finding may point at the ciphertext (line 1) "encrypted:" line.
+    for finding in filtered.unique_findings:
+        if finding.file_path.name == "combined.env":
+            assert finding.line_number != 1, "ciphertext-line finding should have been filtered out"
+    # The cleartext secret on line 2 must still be reported by some scanner.
+    cleartext_survivors = [
+        f
+        for f in filtered.unique_findings
+        if f.file_path.name == "combined.env" and f.line_number == 2
+    ]
+    assert cleartext_survivors, "cleartext secret on line 2 should survive filtering"
+    # Filtering never increases the finding count.
+    assert len(unfiltered.unique_findings) >= len(filtered.unique_findings)
+
+
+@requires_trivy
+def test_scan_engine_filters_dotenvx_public_keys_from_real_output(tmp_path):
+    """EC-12: ScanEngine filters dotenvx EC secp256k1 public keys (66 hex, 02/03)."""
+    _write_secret_file(tmp_path, "creds.env")
+
+    config = GuardConfig(
+        use_native=True,
+        use_gitleaks=False,
+        use_trivy=True,
+        auto_install=False,
+        skip_encrypted_files=False,
+    )
+    engine = ScanEngine(config)
+    result = engine.scan([tmp_path])
+
+    # No surviving finding should be a 66-hex EC public key starting 02/03.
+    for finding in result.unique_findings:
+        clean = finding.secret_preview.replace("*", "")
+        is_pubkey = clean.startswith(("02", "03")) and len(clean) == 66
+        if is_pubkey:
+            try:
+                int(clean, 16)
+                pytest.fail(f"public key leaked through filter: {finding.secret_preview}")
+            except ValueError:
+                pass
+
+    # Control: a synthetic pubkey finding is removed while a normal one is kept.
+    pubkey = "02" + "ab" * 32  # 66 hex chars, starts with 02
+    pubkey_finding = ScanFinding(
+        file_path=tmp_path / "keys.env",
+        rule_id="trivy-generic",
+        rule_description="Public Key",
+        description="pubkey",
+        severity=result.unique_findings[0].severity
+        if result.unique_findings
+        else __import__("envdrift.scanner.base", fromlist=["FindingSeverity"]).FindingSeverity.HIGH,
+        scanner="trivy",
+        secret_preview=pubkey,  # unredacted, exactly 66 hex
+    )
+    normal_finding = ScanFinding(
+        file_path=tmp_path / "keys.env",
+        rule_id="trivy-github-pat",
+        rule_description="GitHub PAT",
+        description="secret",
+        severity=pubkey_finding.severity,
+        scanner="trivy",
+        secret_preview="ghp_****abcd",
+    )
+    kept = engine._filter_public_keys([pubkey_finding, normal_finding])
+    assert pubkey_finding not in kept
+    assert normal_finding in kept

--- a/tests/integration/test_sops_backend_e2e.py
+++ b/tests/integration/test_sops_backend_e2e.py
@@ -1,0 +1,344 @@
+"""End-to-end integration tests for the SOPS encryption backend.
+
+These exercise the real ``sops`` binary (CI-installed) driven through
+``SOPSEncryptionBackend`` with a real age keypair. ``sops`` and ``age`` are not
+installed on developer machines, so every test gates on the binary and SKIPs
+when it is absent (they run in CI where the binaries are provisioned).
+
+The age keypair is reused from ``test_encryption_tools.py``.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from envdrift.encryption.base import (
+    EncryptionBackendError,
+    EncryptionStatus,
+)
+from envdrift.encryption.sops import SOPSEncryptionBackend
+
+pytestmark = pytest.mark.integration
+
+# Age keypair shared with test_encryption_tools.py.
+AGE_PUBLIC_KEY = "age1c89jtrvyl72y0muvdp5lm3jpemvc2gr303up4g37tuq4uftcku3q4svqau"
+AGE_PRIVATE_KEY = "AGE-SECRET-KEY-1HGE3ZE9NPEN5R76LVKKJ2Z3G9TYZJLW84P2CHAF6UGL43R7TWPUSZ89MK6"
+
+# A second, non-matching age keypair used to prove decryption rejects the wrong key.
+WRONG_AGE_PUBLIC_KEY = "age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p"
+WRONG_AGE_PRIVATE_KEY = "AGE-SECRET-KEY-1GFPYYSJZGFPYYSJZGFPYYSJZGFPYYSJZGFPYYSJZGFPYYSJZGFPQ4EGAEX"
+
+
+def _require_sops() -> Path:
+    """Skip the test unless a real sops binary is resolvable; return its path."""
+    sops_path = shutil.which("sops")
+    if not sops_path:
+        pytest.skip("sops binary not available (installed in CI, absent on dev machines)")
+    return Path(sops_path)
+
+
+@pytest.fixture
+def sops_workspace(tmp_path: Path) -> Path:
+    """Create a work dir with an age key file and a .sops.yaml recipient rule.
+
+    The recipient rule matches any ``.env*`` file. Returns the work dir.
+    """
+    work_dir = tmp_path / "sops_ws"
+    work_dir.mkdir()
+
+    (work_dir / "age.key").write_text(
+        textwrap.dedent(
+            f"""\
+            # created: 2026-01-01T23:59:46-05:00
+            # public key: {AGE_PUBLIC_KEY}
+            {AGE_PRIVATE_KEY}
+            """
+        )
+    )
+    (work_dir / ".sops.yaml").write_text(
+        textwrap.dedent(
+            f"""\
+            creation_rules:
+              - path_regex: \\.env.*$
+                age: {AGE_PUBLIC_KEY}
+            """
+        )
+    )
+    return work_dir
+
+
+def _make_backend(sops_workspace: Path) -> SOPSEncryptionBackend:
+    """Build a backend wired to the workspace .sops.yaml + age key file."""
+    return SOPSEncryptionBackend(
+        config_file=sops_workspace / ".sops.yaml",
+        age_key_file=sops_workspace / "age.key",
+    )
+
+
+def _write_and_encrypt(
+    backend: SOPSEncryptionBackend, work_dir: Path, name: str, content: str
+) -> Path:
+    """Write a plaintext env file and encrypt it in place; return its path."""
+    env_file = work_dir / name
+    env_file.write_text(content)
+    result = backend.encrypt(env_file, age_recipients=AGE_PUBLIC_KEY, cwd=work_dir)
+    assert result.success, f"encrypt failed: {result.message}"
+    return env_file
+
+
+# --------------------------------------------------------------------------- #
+# P0
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.xfail(
+    strict=False,
+    reason=(
+        "BUG: SOPSEncryptionBackend.exec_env builds an invalid sops invocation "
+        "('exec-env --input-type dotenv <file> -- <cmd...>'). Real sops rejects "
+        "the unsupported '--input-type' subcommand flag plus the '--'/list command "
+        "form with 'error: missing file to decrypt'. The correct form is "
+        "'sops exec-env <file> <command-as-single-string>' with the dotenv type "
+        "inferred from the file extension. This test asserts the documented "
+        "behavior; remove the xfail when sops.py:451-458 is fixed (see #329)."
+    ),
+)
+def test_exec_env_injects_decrypted_secrets_without_writing_disk(
+    tmp_path: Path, sops_workspace: Path
+) -> None:
+    """HP-10: exec_env runs a child with decrypted secrets; file stays encrypted."""
+    _require_sops()
+    backend = _make_backend(sops_workspace)
+    env_file = _write_and_encrypt(
+        backend,
+        sops_workspace,
+        ".env.exec",
+        "DB_PASSWORD=hunter2\n",
+    )
+    encrypted_snapshot = env_file.read_text()
+    assert "ENC[AES256_GCM," in encrypted_snapshot
+    assert "hunter2" not in encrypted_snapshot
+
+    # Child prints the injected secret to stdout (never written to disk).
+    cp = backend.exec_env(
+        env_file,
+        [sys.executable, "-c", "import os; print(os.environ['DB_PASSWORD'])"],
+    )
+
+    assert cp.returncode == 0, f"exec-env failed: {cp.stderr}"
+    assert cp.stdout.strip() == "hunter2"
+    # The on-disk file is still the encrypted snapshot.
+    assert env_file.read_text() == encrypted_snapshot
+
+
+def test_decrypt_in_place_false_no_output_discards_stdout_leaves_file_encrypted(
+    tmp_path: Path, sops_workspace: Path
+) -> None:
+    """EC-07: decrypt(in_place=False) with no output_file reports success but
+    discards plaintext to stdout, leaving the file encrypted (known bug captured
+    as documented current behavior)."""
+    _require_sops()
+    backend = _make_backend(sops_workspace)
+    env_file = _write_and_encrypt(
+        backend,
+        sops_workspace,
+        ".env.discard",
+        "DB_PASSWORD=hunter2\n",
+    )
+    encrypted_snapshot = env_file.read_text()
+    assert "ENC[AES256_GCM," in encrypted_snapshot
+
+    result = backend.decrypt(env_file, in_place=False)
+
+    assert result.success is True
+    assert result.file_path == env_file
+    # Plaintext went to (discarded) stdout: the file remains encrypted.
+    assert env_file.read_text() == encrypted_snapshot
+    assert "hunter2" not in env_file.read_text()
+
+
+def test_decrypt_with_wrong_age_key_raises_backend_error(
+    tmp_path: Path, sops_workspace: Path
+) -> None:
+    """BP-13: decrypting with a non-matching age key raises EncryptionBackendError."""
+    _require_sops()
+    backend = _make_backend(sops_workspace)
+    env_file = _write_and_encrypt(
+        backend,
+        sops_workspace,
+        ".env.wrongkey",
+        "DB_PASSWORD=hunter2\n",
+    )
+    encrypted_snapshot = env_file.read_text()
+
+    # A second backend pointed at a different (non-recipient) age key.
+    wrong_key_file = sops_workspace / "wrong-age.key"
+    wrong_key_file.write_text(
+        textwrap.dedent(
+            f"""\
+            # public key: {WRONG_AGE_PUBLIC_KEY}
+            {WRONG_AGE_PRIVATE_KEY}
+            """
+        )
+    )
+    wrong_backend = SOPSEncryptionBackend(
+        config_file=sops_workspace / ".sops.yaml",
+        age_key_file=wrong_key_file,
+    )
+
+    with pytest.raises(EncryptionBackendError) as exc:
+        wrong_backend.decrypt(env_file)
+
+    message = str(exc.value)
+    assert message.startswith("SOPS decryption failed:")
+    # Real sops stderr reports that no configured key could recover the data key.
+    lowered = message.lower()
+    assert (
+        "data key" in lowered or "no key could decrypt" in lowered or "but none were" in lowered
+    ), f"unexpected sops stderr: {message!r}"
+    # The file was not mutated.
+    assert env_file.read_text() == encrypted_snapshot
+
+
+# --------------------------------------------------------------------------- #
+# P1
+# --------------------------------------------------------------------------- #
+
+
+def test_get_version_parses_real_sops_version(tmp_path: Path, sops_workspace: Path) -> None:
+    """HP-07: get_version() returns the token parsed from real `sops --version`."""
+    _require_sops()
+    backend = _make_backend(sops_workspace)
+
+    version = backend.get_version()
+
+    assert version is not None
+    assert re.fullmatch(r"\d+\.\d+\.\d+.*", version), f"unexpected version token: {version!r}"
+    assert backend.is_installed() is True
+
+
+def test_decrypt_to_output_file_leaves_source_encrypted(
+    tmp_path: Path, sops_workspace: Path
+) -> None:
+    """HP-14 + EC-16: decrypt with output_file writes plaintext to a separate file;
+    the source stays encrypted and result.file_path is the output."""
+    _require_sops()
+    backend = _make_backend(sops_workspace)
+    env_file = _write_and_encrypt(
+        backend,
+        sops_workspace,
+        ".env.outsrc",
+        "DB_PASSWORD=hunter2\n",
+    )
+    encrypted_snapshot = env_file.read_text()
+    out = sops_workspace / ".env.plaintext.out"
+
+    result = backend.decrypt(env_file, output_file=out)
+
+    assert result.success is True
+    assert result.file_path == out
+    out_content = out.read_text()
+    assert "DB_PASSWORD=hunter2" in out_content
+    assert "ENC[" not in out_content
+    # Source unchanged and still encrypted.
+    assert env_file.read_text() == encrypted_snapshot
+    assert "ENC[AES256_GCM," in env_file.read_text()
+
+
+def test_config_file_passed_before_positional_args_end_to_end(
+    tmp_path: Path, sops_workspace: Path
+) -> None:
+    """HP-11 + EC-17: a relative .sops.yaml passed via --config (resolved against
+    cwd) is placed before the positional file, enabling an end-to-end roundtrip."""
+    _require_sops()
+    # The backend prepends `--config <path>` before the positional file. We run
+    # with cwd=sops_workspace and an absolute config so the encrypt/decrypt
+    # roundtrip succeeds end-to-end, proving the --config flag is ordered ahead
+    # of the positional argument (sops rejects late flags as extra paths).
+    backend = SOPSEncryptionBackend(
+        config_file=sops_workspace / ".sops.yaml",
+        age_key_file=sops_workspace / "age.key",
+    )
+
+    env_file = sops_workspace / ".env.cfgorder"
+    env_file.write_text("DB_PASSWORD=hunter2\n")
+
+    enc = backend.encrypt(env_file, age_recipients=AGE_PUBLIC_KEY, cwd=sops_workspace)
+    assert enc.success
+    assert "ENC[" in env_file.read_text()
+
+    dec = backend.decrypt(env_file, cwd=sops_workspace)
+    assert dec.success
+    final = env_file.read_text()
+    assert "DB_PASSWORD=hunter2" in final
+    assert "ENC[" not in final
+
+
+def test_encrypt_missing_file_returns_failure_result(tmp_path: Path, sops_workspace: Path) -> None:
+    """BP-01: encrypt() on a non-existent file returns failure without raising."""
+    _require_sops()
+    backend = _make_backend(sops_workspace)
+    missing = sops_workspace / ".env.does-not-exist"
+
+    result = backend.encrypt(missing, age_recipients=AGE_PUBLIC_KEY)
+
+    assert result.success is False
+    assert "File not found" in result.message
+    assert result.file_path == missing
+
+
+def test_decrypt_missing_file_returns_failure_result(tmp_path: Path, sops_workspace: Path) -> None:
+    """BP-03: decrypt() on a non-existent file returns failure without raising."""
+    _require_sops()
+    backend = _make_backend(sops_workspace)
+    missing = sops_workspace / ".env.also-missing"
+
+    result = backend.decrypt(missing)
+
+    assert result.success is False
+    assert "File not found" in result.message
+    assert result.file_path == missing
+
+
+def test_decrypt_nonencrypted_file_raises_backend_error_with_stderr(
+    tmp_path: Path, sops_workspace: Path
+) -> None:
+    """BP-06: real sops exits non-zero decrypting a non-sops file -> error w/ stderr."""
+    _require_sops()
+    backend = _make_backend(sops_workspace)
+    plain = sops_workspace / ".env.plain"
+    plain.write_text("DB_PASSWORD=hunter2\n")
+
+    with pytest.raises(EncryptionBackendError) as exc:
+        backend.decrypt(plain)
+
+    message = str(exc.value)
+    prefix = "SOPS decryption failed:"
+    assert message.startswith(prefix)
+    # Real stderr was captured (message is more than the bare prefix).
+    assert len(message) > len(prefix)
+    # The plaintext file was not corrupted.
+    assert plain.read_text() == "DB_PASSWORD=hunter2\n"
+
+
+def test_has_encrypted_header_false_positive_on_plaintext_sops_url(
+    tmp_path: Path, sops_workspace: Path
+) -> None:
+    """EC-04: has_encrypted_header is a documented false positive for plaintext
+    containing the literal substring 'sops:' (e.g. a URL), while
+    detect_encryption_status on a single plain value stays PLAINTEXT."""
+    backend = _make_backend(sops_workspace)
+
+    content = "REPO=https://github.com/getsops/sops:main\n"
+    assert backend.has_encrypted_header(content) is True
+    # Value-level classification is not fooled.
+    assert (
+        backend.detect_encryption_status("https://github.com/getsops/sops:main")
+        == EncryptionStatus.PLAINTEXT
+    )

--- a/tests/integration/test_validation_edge_cases.py
+++ b/tests/integration/test_validation_edge_cases.py
@@ -15,6 +15,7 @@ Requires: pydantic-settings installed
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 import textwrap
@@ -798,7 +799,9 @@ def _run_validate(
     env_file = tmp_path / ".env"
     env_file.write_text(textwrap.dedent(env_text))
 
-    env = {"PYTHONPATH": integration_pythonpath, "COLUMNS": "200"}
+    env = os.environ.copy()
+    env["PYTHONPATH"] = integration_pythonpath
+    env["COLUMNS"] = "200"
 
     cmd = [
         sys.executable,

--- a/tests/integration/test_validation_edge_cases.py
+++ b/tests/integration/test_validation_edge_cases.py
@@ -757,3 +757,428 @@ class TestValidateCommand:
         # Should exit with error
         assert result.returncode != 0
         assert "Traceback" not in result.stderr, "Should not crash with traceback"
+
+
+# ---------------------------------------------------------------------------
+# Additional real e2e coverage for the validate CLI.
+#
+# These tests drive the real ``python -m envdrift.cli validate`` subprocess over
+# real .env files and real ``settings.py`` modules (no mocks, no container).
+#
+# IMPORTANT: envdrift's validator matches schema field names against .env keys
+# *case-sensitively* (see src/envdrift/core/validator.py:124-146). To exercise
+# the *documented* behavior (missing-required / extra / type-error detection)
+# rather than the case-sensitivity bug, these schemas declare their fields in
+# UPPERCASE so they match the conventional UPPERCASE .env keys exactly.
+#
+# Also note: pydantic-settings BaseSettings defaults ``model_config["extra"]``
+# to "forbid", so a schema must explicitly set ``extra="ignore"`` to downgrade
+# unknown variables from errors to warnings.
+# ---------------------------------------------------------------------------
+
+
+def _run_validate(
+    *,
+    tmp_path: Path,
+    integration_pythonpath: str,
+    settings_src: str,
+    env_text: str,
+    extra_args: list[str] | None = None,
+    schema: str = "settings:Settings",
+) -> subprocess.CompletedProcess[str]:
+    """Run the real ``envdrift validate`` CLI as a subprocess.
+
+    Writes ``settings.py`` and ``.env`` into ``tmp_path`` and invokes the CLI
+    against them. ``COLUMNS`` is pinned wide so Rich does not wrap section
+    headers / value lines, keeping output assertions stable in a non-TTY pipe.
+    """
+    settings_module = tmp_path / "settings.py"
+    settings_module.write_text(textwrap.dedent(settings_src))
+
+    env_file = tmp_path / ".env"
+    env_file.write_text(textwrap.dedent(env_text))
+
+    env = {"PYTHONPATH": integration_pythonpath, "COLUMNS": "200"}
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "envdrift.cli",
+        "validate",
+        str(env_file),
+        "--schema",
+        schema,
+        "--service-dir",
+        str(tmp_path),
+    ]
+    if extra_args:
+        cmd.extend(extra_args)
+
+    return subprocess.run(
+        cmd,
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+class TestValidateRealEdgeCases:
+    """High-value real e2e edge cases for the validate command."""
+
+    def test_validate_extra_ignore_emits_warning_not_error(
+        self,
+        tmp_path: Path,
+        integration_pythonpath: str,
+    ) -> None:
+        """HP-06: extra='ignore' downgrades an unknown var to a warning.
+
+        Validation must PASS (exit 0 even with --ci) and the unknown variable
+        is reported only as a warning, never in an EXTRA VARIABLES error
+        section.
+        """
+        result = _run_validate(
+            tmp_path=tmp_path,
+            integration_pythonpath=integration_pythonpath,
+            settings_src='''
+                from pydantic_settings import BaseSettings
+
+                class Settings(BaseSettings):
+                    """Schema that tolerates extra vars."""
+                    APP_NAME: str
+                    model_config = {"extra": "ignore"}
+            ''',
+            env_text="""
+                APP_NAME=MyApp
+                UNKNOWN_VAR=tolerated
+            """,
+            extra_args=["--no-check-encryption", "--ci"],
+        )
+
+        combined = result.stdout + result.stderr
+        assert result.returncode == 0, (
+            f"extra=ignore should pass even with --ci. Output: {combined}"
+        )
+        assert "Traceback" not in result.stderr
+        assert "PASSED" in combined, f"Should report PASSED. Output: {combined}"
+        # Reported as a warning, not an error section.
+        assert "EXTRA VARIABLES" not in combined, (
+            f"extra=ignore must not produce an error section. Output: {combined}"
+        )
+        assert "Extra variable 'UNKNOWN_VAR' not in schema" in combined, (
+            f"Should warn about UNKNOWN_VAR. Output: {combined}"
+        )
+
+    def test_validate_extra_forbid_reports_error_matching_case(
+        self,
+        tmp_path: Path,
+        integration_pythonpath: str,
+    ) -> None:
+        """BP-04: extra='forbid' with a case-matching extra var is an ERROR.
+
+        The unknown variable appears under an EXTRA VARIABLES section,
+        validation FAILS, and --ci exits 1.
+        """
+        result = _run_validate(
+            tmp_path=tmp_path,
+            integration_pythonpath=integration_pythonpath,
+            settings_src='''
+                from pydantic_settings import BaseSettings
+
+                class Settings(BaseSettings):
+                    """Schema that forbids extra vars."""
+                    APP_NAME: str
+                    model_config = {"extra": "forbid"}
+            ''',
+            env_text="""
+                APP_NAME=MyApp
+                UNKNOWN_VAR=should_be_rejected
+            """,
+            extra_args=["--no-check-encryption", "--ci"],
+        )
+
+        combined = result.stdout + result.stderr
+        assert result.returncode == 1, f"extra=forbid + --ci must exit 1. Output: {combined}"
+        assert "Traceback" not in result.stderr
+        assert "FAILED" in combined, f"Should report FAILED. Output: {combined}"
+        assert "EXTRA VARIABLES" in combined, (
+            f"Should print EXTRA VARIABLES section. Output: {combined}"
+        )
+        assert "UNKNOWN_VAR" in combined, f"Should list UNKNOWN_VAR. Output: {combined}"
+
+    def test_validate_type_errors_for_float_and_bool(
+        self,
+        tmp_path: Path,
+        integration_pythonpath: str,
+    ) -> None:
+        """BP-03: invalid float and non-canonical bool produce TYPE ERRORS."""
+        result = _run_validate(
+            tmp_path=tmp_path,
+            integration_pythonpath=integration_pythonpath,
+            settings_src='''
+                from pydantic_settings import BaseSettings
+
+                class Settings(BaseSettings):
+                    """Schema with a float and a bool field."""
+                    RATIO: float
+                    ENABLED: bool
+            ''',
+            env_text="""
+                RATIO=not_a_float
+                ENABLED=maybe
+            """,
+            extra_args=["--no-check-encryption"],
+        )
+
+        combined = result.stdout + result.stderr
+        assert "Traceback" not in result.stderr
+        assert "TYPE ERRORS" in combined, f"Should print TYPE ERRORS section. Output: {combined}"
+        assert "RATIO" in combined and "float" in combined, (
+            f"Should flag RATIO as a float error. Output: {combined}"
+        )
+        assert "ENABLED" in combined and "boolean" in combined, (
+            f"Should flag ENABLED as a boolean error. Output: {combined}"
+        )
+
+    def test_validate_fix_template_encrypted_placeholder_for_sensitive_required(
+        self,
+        tmp_path: Path,
+        integration_pythonpath: str,
+    ) -> None:
+        """HP-12: --fix uses an encrypted placeholder for sensitive required fields.
+
+        A missing sensitive required field renders as
+        ``API_KEY="encrypted:YOUR_VALUE_HERE"`` while a missing non-sensitive
+        required field renders as a bare ``PUBLIC_NAME=`` assignment.
+        """
+        result = _run_validate(
+            tmp_path=tmp_path,
+            integration_pythonpath=integration_pythonpath,
+            settings_src='''
+                from pydantic_settings import BaseSettings
+                from pydantic import Field
+
+                class Settings(BaseSettings):
+                    """Schema with a sensitive and a non-sensitive required field."""
+                    APP_NAME: str
+                    API_KEY: str = Field(json_schema_extra={"sensitive": True})
+                    PUBLIC_NAME: str
+                    model_config = {"extra": "ignore"}
+            ''',
+            env_text="""
+                APP_NAME=MyApp
+            """,
+            extra_args=["--no-check-encryption", "--fix"],
+        )
+
+        combined = result.stdout + result.stderr
+        assert "Traceback" not in result.stderr
+        assert "Fix template:" in combined, f"Should print a fix template. Output: {combined}"
+        assert 'API_KEY="encrypted:YOUR_VALUE_HERE"' in combined, (
+            f"Sensitive required field needs encrypted placeholder. Output: {combined}"
+        )
+        # Non-sensitive required field is a bare assignment (own line).
+        assert any(line.strip() == "PUBLIC_NAME=" for line in combined.splitlines()), (
+            f"Non-sensitive required field should be a bare assignment. Output: {combined}"
+        )
+
+    def test_validate_fix_is_noop_when_validation_passes(
+        self,
+        tmp_path: Path,
+        integration_pythonpath: str,
+    ) -> None:
+        """EC-22: --fix is a no-op when validation passes."""
+        result = _run_validate(
+            tmp_path=tmp_path,
+            integration_pythonpath=integration_pythonpath,
+            settings_src='''
+                from pydantic_settings import BaseSettings
+
+                class Settings(BaseSettings):
+                    """Schema satisfied by the .env."""
+                    APP_NAME: str
+                    model_config = {"extra": "ignore"}
+            ''',
+            env_text="""
+                APP_NAME=MyApp
+            """,
+            extra_args=["--no-check-encryption", "--fix", "--ci"],
+        )
+
+        combined = result.stdout + result.stderr
+        assert result.returncode == 0, f"Passing validation should exit 0. Output: {combined}"
+        assert "Traceback" not in result.stderr
+        assert "PASSED" in combined, f"Should report PASSED. Output: {combined}"
+        assert "Fix template" not in combined, (
+            f"--fix must be a no-op on a passing run. Output: {combined}"
+        )
+        assert "YOUR_VALUE_HERE" not in combined, (
+            f"No placeholder should be emitted on a passing run. Output: {combined}"
+        )
+
+    def test_validate_encrypted_value_skips_type_check(
+        self,
+        tmp_path: Path,
+        integration_pythonpath: str,
+    ) -> None:
+        """EC-09: an encrypted value for an int field produces no type error."""
+        result = _run_validate(
+            tmp_path=tmp_path,
+            integration_pythonpath=integration_pythonpath,
+            settings_src='''
+                from pydantic_settings import BaseSettings
+
+                class Settings(BaseSettings):
+                    """Schema with a single int field."""
+                    PORT: int
+                    model_config = {"extra": "ignore"}
+            ''',
+            env_text="""
+                PORT=encrypted:c2VjcmV0LXBvcnQtdmFsdWU
+            """,
+            extra_args=["--no-check-encryption"],
+        )
+
+        combined = result.stdout + result.stderr
+        assert result.returncode == 0, f"Encrypted int value should pass. Output: {combined}"
+        assert "Traceback" not in result.stderr
+        assert "PASSED" in combined, f"Should report PASSED. Output: {combined}"
+        assert "TYPE ERRORS" not in combined, (
+            f"Encrypted value must not trigger a type check. Output: {combined}"
+        )
+        assert "Expected integer" not in combined, (
+            f"No spurious integer error for encrypted value. Output: {combined}"
+        )
+
+    def test_validate_suspicious_token_warns_even_when_not_in_schema(
+        self,
+        tmp_path: Path,
+        integration_pythonpath: str,
+    ) -> None:
+        """EC-21: a GitHub-token-shaped value not in schema warns under --check-encryption.
+
+        With extra='ignore' the unknown var is not an error, so validation
+        PASSES (exit 0 without --ci) yet still warns that the value looks like
+        a secret.
+        """
+        result = _run_validate(
+            tmp_path=tmp_path,
+            integration_pythonpath=integration_pythonpath,
+            settings_src='''
+                from pydantic_settings import BaseSettings
+
+                class Settings(BaseSettings):
+                    """Schema that does not declare the suspicious var."""
+                    APP_NAME: str
+                    model_config = {"extra": "ignore"}
+            ''',
+            env_text="""
+                APP_NAME=MyApp
+                GITHUB_TOKEN=ghp_1234567890abcdefABCDEF1234567890abcd
+            """,
+            extra_args=["--check-encryption"],
+        )
+
+        combined = result.stdout + result.stderr
+        assert result.returncode == 0, (
+            f"extra=ignore keeps a suspicious extra var non-fatal. Output: {combined}"
+        )
+        assert "Traceback" not in result.stderr
+        assert "PASSED" in combined, f"Should report PASSED. Output: {combined}"
+        assert "GITHUB_TOKEN" in combined, f"Should mention GITHUB_TOKEN. Output: {combined}"
+        assert "looks like a secret" in combined or "suggesting sensitive data" in combined, (
+            f"Should warn the value/name looks sensitive. Output: {combined}"
+        )
+
+    def test_validate_rejects_malformed_dotted_path(
+        self,
+        tmp_path: Path,
+        integration_pythonpath: str,
+    ) -> None:
+        """BP-05: a schema path missing the ':' separator is rejected, exit 1."""
+        result = _run_validate(
+            tmp_path=tmp_path,
+            integration_pythonpath=integration_pythonpath,
+            settings_src="""
+                from pydantic_settings import BaseSettings
+
+                class Settings(BaseSettings):
+                    APP_NAME: str
+            """,
+            env_text="""
+                APP_NAME=MyApp
+            """,
+            schema="settings_missing_colon",
+            extra_args=["--no-check-encryption"],
+        )
+
+        combined = result.stdout + result.stderr
+        assert result.returncode == 1, f"Malformed schema path must exit 1. Output: {combined}"
+        assert "Traceback" not in result.stderr
+        assert "Invalid schema path" in combined, (
+            f"Should explain the path is invalid. Output: {combined}"
+        )
+        assert "Expected format: 'module.path:ClassName'" in combined, (
+            f"Should show the expected format. Output: {combined}"
+        )
+
+    def test_validate_rejects_non_basesettings_class(
+        self,
+        tmp_path: Path,
+        integration_pythonpath: str,
+    ) -> None:
+        """BP-07: --schema pointing at a non-BaseSettings class exits 1 cleanly."""
+        result = _run_validate(
+            tmp_path=tmp_path,
+            integration_pythonpath=integration_pythonpath,
+            settings_src='''
+                class Plain:
+                    """Not a Pydantic BaseSettings subclass."""
+                    pass
+            ''',
+            env_text="""
+                APP_NAME=MyApp
+            """,
+            schema="settings:Plain",
+            extra_args=["--no-check-encryption"],
+        )
+
+        combined = result.stdout + result.stderr
+        assert result.returncode == 1, f"Non-BaseSettings class must exit 1. Output: {combined}"
+        assert "Traceback" not in result.stderr
+        assert "'Plain' is not a Pydantic BaseSettings subclass" in combined, (
+            f"Should explain the class is not BaseSettings. Output: {combined}"
+        )
+
+    def test_validate_empty_value_parsed_as_empty_skips_type_check(
+        self,
+        tmp_path: Path,
+        integration_pythonpath: str,
+    ) -> None:
+        """EC-01: an empty value (KEY=) is EMPTY status, so an int field passes."""
+        result = _run_validate(
+            tmp_path=tmp_path,
+            integration_pythonpath=integration_pythonpath,
+            settings_src='''
+                from pydantic_settings import BaseSettings
+
+                class Settings(BaseSettings):
+                    """Schema with a single int field."""
+                    PORT: int
+                    model_config = {"extra": "ignore"}
+            ''',
+            env_text="""
+                PORT=
+            """,
+            extra_args=["--no-check-encryption"],
+        )
+
+        combined = result.stdout + result.stderr
+        assert result.returncode == 0, (
+            f"Empty value should not fail an int field. Output: {combined}"
+        )
+        assert "Traceback" not in result.stderr
+        assert "PASSED" in combined, f"Should report PASSED. Output: {combined}"
+        assert "Expected integer" not in combined, (
+            f"Empty value must not trigger an integer type error. Output: {combined}"
+        )

--- a/tests/scanner/test_detect_secrets.py
+++ b/tests/scanner/test_detect_secrets.py
@@ -18,6 +18,7 @@ from envdrift.scanner.detect_secrets import (
     DetectSecretsInstallError,
     DetectSecretsNotFoundError,
     DetectSecretsScanner,
+    _get_detect_secrets_version,
 )
 
 
@@ -27,7 +28,7 @@ class TestDetectSecretsInstaller:
     def test_default_version_from_constants(self):
         """Installer uses pinned version by default."""
         installer = DetectSecretsInstaller()
-        assert installer.version == "1.5.0"
+        assert installer.version == _get_detect_secrets_version()
 
     def test_custom_version(self):
         """Custom version can be specified."""

--- a/tests/scanner/test_gitleaks.py
+++ b/tests/scanner/test_gitleaks.py
@@ -22,6 +22,7 @@ from envdrift.scanner.gitleaks import (
     GitleaksInstallError,
     GitleaksNotFoundError,
     GitleaksScanner,
+    _get_gitleaks_version,
     get_gitleaks_path,
     get_platform_info,
     get_venv_bin_dir,
@@ -176,7 +177,7 @@ class TestGitleaksInstaller:
     def test_default_version_from_constants(self):
         """Test that installer uses version from constants."""
         installer = GitleaksInstaller()
-        assert installer.version == "8.30.0"
+        assert installer.version == _get_gitleaks_version()
 
     def test_custom_version(self):
         """Test that custom version can be specified."""

--- a/tests/scanner/test_infisical.py
+++ b/tests/scanner/test_infisical.py
@@ -16,6 +16,7 @@ from envdrift.scanner.infisical import (
     InfisicalInstallError,
     InfisicalNotFoundError,
     InfisicalScanner,
+    _get_infisical_version,
     get_infisical_path,
     get_platform_info,
 )
@@ -76,7 +77,7 @@ class TestInfisicalInstaller:
     def test_default_version_from_constants(self):
         """Test that installer uses version from constants."""
         installer = InfisicalInstaller()
-        assert installer.version == "0.31.1"
+        assert installer.version == _get_infisical_version()
 
     def test_custom_version(self):
         """Test that custom version can be specified."""

--- a/tests/scanner/test_talisman.py
+++ b/tests/scanner/test_talisman.py
@@ -16,6 +16,7 @@ from envdrift.scanner.talisman import (
     TalismanInstallError,
     TalismanNotFoundError,
     TalismanScanner,
+    _get_talisman_version,
     get_platform_info,
     get_talisman_path,
 )
@@ -84,7 +85,7 @@ class TestTalismanInstaller:
     def test_default_version_from_constants(self):
         """Test that installer uses version from constants."""
         installer = TalismanInstaller()
-        assert installer.version == "1.32.0"
+        assert installer.version == _get_talisman_version()
 
     def test_custom_version(self):
         """Test that custom version can be specified."""

--- a/tests/scanner/test_trivy.py
+++ b/tests/scanner/test_trivy.py
@@ -16,6 +16,7 @@ from envdrift.scanner.trivy import (
     TrivyInstallError,
     TrivyNotFoundError,
     TrivyScanner,
+    _get_trivy_version,
     get_platform_info,
     get_trivy_path,
 )
@@ -74,7 +75,7 @@ class TestTrivyInstaller:
     def test_default_version_from_constants(self):
         """Test that installer uses version from constants."""
         installer = TrivyInstaller()
-        assert installer.version == "0.58.0"
+        assert installer.version == _get_trivy_version()
 
     def test_custom_version(self):
         """Test that custom version can be specified."""

--- a/tests/scanner/test_trufflehog.py
+++ b/tests/scanner/test_trufflehog.py
@@ -21,6 +21,7 @@ from envdrift.scanner.trufflehog import (
     TrufflehogInstallError,
     TrufflehogNotFoundError,
     TrufflehogScanner,
+    _get_trufflehog_version,
     get_platform_info,
     get_trufflehog_path,
     get_venv_bin_dir,
@@ -177,7 +178,7 @@ class TestTrufflehogInstaller:
     def test_default_version_from_constants(self):
         """Test that installer uses version from constants."""
         installer = TrufflehogInstaller()
-        assert installer.version == "3.92.4"
+        assert installer.version == _get_trufflehog_version()
 
     def test_custom_version(self):
         """Test that custom version can be specified."""


### PR DESCRIPTION
## What this PR does

Adds **123 real, container/binary-backed e2e tests** (74 in 8 new files, 49 appended to 4 existing files) across every envdrift subsystem. The tests drive **real backends only** — no mocks:

- **LocalStack** (AWS Secrets Manager), **HashiCorp Vault**, **Lowkey Vault** (Azure Key Vault) containers
- Real **dotenvx** and **sops** binaries; real scanner binaries (**talisman / trivy / infisical / git-secrets / kingfisher**)
- The real **envdrift CLI** invoked as a subprocess

Every test ends **green, skip-gated** (absent binary/cred), or **xfail** (a confirmed product bug). Full integration suite: **259 passed, 14 skipped, 3 xfailed, 0 failed**.

### How this was produced

A multi-agent pipeline: parallel **exploration** agents mapped happy/bad/edge/extreme cases + doc claims across 12 subsystems → **review** agents audited the *existing* real container tests for gaps and flagged real bugs / doc mismatches → **plan** agents designed concrete e2e tests → **coding** agents implemented them → **SQA** agents ran each file against the live containers and fixed/`xfail`ed until green.

### New test files

- `test_cli_e2e.py` — real CLI subprocess — exit codes, real file I/O
- `test_diff_cli.py` — diff command over real .env files
- `test_encryption_dotenvx_binary.py` — dotenvx binary resolution + roundtrip
- `test_gcp_integration.py` — GCP backend (skip-gated, real-cred only)
- `test_guard_cli_e2e.py` — guard secret-scanning over real git repos
- `test_partial_encryption_e2e.py` — lock / push / pull --merge with real dotenvx + git
- `test_scanner_external_binaries.py` — real talisman / trivy / infisical + ScanEngine filtering
- `test_sops_backend_e2e.py` — real sops binary + age keypair

Extended: `test_aws_integration.py`, `test_azure_integration.py`, `test_hashicorp_integration.py`, `test_validation_edge_cases.py`.

### CI

`integration-tests.yml` now installs **sops** and reads **both** the dotenvx and sops versions from `src/envdrift/constants.json` (the Renovate-maintained source of truth) instead of hardcoding — so these real tests actually run in CI and stay current automatically.

### Confirmed regressions (xfail in this PR)

Three tests assert the correct/documented behavior and are `xfail(strict=False)`, pinned to their issues — they'll XPASS (and can drop the marker) once fixed:

- #302 — `guard --staged` from a subdirectory silently bypasses the scan
- #305 — HashiCorp `authenticate()` re-wraps `AuthenticationError` as `VaultError`
- #329 — SOPS `exec_env` builds an invalid sops invocation

## Bugs & doc gaps found (filed as issues)

The review surfaced real defects in the **main code** and **doc claims the code doesn't honor**. Filed as 29 surgical, deduplicated issues:

### Bugs (26 )
- #301 _(critical)_ — TalismanScanner parses wrong JSON keys (failures/warnings) and never reports any real finding
- #302 _(high)_ — guard --staged / --pr-base silently skip all files when run from a repo subdirectory
- #303 _(high)_ — lock --check (dry run) decrypts and re-encrypts files on key-name mismatch
- #304 _(high)_ — Azure is_authenticated() returns True after a failed authenticate()
- #305 _(high)_ — HashiCorp authenticate(): invalid/expired-token AuthenticationError is re-wrapped as VaultError by broad except
- #306 _(high)_ — Validator name matching is case-sensitive while Pydantic Settings is case-insensitive — UPPERCASE .env + lowercase fields yields false missing_required AND false extra_vars
- #307 _(high)_ — SOPS decrypt(in_place=False) with no output_file discards plaintext and falsely reports success
- #329 _(high)_ — SOPS exec_env builds an invalid sops invocation (--input-type + '--' form) so it always fails
- #308 _(medium)_ — set_secret silently masks AccessDeniedException on create by falling back to put_secret_value
- #309 _(medium)_ — dotenvx decrypt() lacks the exit-code-0 error-pattern post-check that encrypt() has
- #310 _(medium)_ — Stale install hint references a non-existent CLI command 'envdrift install-dotenvx'
- #311 _(medium)_ — Binary download via urllib.urlretrieve has no timeout and can hang indefinitely
- #312 _(medium)_ — install check misreports a stopped agent as Running (naive 'running' substring match)
- #314 _(medium)_ — GuardConfig.from_dict drops allowed_clear_files, combined_files, mapped_env_files (partial-encryption awareness lost for SDK callers)
- #315 _(medium)_ — TalismanScanner per-failure parsing reads non-existent 'match'/'line_number' keys; secret_preview and line_number always empty
- #313 _(low)_ — AWS get_secret raises bare KeyError when response has neither SecretString nor SecretBinary
- #316 _(low)_ — combine_files only strips dotenvx header BORDER lines, leaking the two inner public-key comment lines
- #317 _(low)_ — _test_decryption restore raises a secondary FileNotFoundError when the initial backup copy fails
- #318 _(low)_ — vault-push --all single-service .env.keys lookup ignores env_keys_filename fallback (inconsistent with rest of subsystem)
- #319 _(low)_ — guard --pr-base uses global str.replace('origin/','') which can corrupt branch/ref names
- #320 _(low)_ — normalize_dotenvx_metadata adds a spurious trailing newline to .env.keys when the original had none
- #321 _(low)_ — init / api.init crash (unhandled ValueError) on values that are isdigit() but not int-convertible
- #322 _(low)_ — GitSecretsScanner stdout finding-parse branch is dead code (git-secrets writes findings to stderr)
- #323 _(low)_ — install agent --force running-warning guard defeated by whitespace; warns even when agent is stopped
- #324 _(low)_ — SOPS has_encrypted_header false-positives on plaintext containing the literal substring 'sops:'
- #325 _(low)_ — Ephemeral pull key_name fallback uses folder name instead of the configured environment

### Documentation mismatches (3)
- #326 — Docs list 'explicit credentials passed to boto3.client()' as a supported AWS auth provider, but envdrift never passes credentials
- #327 — Docs advertise AppRole / OIDC / Kubernetes / 'many others' HashiCorp auth; code supports Token only
- #328 — [vault.hashicorp] token in TOML config is silently ignored; token only comes from VAULT_TOKEN env

---
*Tests added here are green/skip/xfail; the bugs above are **not** fixed in this PR — each is tracked in its own issue for separate, surgical fixes.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Large expansion of integration/end-to-end tests covering AWS, Azure, GCP, HashiCorp, SOPS, dotenvx, scanner binaries, partial-encryption flows, CLI commands (diff, guard, agent registry, validate) and durability/permissions scenarios to improve real-world reliability.
  * Added deterministic test settings to stabilize CLI output and CI-gated real-backend suites.

* **Chores**
  * CI workflow: improved install/validation steps for external tools and adjusted Vault dev container env to avoid startup failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds 123 real, container/binary-backed end-to-end tests across every envdrift subsystem — LocalStack, HashiCorp Vault, Lowkey Vault, dotenvx, sops, and external scanner binaries — with no mocks; three known regressions are pinned as `xfail`. The CI workflow is updated to install sops and external scanners from `constants.json` (the Renovate-managed source of truth) and the Renovate config gains version managers for six new tools.

- **New test files** cover the real CLI (agent registry, diff, guard, validate, partial-encryption), SOPS e2e, dotenvx binary installer, GCP (skip-gated), and real talisman/trivy/infisical scanner output parsing.
- **Extended test files** (`test_aws_integration.py`, `test_azure_integration.py`, `test_hashicorp_integration.py`, `test_validation_edge_cases.py`) add CLI round-trip coverage against live containers.
- **Scanner unit tests** are decoupled from hardcoded version strings; they now read the pinned version from `constants.json` via the same helper used by the installer.

<h3>Confidence Score: 4/5</h3>

Safe to merge with one fix: the overly-broad auth-failure heuristic in the Azure tests should drop the bare "credential" entry to prevent real regressions from being silently skipped.

The bulk of the PR is a large, well-structured test-only addition that does not touch production code. The CI workflow changes are additive and carefully fail-fast. The single defect is in `_looks_like_auth_failure` in `test_azure_integration.py`: including bare `"credential"` in the auth-signature list is broad enough that a non-auth CLI bug whose error message mentions credentials would trigger a skip instead of a failure, silently hiding the regression.

tests/integration/test_azure_integration.py — the `_looks_like_auth_failure` helper needs the standalone `"credential"` entry removed.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| tests/integration/test_azure_integration.py | Adds 554 lines of Lowkey Vault round-trip tests; the `_looks_like_auth_failure` helper's bare `"credential"` match is overly broad and can silently convert non-auth failures into skips. |
| .github/workflows/integration-tests.yml | Installs sops and external scanner binaries from constants.json; adds SKIP_SETCAP/VAULT_DISABLE_MLOCK for Vault container compatibility; extracts sops/scanner versions dynamically via Renovate-backed constants.json. |
| tests/integration/test_sops_backend_e2e.py | New real-sops e2e tests with age keypair, covering encrypt/decrypt roundtrips, wrong-key rejection, exec_env (xfail per #329), and in_place=False discard behavior. Skip-gated on sops binary presence. |
| tests/integration/test_guard_cli_e2e.py | New guard CLI subprocess tests covering PR-base scanning, exit-code contracts, CI --fail-on threshold, staged-subdirectory xfail (#302), and allowlist behavior — all using native scanner only. |
| tests/integration/test_scanner_external_binaries.py | New real-binary scanner tests for talisman, trivy, and infisical; uses runtime-assembled secret strings to avoid push-protection while exercising real scanner output parsing. |
| tests/integration/test_hashicorp_integration.py | Extends Vault integration tests with CLI vault-push/pull flows and an xfail for the AuthenticationError re-wrap bug (#305); cleans up KV paths in finally blocks. |
| tests/integration/conftest.py | Adds autouse `_deterministic_cli_output` fixture to strip FORCE_COLOR and set NO_COLOR for all integration tests, preventing ANSI escape sequences from breaking JSON output assertions. |
| renovate.json | Adds Renovate regex managers for trivy, gitleaks, trufflehog, talisman, infisical, and detect-secrets versions in constants.json, keeping CI tool versions automatically current. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    CI[CI: integration-tests.yml] --> INS[Install tools from constants.json\ndotenvx · sops · talisman · trivy · infisical]
    INS --> SVC[Start containers\nLocalStack · Vault · Lowkey Vault]
    SVC --> SUITE[pytest integration suite]

    SUITE --> AWS[test_aws_integration\nLocalStack round-trips]
    SUITE --> AZ[test_azure_integration\nLowkey Vault round-trips]
    SUITE --> HCV[test_hashicorp_integration\nVault KV v2 push/pull]
    SUITE --> GCP[test_gcp_integration\nskip-gated on GOOGLE_CLOUD_PROJECT]
    SUITE --> CLI[test_cli_e2e\nagent registry via isolated HOME]
    SUITE --> DIFF[test_diff_cli\nreal CLI subprocess]
    SUITE --> GUARD[test_guard_cli_e2e\nnative scanner only]
    SUITE --> PE[test_partial_encryption_e2e\nreal dotenvx + git]
    SUITE --> SOPS[test_sops_backend_e2e\nreal sops + age keypair]
    SUITE --> SCAN[test_scanner_external_binaries\ntalisman · trivy · infisical]
    SUITE --> VAL[test_validation_edge_cases\nCLI validate subprocess]
    SUITE --> DOT[test_encryption_dotenvx_binary\nDotenvxWrapper/Installer]

    AWS & AZ & HCV --> XFAIL{xfail bugs\n302 · 305 · 329}
    XFAIL --> REPORT[259 pass · 14 skip · 3 xfail · 0 fail]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `tests/integration/test_azure_integration.py`, line 80-102 ([link](https://github.com/jainal09/envdrift/blob/41e67abb9db0834ba16adf4a61039294ac266caa/tests/integration/test_azure_integration.py#L80-L102)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Bare `"credential"` match silently converts non-auth failures to skips**

   The `auth_signatures` tuple includes the bare string `"credential"`, which matches any error output containing that substring — far broader than the author's intent. For example, a CLI bug in `--vault-url` parsing that surfaces a message like `"Failed to build credential chain for endpoint: ..."` or `"Azure credential lookup: no suitable provider found"` would match, causing `assert _looks_like_auth_failure(...)` to pass and the test to skip instead of fail. This silently hides real regressions in the vault command layer. The helper comment itself warns against this pattern ("A blanket `vault` match would also swallow non-auth regressions"), yet `"credential"` is nearly as broad. The other entries in the tuple (`"authenticationerror"`, `"invalid credential"`, `"defaultazurecredential"`) are specific enough; the standalone `"credential"` entry should be removed.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (4): Last reviewed commit: ["test: read scanner default version from ..."](https://github.com/jainal09/envdrift/commit/41e67abb9db0834ba16adf4a61039294ac266caa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35888899)</sub>

<!-- /greptile_comment -->