### PR TITLE
fix(scanner): native-scanner false-positive/negative correctness (#354,#355,#368,#369,#370)

### DIFF
--- a/src/envdrift/scanner/engine.py
+++ b/src/envdrift/scanner/engine.py
@@ -751,12 +751,18 @@ class ScanEngine:
         Returns:
             Filtered list excluding public key findings.
         """
-        known_pubkey_hashes = self._collect_public_key_hashes(findings)
-        if not known_pubkey_hashes:
+        pubkey_hashes_by_file = self._collect_public_key_hashes(findings)
+        if not pubkey_hashes_by_file:
             return findings
 
         def is_public_key(finding: ScanFinding) -> bool:
-            if finding.secret_hash and finding.secret_hash in known_pubkey_hashes:
+            # Per-file: a finding is only a public key if ITS OWN file declares
+            # that value on a DOTENV_PUBLIC_KEY line. A global set would let a key
+            # in file A suppress a same-hash finding in file B (cross-file FN).
+            if not finding.secret_hash:
+                return False
+            file_hashes = pubkey_hashes_by_file.get(str(finding.file_path))
+            if file_hashes and finding.secret_hash in file_hashes:
                 logger.debug("Filtering dotenvx public key finding by hash")
                 return True
             return False
@@ -773,22 +779,23 @@ class ScanEngine:
         r'^\s*DOTENV_PUBLIC_KEY[A-Za-z0-9_]*\s*=\s*["\']?(0[23][0-9a-fA-F]{64})["\']?'
     )
 
-    def _collect_public_key_hashes(self, findings: list[ScanFinding]) -> set[str]:
-        """Build the set of ``hash_secret`` values for every dotenvx public key
-        declared in the files referenced by ``findings``.
+    def _collect_public_key_hashes(self, findings: list[ScanFinding]) -> dict[str, set[str]]:
+        """Map each referenced file to the ``hash_secret`` values of the dotenvx
+        public keys declared IN THAT FILE.
 
-        The public key is present, in cleartext, in the file's
+        The public key is present, in cleartext, on the file's
         ``DOTENV_PUBLIC_KEY*`` line. We hash it the same way scanners hash the
-        secret they report, so a finding whose value *is* that public key matches
-        by ``secret_hash`` and gets dropped. Each file is parsed once.
+        secret they report, so a finding whose value *is* that file's public key
+        matches by ``secret_hash`` and gets dropped. Per-file (not a global set)
+        so a key in one file can't suppress findings in another. Each file is
+        parsed once.
         """
-        hashes: set[str] = set()
-        seen_files: set[str] = set()
+        by_file: dict[str, set[str]] = {}
         for finding in findings:
             file_path = str(finding.file_path)
-            if file_path in seen_files:
+            if file_path in by_file:
                 continue
-            seen_files.add(file_path)
+            hashes: set[str] = set()
             try:
                 with open(file_path, encoding="utf-8", errors="ignore") as f:
                     for line in f:
@@ -796,8 +803,9 @@ class ScanEngine:
                         if match:
                             hashes.add(hash_secret(match.group(1)))
             except OSError:
-                continue
-        return hashes
+                hashes = set()
+            by_file[file_path] = hashes
+        return by_file
 
     def _filter_gitignored_files(self, findings: list[ScanFinding]) -> list[ScanFinding]:
         """Filter out findings from files that are in .gitignore.

--- a/src/envdrift/scanner/engine.py
+++ b/src/envdrift/scanner/engine.py
@@ -9,6 +9,7 @@ The ScanEngine is responsible for:
 
 from __future__ import annotations
 
+import re
 import time
 from collections.abc import Callable
 from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, wait
@@ -31,6 +32,7 @@ from envdrift.scanner.native import (
     NativeScanner,
     _is_encrypted_value_line,
 )
+from envdrift.scanner.patterns import hash_secret
 
 if TYPE_CHECKING:
     pass
@@ -686,8 +688,13 @@ class ScanEngine:
             checked_files.add(file_path)
             try:
                 with open(file_path, encoding="utf-8", errors="ignore") as f:
-                    # Read first 2KB to check for markers
-                    content = f.read(2048)
+                    # Read the whole file (#368): the dotenvx ``encrypted:`` marker
+                    # is a *value* prefix that can sit far past the first 2KB in a
+                    # combined file (cleartext config first, encrypted secrets
+                    # after). A 2KB window misjudged such files as unencrypted and
+                    # leaked their ciphertext as findings. This matches line_at()
+                    # and the native scanner, which both read full content.
+                    content = f.read()
                     # Use markers from native scanner
                     for marker in DOTENVX_MARKERS + SOPS_MARKERS:
                         if marker in content:
@@ -724,9 +731,19 @@ class ScanEngine:
     def _filter_public_keys(self, findings: list[ScanFinding]) -> list[ScanFinding]:
         """Filter out findings that are dotenvx public keys.
 
-        Dotenvx public keys are EC secp256k1 keys that start with 02 or 03
-        followed by 64 hex characters. These are meant to be public and
-        should not be flagged as secrets.
+        Dotenvx public keys are EC secp256k1 compressed keys (``02``/``03`` + 64
+        hex chars). They are public by definition and should not be flagged as
+        secrets.
+
+        Production findings only carry a *redacted* ``secret_preview`` (the
+        middle is collapsed to ``*``) and a one-way ``secret_hash`` — never the
+        full secret. The previous implementation compared the preview's length to
+        66, which is never true after redaction, so the filter was dead on real
+        data (#370). The native scanner now drops these keys at detection by
+        value shape; this central filter salvages cross-scanner coverage
+        (gitleaks/trufflehog/native, all of which hash with ``hash_secret``) by
+        matching each finding's ``secret_hash`` against the hash of the public
+        key declared in its own file's ``DOTENV_PUBLIC_KEY*`` line.
 
         Args:
             findings: List of findings to filter.
@@ -734,24 +751,14 @@ class ScanEngine:
         Returns:
             Filtered list excluding public key findings.
         """
-        # Note: ec_pubkey_pattern is not used - we rely on simpler checks below
-        # that can handle truncated previews with redaction markers
+        known_pubkey_hashes = self._collect_public_key_hashes(findings)
+        if not known_pubkey_hashes:
+            return findings
 
         def is_public_key(finding: ScanFinding) -> bool:
-            preview = finding.secret_preview
-            if not preview:
-                return False
-            # Remove redaction markers (****) and check the full pattern
-            # EC secp256k1 compressed public keys are exactly 66 hex chars (33 bytes)
-            clean = preview.replace("*", "")
-            if clean.startswith(("02", "03")) and len(clean) == 66:
-                # Check if remaining chars are hex
-                try:
-                    int(clean, 16)
-                    logger.debug("Filtering dotenvx public key finding")
-                    return True
-                except ValueError:
-                    pass
+            if finding.secret_hash and finding.secret_hash in known_pubkey_hashes:
+                logger.debug("Filtering dotenvx public key finding by hash")
+                return True
             return False
 
         before_count = len(findings)
@@ -760,6 +767,37 @@ class ScanEngine:
         if before_count != after_count:
             logger.info(f"Filtered {before_count - after_count} public key findings")
         return filtered
+
+    # Matches a dotenvx public-key assignment and captures the compressed EC key.
+    _DOTENV_PUBLIC_KEY_RE = re.compile(
+        r'^\s*DOTENV_PUBLIC_KEY[A-Za-z0-9_]*\s*=\s*["\']?(0[23][0-9a-fA-F]{64})["\']?'
+    )
+
+    def _collect_public_key_hashes(self, findings: list[ScanFinding]) -> set[str]:
+        """Build the set of ``hash_secret`` values for every dotenvx public key
+        declared in the files referenced by ``findings``.
+
+        The public key is present, in cleartext, in the file's
+        ``DOTENV_PUBLIC_KEY*`` line. We hash it the same way scanners hash the
+        secret they report, so a finding whose value *is* that public key matches
+        by ``secret_hash`` and gets dropped. Each file is parsed once.
+        """
+        hashes: set[str] = set()
+        seen_files: set[str] = set()
+        for finding in findings:
+            file_path = str(finding.file_path)
+            if file_path in seen_files:
+                continue
+            seen_files.add(file_path)
+            try:
+                with open(file_path, encoding="utf-8", errors="ignore") as f:
+                    for line in f:
+                        match = self._DOTENV_PUBLIC_KEY_RE.match(line)
+                        if match:
+                            hashes.add(hash_secret(match.group(1)))
+            except OSError:
+                continue
+        return hashes
 
     def _filter_gitignored_files(self, findings: list[ScanFinding]) -> list[ScanFinding]:
         """Filter out findings from files that are in .gitignore.

--- a/src/envdrift/scanner/native.py
+++ b/src/envdrift/scanner/native.py
@@ -889,8 +889,11 @@ class NativeScanner(ScannerBackend):
 
                     # Drop dotenvx EC public keys by value shape (#370): public,
                     # not a secret. The full secret is still available here,
-                    # before redaction collapses it.
-                    if _EC_PUBKEY_RE.match(secret):
+                    # before redaction collapses it. Defensive secondary guard —
+                    # the primary pubkey filter is the hash-based
+                    # ScanEngine._filter_public_keys; no standard pattern captures
+                    # a bare EC pubkey as an exact group, so this rarely fires.
+                    if _EC_PUBKEY_RE.match(secret):  # pragma: no cover
                         continue
 
                     # For generic-secret pattern, apply entropy filter to reduce false positives

--- a/src/envdrift/scanner/native.py
+++ b/src/envdrift/scanner/native.py
@@ -11,6 +11,7 @@ any external tools. It checks for:
 from __future__ import annotations
 
 import fnmatch
+import re
 import time
 from pathlib import Path
 
@@ -23,6 +24,7 @@ from envdrift.scanner.base import (
 )
 from envdrift.scanner.patterns import (
     ALL_PATTERNS,
+    SecretPattern,
     calculate_entropy,
     hash_secret,
     redact_secret,
@@ -37,6 +39,15 @@ def _is_encrypted_value_line(line: str) -> bool:
     values are never re-flagged. Shared by both scans so they stay in sync.
     """
     return "encrypted:" in line or "ENC[" in line
+
+
+# A dotenvx public key is a secp256k1 *compressed* EC point: a 0x02/0x03 prefix
+# byte followed by 32 bytes (64 hex chars) — 66 hex chars total. It is public by
+# definition (not a secret) but is high-entropy and matches generic patterns, so
+# we drop it at detection by value shape (anchored) regardless of var name. This
+# complements the var-name skip (is_dotenvx_public_key_var) for cases where the
+# key appears under an unexpected name. See #370.
+_EC_PUBKEY_RE = re.compile(r"^0[23][0-9a-fA-F]{64}$")
 
 
 # Encryption markers for dotenvx
@@ -814,6 +825,26 @@ class NativeScanner(ScannerBackend):
         findings: list[ScanFinding] = []
         lines = content.splitlines()
 
+        # File-scope keyword gate (#355): a keyword-gated pattern only fires when
+        # one of its context keywords appears anywhere in the file. Computed once.
+        content_lower = content.lower()
+
+        def _build_finding(
+            pattern: SecretPattern, secret: str, line_num: int, col_num: int
+        ) -> ScanFinding:
+            return ScanFinding(
+                file_path=file_path,
+                line_number=line_num,
+                column_number=col_num,
+                rule_id=pattern.id,
+                rule_description=pattern.description,
+                description=f"Potential {pattern.description} detected",
+                severity=pattern.severity,
+                secret_preview=redact_secret(secret),
+                secret_hash=hash_secret(secret),
+                scanner=self.name,
+            )
+
         for line_num, line in enumerate(lines, start=1):
             # Skip empty lines and comments
             stripped = line.strip()
@@ -833,10 +864,34 @@ class NativeScanner(ScannerBackend):
                 continue
 
             for pattern in ALL_PATTERNS:
+                # Multiline patterns (e.g. gcp-service-account JSON) are scanned
+                # against the whole file in a separate pass below (#354).
+                if pattern.multiline:
+                    continue
+
+                # File-scope keyword gate (#355): suppress broad-regex matches
+                # unless the file mentions the provider context somewhere. Only
+                # applies to patterns flagged require_keyword (ambiguous prefixes
+                # like twilio AC<32hex>); distinctive-prefix patterns (AKIA…,
+                # sq0atp-…) are never suppressed, so a genuine key with no
+                # sibling provider context is still reported.
+                if (
+                    pattern.require_keyword
+                    and pattern.keywords
+                    and not any(kw.lower() in content_lower for kw in pattern.keywords)
+                ):
+                    continue
+
                 match = pattern.pattern.search(line)
                 if match:
                     # Extract the secret (first group or full match)
                     secret = match.group(1) if match.groups() else match.group(0)
+
+                    # Drop dotenvx EC public keys by value shape (#370): public,
+                    # not a secret. The full secret is still available here,
+                    # before redaction collapses it.
+                    if _EC_PUBKEY_RE.match(secret):
+                        continue
 
                     # For generic-secret pattern, apply entropy filter to reduce false positives
                     # Real secrets have high entropy (randomness), code variables don't
@@ -858,20 +913,22 @@ class NativeScanner(ScannerBackend):
                     # Calculate column number
                     col_num = match.start() + 1
 
-                    findings.append(
-                        ScanFinding(
-                            file_path=file_path,
-                            line_number=line_num,
-                            column_number=col_num,
-                            rule_id=pattern.id,
-                            rule_description=pattern.description,
-                            description=f"Potential {pattern.description} detected",
-                            severity=pattern.severity,
-                            secret_preview=redact_secret(secret),
-                            secret_hash=hash_secret(secret),
-                            scanner=self.name,
-                        )
-                    )
+                    findings.append(_build_finding(pattern, secret, line_num, col_num))
+
+        # Full-content pass for multiline patterns (#354). These match across
+        # newlines (re.DOTALL is baked into the compiled regex), so they cannot be
+        # found in the per-line loop above. The keyword gate is intentionally not
+        # applied here: the multiline patterns carry their own strong anchors
+        # (e.g. "type":"service_account").
+        for pattern in ALL_PATTERNS:
+            if not pattern.multiline:
+                continue
+            match = pattern.pattern.search(content)
+            if match:
+                secret = match.group(1) if match.groups() else match.group(0)
+                line_num = content.count("\n", 0, match.start()) + 1
+                col_num = match.start() - content.rfind("\n", 0, match.start())
+                findings.append(_build_finding(pattern, secret, line_num, col_num))
 
         return findings
 
@@ -885,13 +942,17 @@ class NativeScanner(ScannerBackend):
         Returns:
             List of entropy-based findings.
         """
-        import re
-
         findings: list[ScanFinding] = []
         lines = content.splitlines()
 
-        # Pattern for assignment-like statements
-        assignment_pattern = re.compile(r"[A-Z_][A-Z0-9_]*\s*[=:]\s*[\"']?([^\"'\s=]{16,})[\"']?")
+        # Pattern for assignment-like statements. The LHS allows lower/upper/mixed
+        # case (#369) so lowercase or camelCase var names — api_key=, apiKey:,
+        # secretToken = — are not missed. Downstream filters (URL/path skip,
+        # alpha-only skip, template-string skip, entropy threshold) contain the
+        # added surface to genuine high-entropy assignments.
+        assignment_pattern = re.compile(
+            r"[A-Za-z_][A-Za-z0-9_]*\s*[=:]\s*[\"']?([^\"'\s=]{16,})[\"']?"
+        )
 
         for line_num, line in enumerate(lines, start=1):
             # Skip comments

--- a/src/envdrift/scanner/native.py
+++ b/src/envdrift/scanner/native.py
@@ -892,12 +892,17 @@ class NativeScanner(ScannerBackend):
                     secret = match.group(1) if match.groups() else match.group(0)
 
                     # Drop dotenvx EC public keys by value shape (#370): public,
-                    # not a secret. Defensive secondary guard — the primary pubkey
-                    # filter is the hash-based ScanEngine._filter_public_keys; no
-                    # standard pattern captures a bare EC pubkey as its exact
-                    # group (generic-secret captures the keyword), so this is hard
-                    # to exercise directly and is excluded from coverage.
-                    if _EC_PUBKEY_RE.match(secret):  # pragma: no cover
+                    # not a secret. This IS reachable: the generic-api-key pattern
+                    # (api[_-]?key … ([a-zA-Z0-9_-]{20,})) excludes the quote char
+                    # from its capture group, so `API_KEY="<66-hex pubkey>"`
+                    # captures the *bare* pubkey as `secret`, and that pattern has
+                    # no entropy filter (only generic-secret does). Without this
+                    # drop the bare pubkey is reported as a generic-api-key FP under
+                    # an unexpected (non-DOTENV_PUBLIC_KEY) var name; the var-name
+                    # skip above and the hash-based ScanEngine._filter_public_keys
+                    # don't cover that case. Covered by
+                    # TestKeywordGate.test_ec_pubkey_dropped_by_value_shape_under_api_key_var.
+                    if _EC_PUBKEY_RE.match(secret):
                         continue
 
                     # For generic-secret pattern, apply entropy filter to reduce false positives

--- a/src/envdrift/scanner/native.py
+++ b/src/envdrift/scanner/native.py
@@ -826,8 +826,17 @@ class NativeScanner(ScannerBackend):
         lines = content.splitlines()
 
         # File-scope keyword gate (#355): a keyword-gated pattern only fires when
-        # one of its context keywords appears anywhere in the file. Computed once.
+        # one of its context keywords appears anywhere in the file. Computed once
+        # for the whole file (not per line). A pattern flagged require_keyword but
+        # configured with no keywords is treated as always-gated (fail-safe: it
+        # never fires without context) rather than silently disabling the gate.
         content_lower = content.lower()
+        gated_out_patterns = {
+            pattern.id
+            for pattern in ALL_PATTERNS
+            if pattern.require_keyword
+            and not any(kw.lower() in content_lower for kw in pattern.keywords)
+        }
 
         def _build_finding(
             pattern: SecretPattern, secret: str, line_num: int, col_num: int
@@ -870,16 +879,11 @@ class NativeScanner(ScannerBackend):
                     continue
 
                 # File-scope keyword gate (#355): suppress broad-regex matches
-                # unless the file mentions the provider context somewhere. Only
-                # applies to patterns flagged require_keyword (ambiguous prefixes
-                # like twilio AC<32hex>); distinctive-prefix patterns (AKIA…,
-                # sq0atp-…) are never suppressed, so a genuine key with no
+                # unless the file mentions the provider context somewhere (gate
+                # set precomputed once above). Distinctive-prefix patterns (AKIA…,
+                # sq0atp-…) aren't require_keyword, so a genuine key with no
                 # sibling provider context is still reported.
-                if (
-                    pattern.require_keyword
-                    and pattern.keywords
-                    and not any(kw.lower() in content_lower for kw in pattern.keywords)
-                ):
+                if pattern.id in gated_out_patterns:
                     continue
 
                 match = pattern.pattern.search(line)
@@ -888,11 +892,11 @@ class NativeScanner(ScannerBackend):
                     secret = match.group(1) if match.groups() else match.group(0)
 
                     # Drop dotenvx EC public keys by value shape (#370): public,
-                    # not a secret. The full secret is still available here,
-                    # before redaction collapses it. Defensive secondary guard —
-                    # the primary pubkey filter is the hash-based
-                    # ScanEngine._filter_public_keys; no standard pattern captures
-                    # a bare EC pubkey as an exact group, so this rarely fires.
+                    # not a secret. Defensive secondary guard — the primary pubkey
+                    # filter is the hash-based ScanEngine._filter_public_keys; no
+                    # standard pattern captures a bare EC pubkey as its exact
+                    # group (generic-secret captures the keyword), so this is hard
+                    # to exercise directly and is excluded from coverage.
                     if _EC_PUBKEY_RE.match(secret):  # pragma: no cover
                         continue
 
@@ -926,8 +930,9 @@ class NativeScanner(ScannerBackend):
         for pattern in ALL_PATTERNS:
             if not pattern.multiline:
                 continue
-            match = pattern.pattern.search(content)
-            if match:
+            # finditer (not search): a file may hold multiple service-account
+            # JSON blocks; search() would report only the first.
+            for match in pattern.pattern.finditer(content):
                 secret = match.group(1) if match.groups() else match.group(0)
                 line_num = content.count("\n", 0, match.start()) + 1
                 col_num = match.start() - content.rfind("\n", 0, match.start())

--- a/src/envdrift/scanner/patterns.py
+++ b/src/envdrift/scanner/patterns.py
@@ -24,7 +24,21 @@ class SecretPattern:
         description: Human-readable description of what this pattern detects.
         pattern: Compiled regex pattern. Should have a capture group for the secret.
         severity: Severity level when this pattern matches.
-        keywords: Optional context keywords that increase confidence.
+        keywords: Optional context keywords that increase confidence. Used as a
+            file-scope gate **only** when ``require_keyword`` is True (so a
+            distinctive-prefix pattern can still expose keywords for ranking
+            without being suppressed when none appear).
+        require_keyword: When True the pattern only fires if one of its
+            ``keywords`` appears anywhere in the file (#355). Set this only for
+            *broad* regexes with ambiguous prefixes (e.g. twilio ``AC<32hex>``,
+            telegram ``<digits>:<base64>``) that flood combined files with false
+            positives. Distinctive-prefix patterns (``AKIA…``, ``sq0atp-…``,
+            ``EAA…``) keep ``require_keyword=False`` so a genuine key with no
+            sibling provider context is never wrongly suppressed.
+        multiline: When True the pattern is matched against the *whole file
+            content* (with ``re.DOTALL`` baked into the regex) instead of
+            per-line, for secrets whose tokens span multiple lines (e.g. a GCP
+            service-account JSON).
     """
 
     id: str
@@ -32,6 +46,8 @@ class SecretPattern:
     pattern: re.Pattern[str]
     severity: FindingSeverity
     keywords: tuple[str, ...] = ()
+    require_keyword: bool = False
+    multiline: bool = False
 
 
 # High-confidence patterns - known secret formats with distinctive prefixes
@@ -186,8 +202,16 @@ CRITICAL_PATTERNS: list[SecretPattern] = [
     SecretPattern(
         id="gcp-service-account",
         description="GCP Service Account Key",
-        pattern=re.compile(r'"type"\s*:\s*"service_account".*"private_key"\s*:\s*"-----BEGIN'),
+        # Real service-account JSON spans multiple lines, so the two anchor
+        # tokens are never on one line. Match against the whole file with
+        # re.DOTALL and a lazy ``.*?`` bounded to the nearest private_key, and
+        # flag the pattern as multiline so the scanner uses a full-content pass.
+        pattern=re.compile(
+            r'"type"\s*:\s*"service_account".*?"private_key"\s*:\s*"-----BEGIN',
+            re.DOTALL,
+        ),
         severity=FindingSeverity.CRITICAL,
+        multiline=True,
     ),
     # Azure
     SecretPattern(
@@ -205,6 +229,7 @@ CRITICAL_PATTERNS: list[SecretPattern] = [
         pattern=re.compile(r"(SK[a-fA-F0-9]{32})"),
         severity=FindingSeverity.HIGH,
         keywords=("twilio",),
+        require_keyword=True,
     ),
     SecretPattern(
         id="twilio-account-sid",
@@ -212,6 +237,7 @@ CRITICAL_PATTERNS: list[SecretPattern] = [
         pattern=re.compile(r"(AC[a-fA-F0-9]{32})"),
         severity=FindingSeverity.HIGH,
         keywords=("twilio",),
+        require_keyword=True,
     ),
     # SendGrid
     SecretPattern(
@@ -227,6 +253,7 @@ CRITICAL_PATTERNS: list[SecretPattern] = [
         pattern=re.compile(r"([a-f0-9]{32}-us[0-9]{1,2})"),
         severity=FindingSeverity.HIGH,
         keywords=("mailchimp",),
+        require_keyword=True,
     ),
     # NPM
     SecretPattern(
@@ -300,6 +327,7 @@ CRITICAL_PATTERNS: list[SecretPattern] = [
         pattern=re.compile(r"([0-9]{8,10}:[a-zA-Z0-9_-]{35})"),
         severity=FindingSeverity.HIGH,
         keywords=("telegram", "bot"),
+        require_keyword=True,
     ),
     # Heroku
     SecretPattern(
@@ -346,6 +374,7 @@ CRITICAL_PATTERNS: list[SecretPattern] = [
         pattern=re.compile(r"(AP[a-fA-F0-9]{32})"),
         severity=FindingSeverity.HIGH,
         keywords=("twilio",),
+        require_keyword=True,
     ),
     # Square (legacy format - modern tokens are opaque bearer strings)
     # These patterns detect older sq0atp/sq0csp prefixed tokens

--- a/tests/integration/test_scanner_external_binaries.py
+++ b/tests/integration/test_scanner_external_binaries.py
@@ -317,12 +317,20 @@ def test_scan_engine_skip_encrypted_files_filters_real_scanner_findings(tmp_path
 
 @requires_trivy
 def test_scan_engine_filters_dotenvx_public_keys_from_real_output(tmp_path):
-    """EC-12: ScanEngine filters dotenvx EC secp256k1 public keys (66 hex, 02/03)."""
+    """EC-12: ScanEngine filters dotenvx EC public keys via secret_hash (#370).
+
+    Scanners only ever expose a *redacted* preview plus a one-way ``secret_hash``;
+    the old length-66 preview check was dead (previews are ~8 chars). The filter
+    now hashes the ``DOTENV_PUBLIC_KEY*`` value declared in a finding's file and
+    drops findings whose ``secret_hash`` matches — this test exercises that
+    hash-based contract.
+    """
+    from envdrift.scanner.base import FindingSeverity
+    from envdrift.scanner.patterns import hash_secret
+
     _write_secret_file(tmp_path, "creds.env")
-    # Plant a real dotenvx-style EC public key (66 hex, starts with 03) in the
-    # scanned tree so the real ScanEngine.scan() path below has an actual public
-    # key to filter — without this the real-output loop is vacuous and only the
-    # synthetic control at the end exercises _filter_public_keys.
+    # Plant a real dotenvx-style EC public key (66 hex, starts with 03), declared
+    # on a DOTENV_PUBLIC_KEY line so the engine can hash + filter it.
     real_pubkey = "03" + "cd" * 32  # 66 hex chars
     (tmp_path / "keys.env").write_text(f"DOTENV_PUBLIC_KEY_PRODUCTION={real_pubkey}\n")
 
@@ -336,38 +344,37 @@ def test_scan_engine_filters_dotenvx_public_keys_from_real_output(tmp_path):
     engine = ScanEngine(config)
     result = engine.scan([tmp_path])
 
-    # No surviving finding should be a 66-hex EC public key starting 02/03.
+    # No surviving finding may hash to the planted public key.
+    planted_hash = hash_secret(real_pubkey)
     for finding in result.unique_findings:
-        clean = finding.secret_preview.replace("*", "")
-        is_pubkey = clean.startswith(("02", "03")) and len(clean) == 66
-        if is_pubkey:
-            try:
-                int(clean, 16)
-                pytest.fail(f"public key leaked through filter: {finding.secret_preview}")
-            except ValueError:
-                pass
+        assert finding.secret_hash != planted_hash, (
+            f"public key leaked through filter: {finding.rule_id} in {finding.file_path}"
+        )
 
-    # Control: a synthetic pubkey finding is removed while a normal one is kept.
+    # Control: a finding whose secret_hash matches a DOTENV_PUBLIC_KEY value in
+    # its own file is removed; a normal secret (different hash) is kept.
     pubkey = "02" + "ab" * 32  # 66 hex chars, starts with 02
+    ctrl = tmp_path / "ctrl.env"
+    ctrl.write_text(f"DOTENV_PUBLIC_KEY_X={pubkey}\n")
     pubkey_finding = ScanFinding(
-        file_path=tmp_path / "keys.env",
+        file_path=ctrl,
         rule_id="trivy-generic",
         rule_description="Public Key",
         description="pubkey",
-        severity=result.unique_findings[0].severity
-        if result.unique_findings
-        else __import__("envdrift.scanner.base", fromlist=["FindingSeverity"]).FindingSeverity.HIGH,
+        severity=FindingSeverity.HIGH,
         scanner="trivy",
-        secret_preview=pubkey,  # unredacted, exactly 66 hex
+        secret_preview="02ab****abab",  # redacted, as a real scanner emits
+        secret_hash=hash_secret(pubkey),
     )
     normal_finding = ScanFinding(
-        file_path=tmp_path / "keys.env",
+        file_path=ctrl,
         rule_id="trivy-github-pat",
         rule_description="GitHub PAT",
         description="secret",
-        severity=pubkey_finding.severity,
+        severity=FindingSeverity.HIGH,
         scanner="trivy",
         secret_preview="ghp_****abcd",
+        secret_hash=hash_secret("ghp_realtokenvalue1234567890abcdEFGH"),
     )
     kept = engine._filter_public_keys([pubkey_finding, normal_finding])
     assert pubkey_finding not in kept

--- a/tests/scanner/test_engine.py
+++ b/tests/scanner/test_engine.py
@@ -1423,6 +1423,30 @@ class TestFilterPublicKeys:
         result = engine._filter_public_keys([real_finding])
         assert result == [real_finding]
 
+    def test_filter_public_keys_unreadable_file_swallows_oserror(self, tmp_path):
+        """A finding whose file can't be opened doesn't crash pubkey collection (#370)."""
+        from envdrift.scanner.patterns import hash_secret, redact_secret
+
+        config = GuardConfig(use_native=True, use_gitleaks=False)
+        engine = ScanEngine(config)
+
+        real = "sk_live_" + "anotherrealsecretvalue012345"  # split: dodge push-protection
+        finding = ScanFinding(
+            file_path=tmp_path / "does-not-exist.env",  # open() -> OSError -> skipped
+            rule_id="generic-secret",
+            rule_description="secret",
+            description="x",
+            severity=FindingSeverity.HIGH,
+            scanner="gitleaks",
+            secret_preview=redact_secret(real),
+            secret_hash=hash_secret(real),
+        )
+
+        # No public keys are collectible (file unreadable), so the finding
+        # survives and no exception escapes.
+        result = engine._filter_public_keys([finding])
+        assert result == [finding]
+
     def test_filter_public_keys_mixed_findings(self, tmp_path):
         """In a mixed batch only the public-key finding is dropped."""
         from envdrift.scanner.patterns import hash_secret, redact_secret

--- a/tests/scanner/test_engine.py
+++ b/tests/scanner/test_engine.py
@@ -1296,9 +1296,72 @@ class TestFilterEncryptedFiles:
 
         assert engine._filter_encrypted_files([finding]) == []
 
+    def test_filter_encrypted_marker_beyond_2kb_still_filters(self, tmp_path):
+        """#368: the dotenvx ``encrypted:`` marker can sit far past the first 2KB
+        in a combined file (cleartext config first, encrypted secrets after).
+
+        The old 2KB-only read misjudged such files as unencrypted and leaked
+        their ciphertext lines as findings. Reading the whole file recognizes the
+        marker and drops the ciphertext finding.
+        """
+        config = GuardConfig(use_native=True, use_gitleaks=False)
+        engine = ScanEngine(config)
+
+        f = tmp_path / ".env.production"
+        filler = "".join(
+            f"CONFIG_{i}=plain_padding_value_xxxxxxxxxxxxxxxxxxxxxxxx\n" for i in range(60)
+        )
+        assert len(filler) > 2048  # marker is genuinely beyond the old window
+        f.write_text(filler + 'SECRET="encrypted:vault1GENUINECIPHERTEXTblob+/="\n')
+        cipher_line = filler.count("\n") + 1
+
+        finding = ScanFinding(
+            file_path=f,
+            line_number=cipher_line,
+            rule_id="high-entropy-string",
+            rule_description="entropy",
+            description="blob",
+            severity=FindingSeverity.MEDIUM,
+            scanner="detect-secrets",
+        )
+        assert engine._filter_encrypted_files([finding]) == []
+
+    def test_filter_cleartext_finding_survives_when_marker_beyond_2kb(self, tmp_path):
+        """#368 regression-guard: a finding on a *cleartext* line of the same
+        combined file (whose marker is past 2KB) must still survive."""
+        config = GuardConfig(use_native=True, use_gitleaks=False)
+        engine = ScanEngine(config)
+
+        f = tmp_path / ".env.production"
+        filler = "".join(
+            f"CONFIG_{i}=plain_padding_value_xxxxxxxxxxxxxxxxxxxxxxxx\n" for i in range(60)
+        )
+        assert len(filler) > 2048
+        f.write_text(filler + 'SECRET="encrypted:vault1CIPHERTEXTblob+/="\n')
+
+        cleartext_finding = ScanFinding(
+            file_path=f,
+            line_number=1,  # a cleartext CONFIG_0 line
+            rule_id="generic-secret",
+            rule_description="secret",
+            description="cleartext",
+            severity=FindingSeverity.HIGH,
+            scanner="native",
+        )
+        result = engine._filter_encrypted_files([cleartext_finding])
+        assert result == [cleartext_finding]
+
 
 class TestFilterPublicKeys:
-    """Tests for _filter_public_keys method."""
+    """Tests for _filter_public_keys (#370).
+
+    The filter operates on *production* data: findings carry a redacted
+    ``secret_preview`` and a one-way ``secret_hash`` — never the full secret.
+    Public keys are identified by hashing the file's own ``DOTENV_PUBLIC_KEY*``
+    declaration and matching ``secret_hash``. The previous raw-un-redacted-preview
+    tests were invalid (the pipeline never produces a 66-char preview) and masked
+    the bug; these tests reflect the real pipeline.
+    """
 
     def test_filter_public_keys_empty_list(self):
         """Test filter with empty findings list."""
@@ -1308,96 +1371,121 @@ class TestFilterPublicKeys:
         result = engine._filter_public_keys([])
         assert result == []
 
-    def test_filter_public_keys_ec_compressed_key(self):
-        """Test that EC compressed public keys are filtered."""
+    def test_filter_public_keys_by_hash_with_redacted_preview(self, tmp_path):
+        """A finding carrying the file's DOTENV_PUBLIC_KEY value (matched by
+        ``secret_hash``) is filtered, even though its preview is redacted."""
+        from envdrift.scanner.patterns import hash_secret, redact_secret
+
         config = GuardConfig(use_native=True, use_gitleaks=False)
         engine = ScanEngine(config)
 
-        # EC secp256k1 compressed public key - exactly 66 hex chars starting with 02 or 03
-        ec_pubkey = "02" + "a" * 64  # 66 chars total
+        pubkey = "02" + "a" * 64  # 66-hex compressed EC public key
+        env_file = tmp_path / ".env"
+        env_file.write_text(f'DOTENV_PUBLIC_KEY="{pubkey}"\nSECRET="encrypted:xyz"\n')
 
-        findings = [
-            ScanFinding(
-                file_path=Path("test.py"),
-                rule_id="test-rule",
-                rule_description="Test",
-                description="Test finding",
-                severity=FindingSeverity.HIGH,
-                scanner="native",
-                secret_preview=ec_pubkey,
-            ),
-        ]
+        pub_finding = ScanFinding(
+            file_path=env_file,
+            rule_id="high-entropy-string",
+            rule_description="entropy",
+            description="x",
+            severity=FindingSeverity.MEDIUM,
+            scanner="gitleaks",
+            secret_preview=redact_secret(pubkey),  # PRODUCTION form (redacted)
+            secret_hash=hash_secret(pubkey),
+        )
 
-        result = engine._filter_public_keys(findings)
-        assert len(result) == 0
+        result = engine._filter_public_keys([pub_finding])
+        assert result == []
 
-    def test_filter_public_keys_short_hex_not_filtered(self):
-        """Test that short hex strings starting with 02/03 are NOT filtered."""
+    def test_filter_public_keys_preserves_real_secret(self, tmp_path):
+        """A real secret (whose hash is not the file's public key) survives."""
+        from envdrift.scanner.patterns import hash_secret, redact_secret
+
         config = GuardConfig(use_native=True, use_gitleaks=False)
         engine = ScanEngine(config)
 
-        # Short hex that starts with 02 but is not a full EC public key
-        short_secret = "0200abcd"
+        pubkey = "03" + "b" * 64
+        env_file = tmp_path / ".env"
+        env_file.write_text(f'DOTENV_PUBLIC_KEY="{pubkey}"\n')
 
-        findings = [
-            ScanFinding(
-                file_path=Path("test.py"),
-                rule_id="test-rule",
-                rule_description="Test",
-                description="Test finding",
-                severity=FindingSeverity.HIGH,
-                scanner="native",
-                secret_preview=short_secret,
-            ),
-        ]
+        real = "sk_live_" + "realsecretvalue0123456789"  # split: dodge push-protection
+        real_finding = ScanFinding(
+            file_path=env_file,
+            rule_id="generic-secret",
+            rule_description="secret",
+            description="x",
+            severity=FindingSeverity.HIGH,
+            scanner="gitleaks",
+            secret_preview=redact_secret(real),
+            secret_hash=hash_secret(real),
+        )
 
-        result = engine._filter_public_keys(findings)
-        # Should NOT be filtered - too short to be an EC public key
-        assert len(result) == 1
+        result = engine._filter_public_keys([real_finding])
+        assert result == [real_finding]
 
-    def test_filter_public_keys_non_hex_not_filtered(self):
-        """Test that non-hex strings are not filtered."""
+    def test_filter_public_keys_mixed_findings(self, tmp_path):
+        """In a mixed batch only the public-key finding is dropped."""
+        from envdrift.scanner.patterns import hash_secret, redact_secret
+
         config = GuardConfig(use_native=True, use_gitleaks=False)
         engine = ScanEngine(config)
 
-        # Starts with 02 but contains non-hex characters
-        non_hex = "02" + "g" * 64  # 'g' is not hex
+        pubkey = "02" + "c" * 64
+        env_file = tmp_path / ".env"
+        env_file.write_text(f"DOTENV_PUBLIC_KEY={pubkey}\nSECRET=encrypted:xyz\n")
 
-        findings = [
-            ScanFinding(
-                file_path=Path("test.py"),
-                rule_id="test-rule",
-                rule_description="Test",
-                description="Test finding",
-                severity=FindingSeverity.HIGH,
-                scanner="native",
-                secret_preview=non_hex,
-            ),
-        ]
+        real = "ghp_realgithubtoken0123456789abcdef0123"
+        pub_finding = ScanFinding(
+            file_path=env_file,
+            rule_id="high-entropy-string",
+            rule_description="entropy",
+            description="x",
+            severity=FindingSeverity.MEDIUM,
+            scanner="trufflehog",
+            secret_preview=redact_secret(pubkey),
+            secret_hash=hash_secret(pubkey),
+        )
+        real_finding = ScanFinding(
+            file_path=env_file,
+            rule_id="github-pat",
+            rule_description="GitHub PAT",
+            description="x",
+            severity=FindingSeverity.CRITICAL,
+            scanner="trufflehog",
+            secret_preview=redact_secret(real),
+            secret_hash=hash_secret(real),
+        )
 
-        result = engine._filter_public_keys(findings)
-        # Should NOT be filtered - not valid hex
-        assert len(result) == 1
+        result = engine._filter_public_keys([pub_finding, real_finding])
+        kept_rules = {f.rule_id for f in result}
+        assert "high-entropy-string" not in kept_rules
+        assert "github-pat" in kept_rules
 
-    def test_filter_public_keys_preserves_normal_findings(self):
-        """Test that normal findings are not filtered."""
+    def test_filter_public_keys_no_pubkey_in_file_keeps_all(self, tmp_path):
+        """When no file declares a public key, nothing is filtered."""
+        from envdrift.scanner.patterns import hash_secret, redact_secret
+
         config = GuardConfig(use_native=True, use_gitleaks=False)
         engine = ScanEngine(config)
 
-        findings = [
-            ScanFinding(
-                file_path=Path("test.py"),
-                rule_id="test-rule",
-                rule_description="Test",
-                description="Test finding",
-                severity=FindingSeverity.HIGH,
-                scanner="native",
-                secret_preview="AKIA****WXYZ",  # AWS key preview
-            ),
-        ]
+        env_file = tmp_path / ".env"
+        env_file.write_text("API_KEY=plainvalue123\n")  # no DOTENV_PUBLIC_KEY
 
-        result = engine._filter_public_keys(findings)
-        assert len(result) == 1
+        secret = "02" + "d" * 64  # pubkey-shaped value but not declared in file
+        finding = ScanFinding(
+            file_path=env_file,
+            rule_id="high-entropy-string",
+            rule_description="entropy",
+            description="x",
+            severity=FindingSeverity.MEDIUM,
+            scanner="gitleaks",
+            secret_preview=redact_secret(secret),
+            secret_hash=hash_secret(secret),
+        )
+
+        # No DOTENV_PUBLIC_KEY line -> no known hashes -> finding survives.
+        result = engine._filter_public_keys([finding])
+        assert result == [finding]
 
 
 class TestGitignoreFilter:

--- a/tests/scanner/test_native.py
+++ b/tests/scanner/test_native.py
@@ -1116,17 +1116,64 @@ class TestKeywordGate:
         mc = [f for f in result.findings if f.rule_id == "mailchimp-api-key"]
         assert len(mc) >= 1
 
-    def test_ec_public_key_value_dropped_in_pattern_scan(
+    def test_ec_pubkey_dropped_by_value_shape_under_api_key_var(
         self, scanner: NativeScanner, tmp_path: Path
     ):
-        """A value shaped like a dotenvx EC public key (02/03 + 64 hex) is not a
-        secret and is dropped during pattern scanning (#370)."""
+        """A bare EC public key under a non-dotenvx var (API_KEY=…) is dropped by
+        value shape, not by var name or entropy (#370).
+
+        This is the *load-bearing* test for the in-``_scan_patterns``
+        ``_EC_PUBKEY_RE`` drop. The chain that makes the drop the **sole**
+        suppressor here:
+
+        * ``generic-api-key`` (``api[_-]?key`` … ``([a-zA-Z0-9_-]{20,})``) captures
+          the value **bare** — its char class excludes ``"``, so the closing quote
+          terminates the capture and group(1) is exactly the 66-hex pubkey.
+        * ``generic-api-key`` carries **no entropy filter** (only ``generic-secret``
+          does), so the value is *not* dropped by entropy.
+        * ``API_KEY`` is **not** ``is_dotenvx_public_key_var``, so the var-name skip
+          does not apply.
+
+        Verified empirically: on ``origin/main`` (no ``_EC_PUBKEY_RE`` drop) this
+        line is reported as ``generic-api-key``; with the drop it is suppressed.
+        Revert the drop → this test fails; restore → it passes.
+        """
         from envdrift.scanner.patterns import hash_secret
 
-        pubkey = "03" + "f8a91b2c3d4e5f6a" * 4  # 66 hex, compressed secp256k1 pubkey
+        # 66-hex compressed secp256k1 pubkey shape (03 + 64 hex) built via
+        # concatenation so no realistic-looking secret literal is committed.
+        pubkey = "03" + "12456789abcdef" + ("0123456789abcdef" * 3) + "01"
+        assert len(pubkey) == 66
+        cfg = tmp_path / "api.env"
+        cfg.write_text(f'API_KEY="{pubkey}"\n')
+
+        result = scanner.scan([tmp_path])
+
+        # generic-api-key would otherwise flag the bare pubkey; the value-shape
+        # drop is the only thing that suppresses it here.
+        assert all(f.rule_id != "generic-api-key" for f in result.findings)
+        assert all(f.secret_hash != hash_secret(pubkey) for f in result.findings)
+
+    def test_low_entropy_pubkey_under_secret_var_dropped_by_entropy(
+        self, scanner: NativeScanner, tmp_path: Path
+    ):
+        """A pubkey-shaped value under a ``secret`` var is dropped by the
+        generic-secret entropy filter (entropy < 4.0), independent of #370.
+
+        NOTE: this is *not* a test of the ``_EC_PUBKEY_RE`` drop. ``generic-secret``
+        includes ``"`` in its char class, so ``SECRET="<pubkey>"`` captures
+        ``<pubkey>"`` (with the quote) — which does *not* match the anchored
+        ``_EC_PUBKEY_RE`` — and the entropy filter is what suppresses it. The
+        value-shape drop is covered by
+        ``test_ec_pubkey_dropped_by_value_shape_under_api_key_var`` above.
+        """
+        from envdrift.scanner.patterns import calculate_entropy, hash_secret
+
+        pubkey = "03" + "f8a91b2c3d4e5f6a" * 4  # 66 hex, low symbol diversity
+        # Entropy of the captured value (incl. trailing quote) is < 4.0, so the
+        # generic-secret entropy filter — not the EC drop — discards it.
+        assert calculate_entropy(pubkey + '"') < 4.0
         cfg = tmp_path / "pub.env"
-        # Var name at a word boundary ("secret") so generic-secret actually fires;
-        # the EC-pubkey drop (#370) runs before the entropy filter and discards it.
         cfg.write_text(f'SECRET="{pubkey}"\n')
 
         result = scanner.scan([tmp_path])
@@ -1191,7 +1238,15 @@ class TestLowercaseEntropyAssignment:
 
 
 class TestEcPublicKeyDropped:
-    """#370 — dotenvx EC compressed public keys are dropped by value shape."""
+    """#370 — dotenvx EC compressed public keys are not flagged as secrets.
+
+    These cases use the canonical ``DOTENV_PUBLIC_KEY`` var name, so suppression
+    here flows through the var-name skip (``is_dotenvx_public_key_var``) and the
+    hash-based ``ScanEngine._filter_public_keys`` path — *not* the in-scan
+    ``_EC_PUBKEY_RE`` value-shape drop. The value-shape drop (which fires for a
+    bare pubkey under an *unexpected* var name) is exercised load-bearingly by
+    ``TestKeywordGate.test_ec_pubkey_dropped_by_value_shape_under_api_key_var``.
+    """
 
     @pytest.fixture
     def scanner(self) -> NativeScanner:

--- a/tests/scanner/test_native.py
+++ b/tests/scanner/test_native.py
@@ -1116,6 +1116,24 @@ class TestKeywordGate:
         mc = [f for f in result.findings if f.rule_id == "mailchimp-api-key"]
         assert len(mc) >= 1
 
+    def test_ec_public_key_value_dropped_in_pattern_scan(
+        self, scanner: NativeScanner, tmp_path: Path
+    ):
+        """A value shaped like a dotenvx EC public key (02/03 + 64 hex) is not a
+        secret and is dropped during pattern scanning (#370)."""
+        from envdrift.scanner.patterns import hash_secret
+
+        pubkey = "03" + "f8a91b2c3d4e5f6a" * 4  # 66 hex, compressed secp256k1 pubkey
+        cfg = tmp_path / "pub.env"
+        # Quoted value so the generic-secret pattern matches; the EC-pubkey drop
+        # (#370) runs before the entropy filter, so the match is discarded.
+        cfg.write_text(f'CLIENT_SECRET="{pubkey}"\n')
+
+        result = scanner.scan([tmp_path])
+
+        # The public-key-shaped value must not surface as a secret finding.
+        assert all(f.secret_hash != hash_secret(pubkey) for f in result.findings)
+
     def test_distinctive_prefix_not_suppressed_without_context(
         self, scanner: NativeScanner, tmp_path: Path
     ):

--- a/tests/scanner/test_native.py
+++ b/tests/scanner/test_native.py
@@ -1125,9 +1125,9 @@ class TestKeywordGate:
 
         pubkey = "03" + "f8a91b2c3d4e5f6a" * 4  # 66 hex, compressed secp256k1 pubkey
         cfg = tmp_path / "pub.env"
-        # Quoted value so the generic-secret pattern matches; the EC-pubkey drop
-        # (#370) runs before the entropy filter, so the match is discarded.
-        cfg.write_text(f'CLIENT_SECRET="{pubkey}"\n')
+        # Var name at a word boundary ("secret") so generic-secret actually fires;
+        # the EC-pubkey drop (#370) runs before the entropy filter and discards it.
+        cfg.write_text(f'SECRET="{pubkey}"\n')
 
         result = scanner.scan([tmp_path])
 

--- a/tests/scanner/test_native.py
+++ b/tests/scanner/test_native.py
@@ -1018,3 +1018,190 @@ class TestSkipClearFiles:
         # Should be scanned but not flagged as unencrypted
         unencrypted_findings = [f for f in result.findings if f.rule_id == "unencrypted-env-file"]
         assert len(unencrypted_findings) == 0
+
+
+# Real, fully-formed GCP service-account JSON (synthetic key material). The
+# "type" and "private_key" anchors land on different lines — the bug (#354) was
+# that the per-line scan never saw both anchors together.
+_GCP_SERVICE_ACCOUNT_JSON = """{
+  "type": "service_account",
+  "project_id": "demo-project",
+  "private_key_id": "0123456789abcdef0123456789abcdef01234567",
+  "private_key": "-----BEGIN PRIVATE KEY-----\\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQ\\n-----END PRIVATE KEY-----\\n",
+  "client_email": "demo@demo-project.iam.gserviceaccount.com",
+  "client_id": "123456789012345678901",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token"
+}
+"""
+
+
+class TestMultilineGcpServiceAccount:
+    """#354 — multi-line GCP service-account JSON is detected via full-content pass."""
+
+    @pytest.fixture
+    def scanner(self) -> NativeScanner:
+        return NativeScanner()
+
+    def test_multiline_gcp_service_account_flagged(self, scanner: NativeScanner, tmp_path: Path):
+        """A real multi-line service_account JSON file is flagged (true positive)."""
+        sa = tmp_path / "service-account.json"
+        sa.write_text(_GCP_SERVICE_ACCOUNT_JSON)
+
+        result = scanner.scan([tmp_path])
+
+        gcp = [f for f in result.findings if f.rule_id == "gcp-service-account"]
+        assert len(gcp) >= 1
+        assert gcp[0].severity == FindingSeverity.CRITICAL
+
+    def test_ordinary_multiline_json_not_flagged(self, scanner: NativeScanner, tmp_path: Path):
+        """An ordinary multi-line JSON (no service_account/private_key) is NOT flagged."""
+        ordinary = tmp_path / "config.json"
+        ordinary.write_text(
+            "{\n"
+            '  "type": "config",\n'
+            '  "name": "demo",\n'
+            '  "values": [1, 2, 3],\n'
+            '  "nested": {"a": "b", "c": "d"}\n'
+            "}\n"
+        )
+
+        result = scanner.scan([tmp_path])
+
+        gcp = [f for f in result.findings if f.rule_id == "gcp-service-account"]
+        assert len(gcp) == 0
+
+
+class TestKeywordGate:
+    """#355 — broad/ambiguous prefix patterns require a context keyword."""
+
+    @pytest.fixture
+    def scanner(self) -> NativeScanner:
+        return NativeScanner()
+
+    def test_twilio_sid_with_context_flagged(self, scanner: NativeScanner, tmp_path: Path):
+        """AC<32hex> with a 'twilio' keyword in the file is flagged (true positive)."""
+        cfg = tmp_path / "twilio.env"
+        # Built via concatenation so no complete AC<32hex> literal is committed
+        # (GitHub push-protection flags real-looking secret literals in fixtures).
+        fake_sid = "AC" + "0123456789abcdef" * 2
+        cfg.write_text(f"# twilio credentials\nTWILIO_ACCOUNT_SID={fake_sid}\n")
+
+        result = scanner.scan([tmp_path])
+
+        sid = [f for f in result.findings if f.rule_id == "twilio-account-sid"]
+        assert len(sid) >= 1
+
+    def test_bare_ac_hex_without_keyword_not_flagged(self, scanner: NativeScanner, tmp_path: Path):
+        """A bare AC<32hex> CACHE_KEY with no twilio keyword is NOT flagged (FP killed)."""
+        cfg = tmp_path / "cache.env"
+        fake_sid = "AC" + "0123456789abcdef" * 2
+        cfg.write_text(f"CACHE_KEY={fake_sid}\n")
+
+        result = scanner.scan([tmp_path])
+
+        sid = [f for f in result.findings if f.rule_id == "twilio-account-sid"]
+        assert len(sid) == 0
+
+    def test_mailchimp_keyword_still_catches_true_positive(
+        self, scanner: NativeScanner, tmp_path: Path
+    ):
+        """Another keyword-gated pattern (mailchimp) still catches its true positive."""
+        cfg = tmp_path / "mailchimp.env"
+        fake_key = "0123456789abcdef" * 2 + "-us21"
+        cfg.write_text(f"# mailchimp api\nMAILCHIMP_KEY={fake_key}\n")
+
+        result = scanner.scan([tmp_path])
+
+        mc = [f for f in result.findings if f.rule_id == "mailchimp-api-key"]
+        assert len(mc) >= 1
+
+    def test_distinctive_prefix_not_suppressed_without_context(
+        self, scanner: NativeScanner, tmp_path: Path
+    ):
+        """AKIA… (require_keyword=False) is still flagged with no sibling context."""
+        cfg = tmp_path / "lone.env"
+        cfg.write_text("SOME_VALUE=AKIAIOSFODNN7EXAMPLE\n")
+
+        result = scanner.scan([tmp_path])
+
+        aws = [f for f in result.findings if "aws" in f.rule_id.lower()]
+        assert len(aws) >= 1
+
+
+class TestLowercaseEntropyAssignment:
+    """#369 — entropy assignment LHS accepts lower/mixed case var names."""
+
+    @pytest.fixture
+    def scanner(self) -> NativeScanner:
+        return NativeScanner(check_entropy=True, entropy_threshold=4.0)
+
+    def test_lowercase_api_key_flagged(self, scanner: NativeScanner, tmp_path: Path):
+        """lowercase api_key="<high entropy>" is flagged (was missed before #369)."""
+        cfg = tmp_path / "config.py"
+        cfg.write_text('api_key = "aB3xK9mN2pQ5vR8tY1wZ4cF7hJ0kL6"\n')
+
+        result = scanner.scan([tmp_path])
+
+        ent = [f for f in result.findings if f.rule_id == "high-entropy-string"]
+        assert len(ent) >= 1
+
+    def test_uppercase_still_flagged(self, scanner: NativeScanner, tmp_path: Path):
+        """UPPERCASE var name still flagged (no regression)."""
+        cfg = tmp_path / "config.py"
+        cfg.write_text('API_KEY = "aB3xK9mN2pQ5vR8tY1wZ4cF7hJ0kL6"\n')
+
+        result = scanner.scan([tmp_path])
+
+        ent = [f for f in result.findings if f.rule_id == "high-entropy-string"]
+        assert len(ent) >= 1
+
+    def test_ordinary_lowercase_config_not_flooded(self, scanner: NativeScanner, tmp_path: Path):
+        """Ordinary low-entropy lowercase config is not flagged (no egregious FPs)."""
+        cfg = tmp_path / "settings.py"
+        cfg.write_text(
+            "host = localhost\n"
+            "port = 5432\n"
+            "database_name = my_application_database\n"
+            "log_level = information\n"
+        )
+
+        result = scanner.scan([tmp_path])
+
+        ent = [f for f in result.findings if f.rule_id == "high-entropy-string"]
+        assert len(ent) == 0
+
+
+class TestEcPublicKeyDropped:
+    """#370 — dotenvx EC compressed public keys are dropped by value shape."""
+
+    @pytest.fixture
+    def scanner(self) -> NativeScanner:
+        return NativeScanner(check_entropy=True, entropy_threshold=3.0)
+
+    def test_ec_public_key_not_flagged(self, scanner: NativeScanner, tmp_path: Path):
+        """A 02/03 + 64-hex compressed EC public key is not flagged as a secret."""
+        pub = "03" + "a1b2c3d4e5f6071829" * 3 + "a1b2c3d4e5"  # 66 hex chars
+        assert len(pub) == 66
+        cfg = tmp_path / ".env"
+        cfg.write_text(f"DOTENV_PUBLIC_KEY={pub}\n")
+
+        result = scanner.scan([tmp_path])
+
+        # The pubkey value itself must not appear as any pattern/entropy finding.
+        from envdrift.scanner.patterns import hash_secret
+
+        pub_hash = hash_secret(pub)
+        assert all(f.secret_hash != pub_hash for f in result.findings)
+
+    def test_real_secret_next_to_pubkey_still_flagged(self, scanner: NativeScanner, tmp_path: Path):
+        """A genuine AWS key sitting next to a public key is still flagged."""
+        pub = "02" + "f0e1d2c3b4a5968778" * 3 + "f0e1d2c3b4"  # 66 hex chars
+        assert len(pub) == 66
+        cfg = tmp_path / ".env"
+        cfg.write_text(f"DOTENV_PUBLIC_KEY={pub}\nAWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE\n")
+
+        result = scanner.scan([tmp_path])
+
+        aws = [f for f in result.findings if "aws" in f.rule_id.lower()]
+        assert len(aws) >= 1


### PR DESCRIPTION
## Summary

Five native-scanner correctness fixes — all verified with **real detection matrices** proving true-positives are preserved (no over-suppression).

| # | Bug | Fix |
|---|-----|-----|
| **#354** | `gcp-service-account` pattern required both tokens on one line, but real SA JSON is multi-line + scanning is per-line → CRITICAL pattern **never fired** | `multiline` flag on `SecretPattern` (`re.DOTALL`, lazy) + a separate full-content pass for multiline patterns |
| **#355** | `SecretPattern.keywords` defined on 14 patterns but **never consulted** → broad regexes (twilio `AC[0-9a-f]{32}`) false-positive on unrelated values | file-scope keyword gate (file-scope, not line-scope, so distinctive-prefix keys aren't wrongly dropped) |
| **#368** | encrypted-file filter read only the **first 2 KB** for the marker while the rest of the code reads the whole file → combined file with >2 KB cleartext judged not-encrypted, ciphertext leaked as FPs | read the full file (consistent) |
| **#369** | entropy assignment regex matched **UPPERCASE only**, missing `api_key=` / `apiKey:` | widen char class; existing url/path/all-alpha/entropy filters contain FPs |
| **#370** | `_filter_public_keys` compared the **redacted** preview against length 66 → **dead in production** | filter via one-way `secret_hash` matched to the hash of the file's own `DOTENV_PUBLIC_KEY` value (+ updated the stale synthetic-control test) |

## Verification
- Adversarial SQA detection matrix: every previously-detected secret class still fires (keyword-gated patterns with context, AKIA/distinctive prefixes without context, upper+lower+camel entropy, multiline GCP, cleartext in combined files, real secrets next to public keys). The keyword gate and pubkey filter drop **only** the intended noise.
- `611 passed, 2 skipped` (trufflehog skip-gated); full-project pyrefly (incl. `tests/`) 0 errors; ruff/format/bandit green. Changed-line coverage 95% (patterns 100%, engine 97%, native 90%).
- Test fixtures for twilio/mailchimp/stripe are built via concatenation so no complete secret literal is committed (GitHub push-protection).

## Deferred
**#352** (`partial_encryption.is_file_encrypted` substring) was dropped from this PR — the adversarial SQA proved the naive fix **regressed secret protection** (a bare `DOTENV_PUBLIC_KEY` header on a post-decrypt file was treated as "encrypted," so `encrypt_secret_file` would skip it and leave the secret in cleartext). It needs a ciphertext-anchored fix + a lock→pull→lock e2e regression test, and will ship in a dedicated `partial_encryption.py` PR.

Closes #354
Closes #355
Closes #368
Closes #369
Closes #370

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes five correctness bugs in the native scanner: a GCP service-account pattern that never fired (per-line loop can't see multi-line JSON), a keyword gate that was defined on 14 patterns but never enforced, an encrypted-file filter that only read the first 2 KB (missing `encrypted:` markers in combined files), an entropy-assignment regex that skipped lowercase/camelCase variable names, and a public-key filter that was dead in production because it compared a redacted preview to a fixed length.

- **Pattern engine** (`patterns.py`, `native.py`): Adds `multiline` and `require_keyword` flags to `SecretPattern`; a new full-content pass handles multiline patterns, a file-scope gate precomputed once per file enforces `require_keyword`, and an `_EC_PUBKEY_RE` value-shape check suppresses EC public keys that escape the variable-name skip.
- **Engine filter** (`engine.py`): `_filter_encrypted_files` now reads the full file for marker detection; `_filter_public_keys` replaces the dead preview-length check with a one-way hash comparison against `DOTENV_PUBLIC_KEY*` lines declared in the finding's own file (per-file scoping to prevent cross-file false negatives).
- **Tests** (`test_native.py`, `test_engine.py`, `test_scanner_external_binaries.py`): New test classes cover each bug scenario with adversarial and regression cases; old tests that exercised the broken behaviour are replaced with production-realistic inputs (redacted preview + `secret_hash`).

<h3>Confidence Score: 5/5</h3>

All five correctness fixes are well-scoped and well-tested; no regression paths identified.

Each fix is narrowly targeted, thoroughly tested with both true-positive preservation and false-positive regression guards, and the previously flagged issues from earlier review threads (multiline finditer, per-file public-key hash scoping, fail-safe keyword gate) are confirmed resolved. No cross-cutting logic changes introduce new suppression or detection gaps.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/envdrift/scanner/patterns.py | Adds `require_keyword` and `multiline` fields to `SecretPattern`; applies `require_keyword=True` to four broad-prefix patterns (twilio x2, mailchimp, telegram) and `multiline=True` + `re.DOTALL` to the GCP service-account pattern. Clean, additive change. |
| src/envdrift/scanner/native.py | Four interacting changes: file-scope keyword gate (precomputed set of gated-out pattern IDs), separate multiline full-content pass using finditer, _EC_PUBKEY_RE value-shape drop for EC public keys under unexpected variable names, and widened entropy assignment regex to lowercase/camelCase LHS. Logic is sound; previous review issues confirmed fixed. |
| src/envdrift/scanner/engine.py | Two targeted fixes: full-file read for encryption-marker detection in _filter_encrypted_files, and a new hash-based _filter_public_keys backed by _collect_public_key_hashes that scopes public-key suppression strictly per file. |
| tests/scanner/test_native.py | 263 new lines of tests across TestMultilineGcpServiceAccount, TestKeywordGate, TestLowercaseEntropyAssignment, and TestEcPublicKeyDropped. Each class includes true-positive, false-positive, and regression guards. |
| tests/scanner/test_engine.py | TestFilterEncryptedFiles gains two new tests for the >2 KB marker scenario. TestFilterPublicKeys is fully replaced with production-realistic tests that use redacted previews and secret_hash matching. |
| tests/integration/test_scanner_external_binaries.py | EC-12 integration test updated to exercise the new hash-based contract; synthetic control confirms the finding is dropped while a non-key finding in the same file survives. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[File Content] --> B[_scan_patterns]
    A --> C[_scan_entropy]
    B --> B1{Pattern multiline?}
    B1 -- Yes --> B2[Skip in per-line loop]
    B1 -- No --> B3{pattern.id in gated_out_patterns?}
    B3 -- Yes --> B4[Skip - keyword gate]
    B3 -- No --> B5[Regex search on line]
    B5 --> B6{_EC_PUBKEY_RE matches secret?}
    B6 -- Yes --> B7[Drop EC public key]
    B6 -- No --> B8[Append finding]
    B --> B9[Multiline full-content pass]
    B9 --> B10[finditer on full content]
    B10 --> B11[Append finding with correct line/col]
    C --> C1[Widened LHS regex A-Za-z_]
    C1 --> C2[Entropy filter >= threshold]
    C2 --> C3[Append high-entropy finding]
    B8 & B11 & C3 --> D[Raw findings list]
    D --> E[ScanEngine filters]
    E --> E1[_filter_encrypted_files: read full file]
    E1 --> E2{File has encrypted marker?}
    E2 -- No --> E3[Keep finding]
    E2 -- Yes --> E4{Finding line is ciphertext?}
    E4 -- Yes --> E5[Drop finding]
    E4 -- No --> E3
    E3 --> F[_filter_public_keys]
    F --> F1[_collect_public_key_hashes per-file]
    F1 --> F2{secret_hash matches file DOTENV_PUBLIC_KEY hash?}
    F2 -- Yes --> F3[Drop public key finding]
    F2 -- No --> F4[Keep finding]
    F4 --> G[Final findings]
```

<sub>Reviews (5): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/scanner-cor..."](https://github.com/jainal09/envdrift/commit/7b8ef81061c4e039d240833237cdf165c6cf3bce) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35969122)</sub>

<!-- /greptile_comment -->