### PR TITLE
fix(sops): anchor metadata markers + correct exec-env invocation (#324, #329)

### DIFF
--- a/src/envdrift/encryption/sops.py
+++ b/src/envdrift/encryption/sops.py
@@ -11,6 +11,7 @@ Encrypted values have the format: ENC[AES256_GCM,data:...,iv:...,tag:...,type:st
 from __future__ import annotations
 
 import re
+import shlex
 import shutil
 import subprocess  # nosec B404
 from pathlib import Path
@@ -43,11 +44,14 @@ class SOPSEncryptionBackend(EncryptionBackend):
     # Format: ENC[AES256_GCM,data:...,iv:...,tag:...,type:str]
     ENCRYPTED_PATTERN = re.compile(r"^ENC\[AES256_GCM,")
 
-    # Alternative SOPS patterns (for YAML/JSON metadata)
-    SOPS_METADATA_MARKERS = [
-        "sops:",  # YAML metadata section
-        '"sops":',  # JSON metadata section
-        "sops_version:",  # Version marker in metadata
+    # Line-anchored SOPS metadata markers, matched with re.MULTILINE so a bare
+    # in-line 'sops:' substring in plaintext (e.g. URL=https://sops:8200) does NOT
+    # match, but a genuine SOPS metadata block in any output format does.
+    SOPS_METADATA_PATTERNS = [
+        re.compile(r"^sops:\s*$", re.MULTILINE),  # YAML: top-level `sops:` mapping (col 0)
+        re.compile(r'^\s*"sops"\s*:', re.MULTILINE),  # JSON: `"sops":` (allows indent)
+        re.compile(r"^sops_version\s*=", re.MULTILINE),  # dotenv: flat `sops_version=`
+        re.compile(r"^sops_mac\s*=", re.MULTILINE),  # dotenv: flat `sops_mac=`
     ]
 
     def __init__(
@@ -385,9 +389,9 @@ class SOPSEncryptionBackend(EncryptionBackend):
         if "ENC[AES256_GCM," in content:
             return True
 
-        # Check for SOPS metadata markers (in YAML/JSON files)
-        for marker in self.SOPS_METADATA_MARKERS:
-            if marker in content:
+        # Check for SOPS metadata markers (line-anchored; YAML/JSON/dotenv).
+        for pattern in self.SOPS_METADATA_PATTERNS:
+            if pattern.search(content):
                 return True
 
         return False
@@ -460,14 +464,10 @@ See https://github.com/getsops/sops for full documentation.
         if not self.is_installed():
             raise EncryptionNotFoundError(f"SOPS is not installed.\n{self.install_instructions()}")
 
-        # SOPS exec-env runs a command with secrets as environment variables
-        args = [
-            "exec-env",
-            "--input-type",
-            "dotenv",
-            str(env_file),
-            "--",
-        ] + command
+        # `sops exec-env [file] [command-to-run]`: no --input-type (type is
+        # inferred from the file extension), and the command is a SINGLE shell
+        # string, not a `-- argv` list. shlex.join safely quotes the argv.
+        args = ["exec-env", str(env_file), shlex.join(command)]
 
         return self._run(
             args,

--- a/src/envdrift/encryption/sops.py
+++ b/src/envdrift/encryption/sops.py
@@ -217,6 +217,8 @@ class SOPSEncryptionBackend(EncryptionBackend):
                 - env (dict): Environment variables to pass to subprocess.
                 - cwd (Path | str): Working directory for subprocess.
                 - in_place (bool): Encrypt in-place (default True).
+                - output_file (Path | str): Write ciphertext to a different file
+                  (required when in_place is False).
                 - age_recipients (str): Age public keys for encryption.
                 - kms_arn (str): AWS KMS key ARN.
                 - gcp_kms (str): GCP KMS resource ID.
@@ -252,8 +254,25 @@ class SOPSEncryptionBackend(EncryptionBackend):
 
         # In-place encryption by default
         in_place = kwargs.get("in_place", True)
-        if in_place:
+        output_file = kwargs.get("output_file")
+
+        if output_file:
+            args.extend(["--output", str(output_file)])
+        elif in_place:
             args.append("--in-place")
+        else:
+            # Neither in-place nor an output file: sops would stream the
+            # ciphertext to stdout where _run() captures and discards it, leaving
+            # the on-disk file as PLAINTEXT. Refuse rather than silently dropping
+            # the ciphertext (and the secrets) while reporting success.
+            return EncryptionResult(
+                success=False,
+                message=(
+                    "encrypt(in_place=False) requires an output_file; "
+                    "otherwise the ciphertext is discarded and the file stays plaintext."
+                ),
+                file_path=env_file,
+            )
 
         # Specify input type for .env files
         args.extend(["--input-type", "dotenv", "--output-type", "dotenv"])
@@ -270,10 +289,11 @@ class SOPSEncryptionBackend(EncryptionBackend):
             error_msg = result.stderr.strip() if result.stderr else "Unknown error"
             raise EncryptionBackendError(f"SOPS encryption failed: {error_msg}")
 
+        output_path = Path(output_file) if output_file else env_file
         return EncryptionResult(
             success=True,
-            message=f"Encrypted {env_file}",
-            file_path=env_file,
+            message=f"Encrypted {output_path}",
+            file_path=output_path,
         )
 
     def decrypt(

--- a/tests/integration/test_sops_backend_e2e.py
+++ b/tests/integration/test_sops_backend_e2e.py
@@ -204,6 +204,65 @@ def test_decrypt_in_place_false_no_output_fails_without_discarding_plaintext(
     assert "hunter2" not in env_file.read_text()
 
 
+def test_encrypt_in_place_false_no_output_fails_without_discarding_ciphertext(
+    tmp_path: Path, sops_workspace: Path
+) -> None:
+    """EC-08 (regression for #360): encrypt(in_place=False) with no output_file
+    must report failure instead of streaming the ciphertext to discarded stdout
+    while leaving the on-disk file as PLAINTEXT yet claiming success. The
+    plaintext file stays exactly as written and is never silently consumed."""
+    _require_sops()
+    backend = _make_backend(sops_workspace)
+    env_file = sops_workspace / ".env.discard-enc"
+    env_file.write_text("DB_PASSWORD=hunter2\n")
+    plaintext_snapshot = env_file.read_text()
+
+    result = backend.encrypt(
+        env_file, age_recipients=AGE_PUBLIC_KEY, in_place=False, cwd=sops_workspace
+    )
+
+    # No false success: the ciphertext would have been discarded to stdout.
+    assert result.success is False
+    assert "output_file" in result.message
+    assert result.file_path == env_file
+    # The file is untouched: still the original plaintext, not silently lost.
+    assert env_file.read_text() == plaintext_snapshot
+    assert "ENC[AES256_GCM," not in env_file.read_text()
+
+
+def test_encrypt_with_output_file_writes_ciphertext(tmp_path: Path, sops_workspace: Path) -> None:
+    """HP-11 (regression for #360): encrypt(in_place=False, output_file=...) writes
+    real sops ciphertext to the output file via --output. The output is genuinely
+    encrypted (ENC[...] + sops metadata) and differs from the plaintext, while the
+    source file is left unmodified."""
+    _require_sops()
+    backend = _make_backend(sops_workspace)
+    env_file = sops_workspace / ".env.src"
+    env_file.write_text("DB_PASSWORD=hunter2\n")
+    plaintext_snapshot = env_file.read_text()
+    output_file = sops_workspace / ".env.out"
+
+    result = backend.encrypt(
+        env_file,
+        age_recipients=AGE_PUBLIC_KEY,
+        in_place=False,
+        output_file=output_file,
+        cwd=sops_workspace,
+    )
+
+    assert result.success is True, f"encrypt failed: {result.message}"
+    assert result.file_path == output_file
+    # The output file holds genuine sops ciphertext (markers + metadata).
+    assert output_file.exists()
+    ciphertext = output_file.read_text()
+    assert "ENC[AES256_GCM," in ciphertext
+    assert "hunter2" not in ciphertext
+    assert ciphertext != plaintext_snapshot
+    assert backend.has_encrypted_header(ciphertext) is True
+    # The source plaintext file is left unmodified.
+    assert env_file.read_text() == plaintext_snapshot
+
+
 def test_decrypt_with_wrong_age_key_raises_backend_error(
     tmp_path: Path, sops_workspace: Path
 ) -> None:

--- a/tests/integration/test_sops_backend_e2e.py
+++ b/tests/integration/test_sops_backend_e2e.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import re
 import shutil
+import subprocess
 import sys
 import textwrap
 from pathlib import Path
@@ -92,33 +93,49 @@ def _write_and_encrypt(
     return env_file
 
 
+def _sops_encrypt_inplace(sops_bin: Path, config_free_dir: Path, name: str, content: str) -> Path:
+    """Encrypt a YAML/JSON file in place by driving the real sops binary directly.
+
+    The backend's ``encrypt`` is dotenv-specific (it forces
+    ``--input-type/--output-type dotenv``), so for YAML/JSON we invoke sops
+    itself; the format is inferred from the file extension. ``config_free_dir``
+    MUST be a directory with no ``.sops.yaml`` on its path to root (sops walks
+    parents), so sops uses the explicit ``--age`` recipient instead of the
+    workspace ``.sops.yaml`` (whose only rule matches ``.env*``).
+    """
+    src = config_free_dir / name
+    src.write_text(content)
+    completed = subprocess.run(
+        [str(sops_bin), "--encrypt", "--age", AGE_PUBLIC_KEY, "--in-place", str(src)],
+        capture_output=True,
+        text=True,
+        cwd=config_free_dir,
+        check=False,
+    )
+    assert completed.returncode == 0, f"sops encrypt failed: {completed.stderr}"
+    return src
+
+
 # --------------------------------------------------------------------------- #
 # P0
 # --------------------------------------------------------------------------- #
 
 
-@pytest.mark.xfail(
-    strict=False,
-    reason=(
-        "BUG: SOPSEncryptionBackend.exec_env builds an invalid sops invocation "
-        "('exec-env --input-type dotenv <file> -- <cmd...>'). Real sops rejects "
-        "the unsupported '--input-type' subcommand flag plus the '--'/list command "
-        "form with 'error: missing file to decrypt'. The correct form is "
-        "'sops exec-env <file> <command-as-single-string>' with the dotenv type "
-        "inferred from the file extension. This test asserts the documented "
-        "behavior; remove the xfail when sops.py:451-458 is fixed (see #329)."
-    ),
-)
 def test_exec_env_injects_decrypted_secrets_without_writing_disk(
     tmp_path: Path, sops_workspace: Path
 ) -> None:
-    """HP-10: exec_env runs a child with decrypted secrets; file stays encrypted."""
+    """HP-10 (regression for #329): exec_env runs a child process with the
+    decrypted secrets injected as env vars (never written to disk); the on-disk
+    file stays encrypted. Drives the real sops binary."""
     _require_sops()
     backend = _make_backend(sops_workspace)
+    # Filename MUST end in `.env` so sops exec-env infers the dotenv format from
+    # the extension (sops exec-env ignores --input-type; a non-.env suffix such
+    # as ".env.exec" is parsed as JSON and fails to unmarshal).
     env_file = _write_and_encrypt(
         backend,
         sops_workspace,
-        ".env.exec",
+        "secrets.env",
         "DB_PASSWORD=hunter2\n",
     )
     encrypted_snapshot = env_file.read_text()
@@ -133,8 +150,30 @@ def test_exec_env_injects_decrypted_secrets_without_writing_disk(
 
     assert cp.returncode == 0, f"exec-env failed: {cp.stderr}"
     assert cp.stdout.strip() == "hunter2"
-    # The on-disk file is still the encrypted snapshot.
+    # The on-disk file is still the encrypted snapshot (no plaintext leaked).
     assert env_file.read_text() == encrypted_snapshot
+    assert "hunter2" not in env_file.read_text()
+
+
+def test_exec_env_propagates_child_exit_code(tmp_path: Path, sops_workspace: Path) -> None:
+    """#329: exec_env returns the child's exit code; the secret is sourced from
+    the encrypted file (the child exits 0 only if it saw the injected value)."""
+    _require_sops()
+    backend = _make_backend(sops_workspace)
+    env_file = _write_and_encrypt(backend, sops_workspace, "child.env", "DB_PASSWORD=hunter2\n")
+    cp = backend.exec_env(
+        env_file,
+        [
+            sys.executable,
+            "-c",
+            "import os,sys; sys.exit(0 if os.environ.get('DB_PASSWORD')=='hunter2' else 3)",
+        ],
+    )
+    # Child saw the injected secret -> exits 0; if missing it would be 3.
+    assert cp.returncode == 0, f"secret not injected: {cp.stderr}"
+    # File is still encrypted (not the original plaintext).
+    assert env_file.read_text() != "DB_PASSWORD=hunter2\n"
+    assert "ENC[AES256_GCM," in env_file.read_text()
 
 
 def test_decrypt_in_place_false_no_output_fails_without_discarding_plaintext(
@@ -329,18 +368,82 @@ def test_decrypt_nonencrypted_file_raises_backend_error_with_stderr(
     assert plain.read_text() == "DB_PASSWORD=hunter2\n"
 
 
-def test_has_encrypted_header_false_positive_on_plaintext_sops_url(
+def test_has_encrypted_header_plaintext_sops_substring_not_encrypted(
     tmp_path: Path, sops_workspace: Path
 ) -> None:
-    """EC-04: has_encrypted_header is a documented false positive for plaintext
-    containing the literal substring 'sops:' (e.g. a URL), while
-    detect_encryption_status on a single plain value stays PLAINTEXT."""
+    """EC-04 (regression for #324): plaintext that merely contains the literal
+    substring 'sops:' (e.g. a repo URL) must NOT be misclassified as encrypted.
+    Only a real SOPS header (ENC[AES256_GCM, ...) or a line-anchored SOPS
+    metadata block counts as encrypted."""
     backend = _make_backend(sops_workspace)
 
     content = "REPO=https://github.com/getsops/sops:main\n"
-    assert backend.has_encrypted_header(content) is True
-    # Value-level classification is not fooled.
+    assert backend.has_encrypted_header(content) is False
+    # Value-level classification is not fooled either.
     assert (
         backend.detect_encryption_status("https://github.com/getsops/sops:main")
         == EncryptionStatus.PLAINTEXT
     )
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        "REPO=https://github.com/getsops/sops:main\n",  # 'sops:' in a URL
+        'config = "sops: see the docs"\n',  # 'sops:' in prose
+        '{"note": "we use sops:age for secrets"}\n',  # 'sops:' substring in JSON-ish text
+        "DB_PASSWORD=hunter2\nOTHER=plain\n",  # ordinary plaintext .env
+        "SOPS_VERSION_NOTE=we pin 3.13.1\n",  # dotenv-ish but not a sops_version= marker
+    ],
+)
+def test_has_encrypted_header_false_on_plaintext_with_sops_substring(
+    tmp_path: Path, sops_workspace: Path, content: str
+) -> None:
+    """#324: plaintext containing the literal 'sops:' substring (or a sops-ish
+    key name) is NOT encrypted. Pure-Python; no sops binary required."""
+    backend = _make_backend(sops_workspace)
+    assert backend.has_encrypted_header(content) is False
+
+
+def test_has_encrypted_header_true_on_genuinely_encrypted_dotenv(
+    tmp_path: Path, sops_workspace: Path
+) -> None:
+    """#324: a real sops-encrypted dotenv file is classified encrypted."""
+    _require_sops()
+    backend = _make_backend(sops_workspace)
+    env_file = _write_and_encrypt(
+        backend, sops_workspace, ".env.enc-dotenv", "DB_PASSWORD=hunter2\n"
+    )
+    content = env_file.read_text()
+    assert "ENC[AES256_GCM," in content
+    assert backend.has_encrypted_header(content) is True
+    assert backend.is_file_encrypted(env_file) is True
+
+
+@pytest.mark.parametrize(
+    ("name", "plaintext"),
+    [
+        ("secrets.yaml", "DB_PASSWORD: hunter2\n"),
+        ("secrets.json", '{"DB_PASSWORD": "hunter2"}\n'),
+    ],
+)
+def test_has_encrypted_header_true_on_genuinely_encrypted_yaml_json(
+    tmp_path: Path, sops_workspace: Path, name: str, plaintext: str
+) -> None:
+    """#324: real sops-encrypted YAML and JSON files are classified encrypted.
+
+    Driven by the real sops binary directly (the backend's encrypt is
+    dotenv-only); sops infers the YAML/JSON format from the file extension and
+    emits a line-anchored ``sops:`` / ``"sops":`` metadata block plus
+    ``ENC[AES256_GCM,`` values.
+    """
+    sops_bin = _require_sops()
+    backend = _make_backend(sops_workspace)
+    # Encrypt under tmp_path (NOT sops_workspace), which has no .sops.yaml on its
+    # path to root, so sops honours the explicit --age recipient.
+    src = _sops_encrypt_inplace(sops_bin, tmp_path, name, plaintext)
+
+    content = src.read_text()
+    assert "ENC[AES256_GCM," in content
+    assert backend.has_encrypted_header(content) is True
+    assert backend.is_file_encrypted(src) is True

--- a/tests/unit/test_encryption_backends.py
+++ b/tests/unit/test_encryption_backends.py
@@ -353,10 +353,48 @@ class TestSOPSEncryptionBackend:
         assert backend.has_encrypted_header(content) is True
 
     def test_has_encrypted_header_with_sops_yaml(self):
-        """Test has_encrypted_header with YAML sops: marker."""
+        """Test has_encrypted_header with a genuinely-encrypted YAML block.
+
+        A real SOPS YAML file carries both an ``ENC[AES256_GCM,`` value and a
+        col-0 ``sops:`` metadata mapping; the authoritative ``ENC[`` marker
+        classifies it encrypted.
+        """
         backend = SOPSEncryptionBackend()
-        content = "key: value\nsops:\n  version: 3.8.1"
+        content = "key: ENC[AES256_GCM,data:abc,iv:xyz,tag:123,type:str]\nsops:\n  version: 3.8.1"
         assert backend.has_encrypted_header(content) is True
+
+    def test_has_encrypted_header_metadata_only_no_enc_marker(self):
+        """Metadata markers alone (no ``ENC[``) still classify as encrypted (#324).
+
+        Pins the line-anchored ``SOPS_METADATA_PATTERNS`` branch — content that
+        carries a genuine SOPS metadata block but no ``ENC[AES256_GCM,`` value
+        (e.g. a file encrypted with ``--unencrypted-suffix``) must still be
+        detected. Covers the YAML col-0 ``sops:`` mapping and the flat dotenv
+        ``sops_version=`` / ``sops_mac=`` markers.
+        """
+        backend = SOPSEncryptionBackend()
+        assert backend.has_encrypted_header("key: value\nsops:\n  version: 3.8.1\n") is True
+        assert (
+            backend.has_encrypted_header('{\n\t"sops": {\n\t\t"version": "3.13.1"\n\t}\n}') is True
+        )
+        assert backend.has_encrypted_header("FOO=bar\nsops_version=3.13.1\n") is True
+        assert backend.has_encrypted_header("FOO=bar\nsops_mac=abc123\n") is True
+
+    def test_has_encrypted_header_plaintext_sops_substring_not_encrypted(self):
+        """Plaintext containing the substring 'sops:' is NOT encrypted (#324).
+
+        The old unscoped ``"sops:" in content`` marker false-positived on any
+        plaintext mentioning ``sops:`` (a URL, a comment, a value). The
+        line-anchored patterns must reject these.
+        """
+        backend = SOPSEncryptionBackend()
+        for plaintext in (
+            "URL=https://sops:8200/v1\n",
+            "REPO=https://github.com/getsops/sops:main\n",
+            "# a comment about sops: usage\n",
+            'JSON={"endpoint": "https://sops:8200"}\n',
+        ):
+            assert backend.has_encrypted_header(plaintext) is False, plaintext
 
     def test_has_encrypted_header_false(self):
         """Test has_encrypted_header with plaintext."""
@@ -621,7 +659,9 @@ class TestSOPSEncryptionBackend:
 
         result = backend.exec_env(env_file, ["echo", "ok"])
         assert result.returncode == 0
-        assert captured["args"][:4] == ["exec-env", "--input-type", "dotenv", str(env_file)]
+        # `sops exec-env <file> <command-as-single-shell-string>` (no
+        # --input-type; type is inferred from the file extension).
+        assert captured["args"] == ["exec-env", str(env_file), "echo ok"]
 
     def test_encrypt_includes_key_options(self, tmp_path, monkeypatch):
         """Encrypt should include provided key options in SOPS args."""

--- a/tests/unit/test_encryption_backends.py
+++ b/tests/unit/test_encryption_backends.py
@@ -527,6 +527,61 @@ class TestSOPSEncryptionBackend:
         with pytest.raises(EncryptionBackendError):
             backend.encrypt(env_file)
 
+    def test_encrypt_in_place_false_no_output_fails_without_running(self, tmp_path, monkeypatch):
+        """Regression for #360: encrypt(in_place=False) with no output_file must
+        report failure (not run sops at all) instead of streaming the ciphertext
+        to discarded stdout while leaving the file plaintext and claiming success."""
+        env_file = tmp_path / ".env"
+        env_file.write_text("KEY=value")
+
+        backend = SOPSEncryptionBackend()
+        monkeypatch.setattr(backend, "is_installed", lambda: True)
+
+        ran = {"called": False}
+
+        def fake_run(args, env=None, cwd=None):
+            ran["called"] = True
+            return MagicMock(returncode=0, stderr="", stdout="ENC[AES256_GCM,data:zzz]")
+
+        monkeypatch.setattr(backend, "_run", fake_run)
+
+        result = backend.encrypt(env_file, in_place=False)
+
+        # No false success and sops is never invoked (ciphertext would be lost).
+        assert result.success is False
+        assert "output_file" in result.message
+        assert result.file_path == env_file
+        assert ran["called"] is False
+        # The on-disk file is left untouched (still plaintext, not silently lost).
+        assert env_file.read_text() == "KEY=value"
+
+    def test_encrypt_with_output_file(self, tmp_path, monkeypatch):
+        """Regression for #360: encrypt(in_place=False, output_file=...) honors the
+        output file via --output instead of discarding the ciphertext to stdout."""
+        env_file = tmp_path / ".env"
+        env_file.write_text("KEY=value")
+        output_file = tmp_path / ".env.enc"
+
+        backend = SOPSEncryptionBackend()
+        monkeypatch.setattr(backend, "is_installed", lambda: True)
+
+        captured = {}
+
+        def fake_run(args, env=None, cwd=None):
+            captured["args"] = args
+            return MagicMock(returncode=0, stderr="", stdout="")
+
+        monkeypatch.setattr(backend, "_run", fake_run)
+
+        result = backend.encrypt(env_file, output_file=output_file)
+
+        assert result.success is True
+        assert result.file_path == output_file
+        assert "--output" in captured["args"]
+        assert str(output_file) in captured["args"]
+        # In-place flag must NOT be emitted when writing to a separate output file.
+        assert "--in-place" not in captured["args"]
+
     @patch("shutil.which")
     @patch("subprocess.run")
     def test_decrypt_success(self, mock_run, mock_which, tmp_path):


### PR DESCRIPTION
## Summary

Themed SOPS-backend correctness fixes, both verified end-to-end against the **real `sops` binary** (v3.13.1, the constants.json-pinned version) with a real age keypair.

### `#324` — `has_encrypted_header` false-positive on plaintext containing `sops:`
`has_encrypted_header()` did an unscoped substring match for the bare marker `"sops:"`, so any plaintext containing that substring — `URL=https://sops:8200`, a comment, a JSON value — was misclassified as SOPS-encrypted. Because `is_file_encrypted()` and backend auto-detection build on it, **plaintext could be routed to the SOPS decrypt path**.

**Fix:** replace the substring markers with **line-anchored** regexes (`re.MULTILINE`):
- YAML col-0 `^sops:` mapping
- JSON `"sops":`
- flat dotenv `sops_version=` / `sops_mac=`

The always-present `ENC[AES256_GCM,` value check remains the primary signal, so genuinely-encrypted files in **all three** output formats (YAML/JSON/dotenv) are still detected — confirmed empirically, including the `--unencrypted-suffix` edge case where the `mac` field is the only `ENC[`.

### `#329` — `exec_env` builds an invalid `sops exec-env` invocation
The old code built `exec-env --input-type dotenv <file> -- <argv...>`. Real `sops exec-env` has **no `--input-type` option** (type is inferred from the file extension) and takes a **single command string**, not a `-- argv` list — so it **always failed** with `error: missing file to decrypt`.

**Fix:** `exec-env <file> <shlex.join(command)>`. `shlex.join` safely quotes the argv; verified there is **no shell injection** (the backend runs argv without `shell=True`, and sops's internal `sh -c` receives one literal token — `printenv "A; touch pwned"` does not create `pwned`).

## Tests (real, not mocked)
- Removed the `xfail` from `test_exec_env_injects_decrypted_secrets_without_writing_disk` — it now passes against the real binary, and the file stays byte-for-byte encrypted on disk.
- Corrected the former `test_has_encrypted_header_false_positive_on_plaintext_sops_url` to assert plaintext is **not** classified as encrypted.
- Added unit tests pinning the metadata-marker branch (metadata-only content with **no** `ENC[`) and the plaintext-`sops:`-substring regression.
- Real-sops e2e suite: **19 passed** (ran, not skipped); sops unit suite: **75 passed**. Gates green: ruff / ruff-format / pyrefly / bandit. `sops.py` line coverage 91%.

Closes #324
Closes #329

🤖 Generated with [Claude Code](https://claude.com/claude-code)



Closes #360

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two confirmed bugs in the SOPS backend: a false-positive in `has_encrypted_header` that misclassified any plaintext containing the substring `sops:` as encrypted, and a broken `exec-env` invocation that always failed because it passed `--input-type` (unsupported by that subcommand) and a `-- argv` list instead of a single shell string.

- **#324**: `SOPS_METADATA_MARKERS` (plain substring list) is replaced with four `re.MULTILINE` line-anchored patterns, so URLs, comments, and JSON values containing `sops:` are no longer misclassified; the `--unencrypted-suffix` edge case (metadata-only, no `ENC[`) is preserved via the pattern branch.
- **#329**: `exec_env` now builds `[\"exec-env\", file, shlex.join(command)]`; `shlex.join` safely quotes argv so sops receives one shell string, which it passes to `sh -c` internally.
- **#360**: `encrypt(in_place=False)` with no `output_file` now returns an explicit failure immediately instead of letting sops stream the ciphertext to captured-and-discarded stdout while leaving the source file as plaintext.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all three fixes address confirmed behavioral defects with both unit and integration test coverage.

All three changed behaviors are covered by tests against the real sops binary. The regex patterns are correctly line-anchored for all three output formats. shlex.join quoting is safe since subprocess.run runs without shell=True. The encrypt guard returns an explicit failure before any subprocess call.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/envdrift/encryption/sops.py | Replaces substring SOPS_METADATA_MARKERS with four line-anchored re.MULTILINE patterns; fixes exec-env invocation from -- argv list to shlex.join single string; adds output_file support and a guard that fails fast when neither in_place nor output_file is set. |
| tests/integration/test_sops_backend_e2e.py | Removes xfail from exec_env test, flips EC-04 assertion from True to False, adds _sops_encrypt_inplace helper, and adds e2e coverage for output_file encrypt, exec_env exit-code propagation, and YAML/JSON header detection. |
| tests/unit/test_encryption_backends.py | Adds unit tests for metadata-only header detection, plaintext sops-substring regression, encrypt(in_place=False) guard, and output_file routing; updates exec_env args assertion to match new invocation form. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/envdrift/encryption/sops.py`, line 449-451 ([link](https://github.com/jainal09/envdrift/blob/cec281b6930d239557ac25fcea1d6cde641bc300/src/envdrift/encryption/sops.py#L449-L451)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The `exec_env` method now relies on SOPS inferring the dotenv format from the file extension, but this constraint isn't documented in the docstring. The integration test explicitly comments "Filename MUST end in `.env`" — callers passing a file like `prod.secrets`, `encrypted_config`, or `app.env.bak` will silently get an opaque SOPS unmarshal error (sops defaults to JSON for unknown extensions). The old `--input-type dotenv` made this work for any filename; the new invocation narrows the accepted surface without surfacing that change.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/sops-correc..."](https://github.com/jainal09/envdrift/commit/26d850432ed2bf988736c88065dc110885debe4e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35958923)</sub>

<!-- /greptile_comment -->