### PR TITLE
fix(test): main Publish CI flake — gcp test reloads envdrift.vault and corrupts VaultProvider enum

### DIFF
--- a/tests/integration/test_gcp_integration.py
+++ b/tests/integration/test_gcp_integration.py
@@ -238,26 +238,31 @@ class TestGCPFactory:
             assert expected_msg in str(exc_client.value)
             assert expected_hint in str(exc_client.value)
 
-            # 3. Factory path: reload the factory so it imports the reloaded gcp
-            #    module, then assert the same hint surfaces.
-            import envdrift.vault as vault_pkg
+            # 3. Factory path: get_vault_client imports the gcp module LAZILY
+            #    inside the function, so it already picks up the reloaded
+            #    (unavailable) gcp module and surfaces the same hint. Do NOT
+            #    importlib.reload(envdrift.vault) here — that rebuilds the
+            #    VaultProvider enum with a fresh identity and corrupts provider
+            #    comparisons for any test that imported it earlier in the same
+            #    process (e.g. test_vault.py::test_azure_client_creation under the
+            #    full unit+integration suite that the Publish workflow runs).
+            from envdrift.vault import get_vault_client
 
-            vault_pkg = importlib.reload(vault_pkg)
             with pytest.raises(ImportError) as exc_factory:
-                vault_pkg.get_vault_client("gcp", project_id="p")
+                get_vault_client("gcp", project_id="p")
             assert expected_msg in str(exc_factory.value)
             assert expected_hint in str(exc_factory.value)
         finally:
-            # Restore hidden modules and reload back to the real implementations.
+            # Restore hidden modules and reload only the gcp submodule back to the
+            # real implementation. We intentionally do NOT reload envdrift.vault
+            # (see the note above) — reloading the gcp submodule is enough because
+            # the factory imports it lazily at call time.
             for name, mod in saved.items():
                 if mod is None:
                     sys.modules.pop(name, None)
                 else:
                     sys.modules[name] = mod
             importlib.reload(gcp_mod)
-            import envdrift.vault as vault_pkg
-
-            importlib.reload(vault_pkg)
             assert gcp_mod.GCP_AVAILABLE is True
 
 


### PR DESCRIPTION
## 🚨 Hotfix: main `Publish` CI is red on the v10.13.1 release tag

`tests/unit/test_vault.py::TestGetVaultClient::test_azure_client_creation` fails with `ValueError: Unsupported vault provider: VaultProvider.AZURE` (1 failed, 2257 passed) in the **Publish** workflow.

### Root cause
`test_gcp_integration.py::test_gcp_sdk_not_installed_import_error_has_pip_hint` called `importlib.reload(envdrift.vault)`. `reload()` rebuilds the `VaultProvider` **enum with a fresh identity** in the package dict, so a test that imported `VaultProvider` / `get_vault_client` earlier in the same process then compares an *old* enum member against the *new* class — every `provider == VaultProvider.X` branch is False → "Unsupported vault provider".

### Why local + PR CI were green but main wasn't
The poison only spreads when unit **and** integration tests run in **one process**:

| Workflow | Invocation | Same process? | Result |
|---|---|---|---|
| `CI` (`ci.yml`) | `-m "not integration"` then `-m integration` (split) | no | ✅ |
| `Integration Tests` | `pytest tests/integration/` only | no (test_vault is unit) | ✅ |
| **`Publish`** | **`uv run pytest`** (full suite, one process) | **yes** | ❌ |

Only `Publish` runs the whole suite together, and it only triggers on a release tag — so it surfaced exactly when **v10.13.1** was cut.

