### PR TITLE
docs: add CLAUDE.md engineering conventions + PR checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,14 +2,24 @@
 
 ## Changes
 
+## Related issues
+
+<!-- Closes #NNN -->
+
 ## Testing
 
+- [ ] `uv run pytest` (note any skipped container/binary suites)
 - [ ] Not run (explain why)
-- [ ] `uv run pytest`
-- [ ] Other (describe)
 
 ## Checklist
 
-- [ ] I added/updated tests where needed
-- [ ] I updated docs or README where needed
-- [ ] I verified formatting and linting
+See [CLAUDE.md](../CLAUDE.md) for the full conventions.
+
+- [ ] New/changed behavior has a **real** regression test (containers/binaries/CLI, not mocks)
+- [ ] Confirmed-but-unfixed bugs are `xfail(strict=False)` with an issue ref
+- [ ] Touched files keep **≥ 80%** coverage (codecov green)
+- [ ] No hardcoded binary versions — read from `src/envdrift/constants.json` (Renovate-managed)
+- [ ] `ruff check` / `ruff format` / `pyrefly` / `bandit` clean
+- [ ] Docs (`docs/`) updated for any behavior change
+- [ ] Any pre-existing bug found was fixed or filed as an issue
+- [ ] No `FORCE_COLOR`-dependent integration output; no `importlib.reload()` of package modules

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,13 +33,15 @@ These are the conventions we actually enforce — follow them on every change.
 
 ## External binary versions — never hardcode
 
-- Versions and download-URL templates for `dotenvx`, `sops`, `gitleaks`,
-  `trufflehog`, `talisman`, `trivy`, `infisical`, `detect-secrets` live in
+- Pinned versions for the external tools (`dotenvx`, `sops`, `gitleaks`,
+  `trufflehog`, `talisman`, `trivy`, `infisical`, `detect-secrets`) live in
   **`src/envdrift/constants.json`** and are bumped by **Renovate**