### Fix
The reload is unnecessary: `get_vault_client` imports the gcp module **lazily inside the function**, so it already picks up the hidden/reloaded (unavailable) module and raises the same `pip install envdrift[gcp]` hint. Call the factory directly; drop the `envdrift.vault` reload (the gcp-submodule reload stays — it's harmless).

- Repro before: gcp pip-hint test + `test_azure_client_creation` → **1 failed**.
- After: full gcp file + full `test_vault.py` → **32 passed, 1 skipped**.

### Suggested follow-up (not in this hotfix)
PR CI never runs the full suite in one process, which is exactly why this slipped through. Adding a job that runs `pytest` (units + the no-container integration tests) together would catch this class of cross-test contamination before release. Happy to do it as a separate PR.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This hotfix removes `importlib.reload(envdrift.vault)` calls from the GCP integration test, fixing a test-order contamination bug that only surfaced during the `Publish` workflow (which runs the full suite in a single process).

- `test_gcp_sdk_not_installed_import_error_has_pip_hint` previously reloaded `envdrift.vault` to exercise the factory path, which is unnecessary because `get_vault_client` already imports the GCP submodule lazily — the reloaded (broken) gcp submodule is picked up at call time without touching the vault package.
- The reload caused `VaultProvider` to be rebuilt with a new class identity, breaking `provider == VaultProvider.AZURE` (and other comparisons) in any test that imported `VaultProvider` earlier in the same process, producing the spurious `"Unsupported vault provider: VaultProvider.AZURE"` failure in `test_azure_client_creation`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a targeted test fix that removes a harmful reload without altering any production code or test assertions.

The vault __init__.py confirms that get_vault_client imports the GCP submodule lazily inside each call, so dropping the vault-level reload doesn't change what the test exercises. The reloaded (unavailable) gcp module in sys.modules is picked up at call time, _get_gcp_modules() sees GCP_AVAILABLE = False, and the expected ImportError with the pip-hint message propagates correctly. The finally cleanup is equally sound: restoring sys.modules and reloading only the gcp submodule is sufficient to reset GCP_AVAILABLE = True, and the assertion at the end of finally confirms it. No production code is touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| tests/integration/test_gcp_integration.py | Removes two importlib.reload(envdrift.vault) calls — one from the try block (factory test step) and one from the finally block (cleanup). The lazy-import behavior of get_vault_client is confirmed in src/envdrift/vault/__init__.py, so the factory path correctly raises ImportError without a vault reload. Cleanup in finally is sound: only the gcp submodule is reloaded, which is sufficient to restore GCP_AVAILABLE = True. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant T as test_gcp_sdk_not_installed...
    participant SYS as sys.modules
    participant GCP as envdrift.vault.gcp
    participant V as envdrift.vault (get_vault_client)

    Note over T: BEFORE (broken)
    T->>SYS: "insert None for google.* modules"
    T->>GCP: "importlib.reload(gcp_mod) → GCP_AVAILABLE=False"
    T->>V: importlib.reload(envdrift.vault) ← ROOT CAUSE
    Note over V: VaultProvider rebuilt with NEW identity
    T->>V: vault_pkg.get_vault_client(gcp) raises ImportError
    Note over T,V: test_azure_client_creation holds OLD VaultProvider ref
    Note over T,V: OLD.AZURE ≠ NEW.AZURE → falls through to ValueError

    Note over T: AFTER (fixed)
    T->>SYS: "insert None for google.* modules"
    T->>GCP: "importlib.reload(gcp_mod) → GCP_AVAILABLE=False"
    Note over V: envdrift.vault NOT reloaded — VaultProvider identity unchanged
    T->>V: get_vault_client(gcp) — lazy import hits reloaded gcp
    Note over GCP: _get_gcp_modules() sees GCP_AVAILABLE=False → ImportError
    T->>SYS: "restore google.* modules"
    T->>GCP: "importlib.reload(gcp_mod) → GCP_AVAILABLE=True"
```

<sub>Reviews (1): Last reviewed commit: ["fix(test): don&#39;t reload envdrift.vault i..."](https://github.com/jainal09/envdrift/commit/8b747ed63282b9626fb5cae92cdf21923b856de9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35916289)</sub>

<!-- /greptile_comment -->