-  (`renovate.json` custom managers). Add a Renovate manager when you add a binary.
+  (`renovate.json` custom managers). Most also carry a download-URL template
+  there; `detect-secrets` is installed via pip (Renovate's `pypi` datasource).
+  Add a Renovate manager when you add a tool.
 - CI install steps and source code read the version/URL from `constants.json`
-  (e.g. `python -c "import json; print(json.load(open('src/envdrift/constants.json'))['sops_version'])"`).
-  Do **not** pin a literal version in a workflow, install script, or test.
+  (load it with `json` and pull the `<tool>_version` / `<tool>_download_urls`
+  key) — do **not** pin a literal version in a workflow, install script, or test.
 - Version-assertion tests read the expected value **dynamically** from
   `constants.json` (e.g. `assert installer.version == _get_<tool>_version()`), so
   Renovate bumps don't break CI.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,81 @@
+# Engineering conventions (envdrift)
+
+Guidance for contributors and AI agents (Claude Code, etc.) working in this repo.
+These are the conventions we actually enforce — follow them on every change.
+
+## Testing
+
+- **Real tests, not mocks of the behavior under test.** Integration tests drive
+  real backends: the container stack (LocalStack `:4566` / HashiCorp Vault `:8200`
+  / Lowkey-Vault `:8443` via `tests/docker-compose.test.yml`), real binaries
+  (`dotenvx`, `sops`, the secret scanners), or the real `envdrift` CLI as a
+  subprocess. `unittest.mock`/`monkeypatch` is fine for env vars / cwd, not for
+  faking the thing you're testing.
+- **Markers:** `integration` (container/binary-backed), plus `aws` / `vault` /
+  `azure` / `gcp` / `slow`. Container/cred tests must **skip-gate** cleanly when a
+  binary or credential is absent (`shutil.which` / `importlib.util.find_spec` /
+  `pytest.importorskip`) so the suite is green locally and runs fully in CI.
+- **Every bug fix ships a real regression test.** For a confirmed bug you are
+  *not* fixing in this PR, add a test asserting the correct behavior and mark it
+  `@pytest.mark.xfail(strict=False, reason="… (see #NNN)")`, referencing the
+  filed issue. Flip the `xfail` to a passing assertion in the PR that fixes it.
+- **Coverage:** touched files stay **≥ 80%** line coverage (codecov `patch` and
+  `project` must stay green). Add focused unit tests for new lines/branches.
+- **CI runs tests two ways.** PR `CI` splits them (`-m "not integration"` then
+  `-m integration`); the `Publish` workflow runs the **whole suite in one
+  process** (`uv run pytest`). Tests must be order-independent — never
+  `importlib.reload()` a package module (e.g. `envdrift.vault`): it rebuilds
+  enums/classes with a new identity and breaks unrelated tests in full-suite runs.
+- **Integration subprocesses must be deterministic.** CI sets `FORCE_COLOR=1`;
+  the integration `conftest.py` strips it (an autouse fixture) so CLI output is
+  un-colorized and `--format json` stays parseable. Don't reintroduce a
+  color-dependent assertion.
+
+## External binary versions — never hardcode
+
+- Versions and download-URL templates for `dotenvx`, `sops`, `gitleaks`,
+  `trufflehog`, `talisman`, `trivy`, `infisical`, `detect-secrets` live in
+  **`src/envdrift/constants.json`** and are bumped by **Renovate**
+  (`renovate.json` custom managers). Add a Renovate manager when you add a binary.
+- CI install steps and source code read the version/URL from `constants.json`
+  (e.g. `python -c "import json; print(json.load(open('src/envdrift/constants.json'))['sops_version'])"`).
+  Do **not** pin a literal version in a workflow, install script, or test.
+- Version-assertion tests read the expected value **dynamically** from
+  `constants.json` (e.g. `assert installer.version == _get_<tool>_version()`), so
+  Renovate bumps don't break CI.
+
+## CLI & code
+
+- `--format json` (and any machine-readable output) must emit clean JSON with no
+  ANSI/Rich colorization, regardless of `FORCE_COLOR` / TTY.
+- Resolve git-diff paths against `git rev-parse --show-toplevel` (they're
+  repo-root-relative), but display/scan with paths relative to cwd so output
+  stays short and config matching is stable.
+
+## Pre-existing issues
+
+If you discover a pre-existing bug while working, **fix it or file a GitHub
+issue** — don't silently leave it. Cite `file:line` and evidence in the issue.
+
+## Pull requests
+
+- **Small, themed PRs by subsystem.** Don't bundle unrelated fixes into a mega-PR;
+  don't open a separate PR per trivial change (CodeRabbit is rate-limited).
+- **Batch review fixes into one commit/push**, resolve threads online on GitHub,
+  and wait for CodeRabbit + other bots to finish before pushing again.
+- **Keep docs in sync** — update `docs/` in the same PR as the behavior change.
+- The branch may be auto-updated with `main` (a merge commit appears on the
+  remote); `git fetch` + rebase before pushing rather than racing it.
+
+## Local gates (all must pass)
+
+```bash
+uv sync --all-extras          # required in a fresh git worktree, or pyrefly fails on vault SDK imports
+uv run ruff check src tests
+uv run ruff format --check .
+uv run pyrefly check
+uv run bandit -r src -c pyproject.toml
+uv run pytest                 # full suite (containers via `make test-integration-up`)
+```
+
+Commits follow Conventional Commits (commitlint + `semantic-pr` enforce it).


### PR DESCRIPTION
Commits the conventions we repeatedly apply into the repo so they're followed across dev environments and enforced on every PR.

- **`CLAUDE.md`** — testing (real backends not mocks, markers/skip-gating, regression-test-per-fix, `xfail` for known bugs, ≥80% coverage), order-independent tests (no `importlib.reload()` of package modules — that caused the Publish-CI flake; FORCE_COLOR-free integration subprocesses), **no hardcoded binary versions** (read from `constants.json`, Renovate-managed), `--format json` cleanliness, fix-or-file pre-existing bugs, small themed PRs / batch review fixes / wait for CodeRabbit / keep docs in sync, and the local gate commands.
- **PR template** — links `CLAUDE.md` and adds a checklist enforcing the above on every PR.

Distilled from the patterns applied across the recent test-coverage and bug-fix PRs.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `CLAUDE.md` engineering conventions reference and expands the PR template checklist to enforce those conventions on every contribution.

- **`CLAUDE.md`** documents testing strategy (real backends, marker/skip gating, xfail for known bugs, ≥80% coverage), the `importlib.reload()` and `FORCE_COLOR` pitfalls, version-management via `constants.json`/Renovate, CLI output cleanliness, and local gate commands — all verified against the actual repo configuration.
- **`.github/PULL_REQUEST_TEMPLATE.md`** replaces the thin original checklist with specific, actionable items tied to the conventions in `CLAUDE.md`.

<h3>Confidence Score: 5/5</h3>

Documentation-only change; safe to merge after addressing the dotenvx key name inaccuracy.

Both files contain documentation and template prose — no executable code is modified. The conventions in CLAUDE.md were cross-checked against the actual repo files (constants.json, renovate.json, docker-compose.test.yml, Makefile, pyproject.toml) and are accurate, with one minor factual slip: the described `<tool>_download_urls` key pattern doesn't match dotenvx's actual `download_urls` key in constants.json.

CLAUDE.md lines 32-34 — the dotenvx download URL key description is inconsistent with constants.json.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| CLAUDE.md | New engineering conventions file — accurate overall, but the `<tool>_download_urls` key description doesn't match the actual `download_urls` key used for dotenvx in constants.json. |
| .github/PULL_REQUEST_TEMPLATE.md | PR template updated with a more detailed checklist linked to CLAUDE.md; relative path `../CLAUDE.md` resolves correctly from `.github/`. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Contributor opens PR] --> B[PR Template checklist]
    B --> C{Tests added?}
    C -->|No mocks| D[Real backend / CLI subprocess]
    C -->|Bug not fixed| E[xfail with issue ref]
    B --> F{Coverage ≥ 80%?}
    F -->|Yes| G[codecov patch green]
    B --> H{Binary version?}
    H -->|Read from constants.json| I[Renovate-managed bump]
    H -->|Hardcoded| X[❌ Blocked]
    B --> J{Docs updated?}
    J -->|Yes| K[docs/ in sync]
    D --> L[CI: split integration / unit]
    L --> M[Publish: full suite order-independent]
    M --> N[No importlib.reload · No FORCE_COLOR assertion]
```

<sub>Reviews (2): Last reviewed commit: ["docs: clarify detect-secrets is pip-inst..."](https://github.com/jainal09/envdrift/commit/0ceba752e9e8fe45316b5b1db77e2cbf413d45ca) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35923882)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated pull request submission template with refined testing checklist items, reorganized sections, and added project-specific conventions including coverage and CI checks.
  * Added new engineering conventions document defining repository standards for testing, coverage, CLI output formatting, path handling, contribution workflows, and commit practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->