### PR TITLE
fix(partial-encryption): ciphertext-anchored is_file_encrypted + companion/utf-8 (#352,#358,#371)

### DIFF
--- a/src/envdrift/core/partial_encryption.py
+++ b/src/envdrift/core/partial_encryption.py
@@ -111,12 +111,23 @@ def is_file_encrypted(file_path: Path) -> bool:
 
     True requires at least one assigned VALUE to be genuinely encrypted
     (dotenvx ``encrypted:`` or SOPS ``ENC[AES256_GCM,``), or a real SOPS
-    metadata block. A dotenvx file that has been DECRYPTED keeps its
-    ``DOTENV_PUBLIC_KEY_*`` line and header comment but holds plaintext values,
-    so those markers (and the bare substring ``encrypted:`` appearing inside a
-    plaintext value) must NOT count as encrypted — otherwise
-    ``encrypt_secret_file`` early-returns and leaves a real secret in cleartext
-    (#352).
+    metadata block.
+
+    The #352 bug this fixes: the old check was
+    ``"encrypted:" in content or "DOTENV_VAULT" in content``, so a PLAINTEXT
+    value that merely *contained* the substring ``encrypted:`` (e.g.
+    ``NOTE=... the secret is stored encrypted: see docs``) false-positived as
+    "already encrypted". ``encrypt_secret_file`` then early-returned and the
+    real secrets in that file were committed in cleartext. Anchoring detection
+    to a VALUE that *starts with* a ciphertext prefix removes that false
+    positive.
+
+    Related safety property (a forward-guard, not the #352 bug itself): a
+    dotenvx file that has been DECRYPTED keeps its ``DOTENV_PUBLIC_KEY_*`` line
+    and header comment while its values revert to plaintext. Those markers must
+    not count as encrypted either, so re-encryption (lock -> pull -> lock) still
+    fires. The old substring check already returned False for such files (they
+    hold neither substring); the value-scan preserves that.
 
     Args:
         file_path: Path to check

--- a/src/envdrift/core/partial_encryption.py
+++ b/src/envdrift/core/partial_encryption.py
@@ -13,13 +13,10 @@ from pathlib import Path
 from typing import NamedTuple
 
 from envdrift.config import PartialEncryptionEnvironmentConfig
+from envdrift.env_files import _is_excluded_env_file
 from envdrift.integrations.dotenvx import DotenvxError, DotenvxWrapper
 
 logger = logging.getLogger(__name__)
-
-# dotenvx stores private keys in this file. It must never be encrypted/decrypted
-# as a secret — doing so would lock away the keys needed to decrypt everything else.
-_KEYS_FILENAME = ".env.keys"
 
 # Minimum inner width of the warning box. Long file paths expand the box beyond
 # this so the right-hand border always stays aligned (see _build_warning_header).
@@ -28,6 +25,13 @@ _WARNING_BOX_MIN_WIDTH = 50
 # dotenvx writes a public-key assignment into encrypted files. It is not a
 # secret (public keys are public) so it must not be counted as a secret var.
 _DOTENVX_PUBLIC_KEY_PREFIX = "DOTENV_PUBLIC_KEY"
+
+# A dotenvx-encrypted value starts with this prefix; a SOPS-encrypted dotenv
+# value starts with the AES-GCM marker. Detection keys off an actual assigned
+# VALUE being ciphertext — never a header comment or a public-key line, both of
+# which survive ``dotenvx decrypt`` while the values revert to plaintext (#352).
+_DOTENVX_CIPHERTEXT_PREFIX = "encrypted:"
+_SOPS_CIPHERTEXT_PREFIX = "ENC[AES256_GCM,"
 
 
 def _build_warning_header(clear_file: str, secret_file: str) -> str:
@@ -89,21 +93,54 @@ class PartialEncryptionError(Exception):
         return cls(f"Secret file not found: {path}")
 
 
-def is_file_encrypted(file_path: Path) -> bool:
+def _value_is_ciphertext(value: str) -> bool:
+    """Return True if an assigned dotenv VALUE is genuine ciphertext.
+
+    Strips a single layer of surrounding quotes first because SOPS emits
+    ``KEY="ENC[AES256_GCM,...]"`` (quoted), while dotenvx emits an unquoted
+    ``KEY=encrypted:...``.
     """
-    Check if a file contains dotenvx encrypted content.
+    v = value.strip()
+    if len(v) >= 2 and ((v[0] == '"' and v[-1] == '"') or (v[0] == "'" and v[-1] == "'")):
+        v = v[1:-1]
+    return v.startswith(_DOTENVX_CIPHERTEXT_PREFIX) or v.startswith(_SOPS_CIPHERTEXT_PREFIX)
+
+
+def is_file_encrypted(file_path: Path) -> bool:
+    """Return True only when the file actually contains CIPHERTEXT.
+
+    True requires at least one assigned VALUE to be genuinely encrypted
+    (dotenvx ``encrypted:`` or SOPS ``ENC[AES256_GCM,``), or a real SOPS
+    metadata block. A dotenvx file that has been DECRYPTED keeps its
+    ``DOTENV_PUBLIC_KEY_*`` line and header comment but holds plaintext values,
+    so those markers (and the bare substring ``encrypted:`` appearing inside a
+    plaintext value) must NOT count as encrypted — otherwise
+    ``encrypt_secret_file`` early-returns and leaves a real secret in cleartext
+    (#352).
 
     Args:
         file_path: Path to check
 
     Returns:
-        True if file contains encrypted: prefix or DOTENV_VAULT markers
+        True if the file holds at least one encrypted value or a SOPS metadata block.
     """
     if not file_path.exists():
         return False
 
-    content = file_path.read_text()
-    return "encrypted:" in content or "DOTENV_VAULT" in content
+    content = file_path.read_text(encoding="utf-8")
+
+    for raw_line in content.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        _, _, value = line.partition("=")
+        if _value_is_ciphertext(value):
+            return True
+
+    # Real SOPS metadata block: the trailer carries sops_version alongside an
+    # encrypted MAC value. Both present means it is a genuine SOPS file even if
+    # the assignment scan above did not trip (defensive belt-and-suspenders).
+    return "sops_version" in content and _SOPS_CIPHERTEXT_PREFIX in content
 
 
 def combine_files(
@@ -139,11 +176,11 @@ def combine_files(
     # Read files
     clear_lines = []
     if clear_file.exists():
-        clear_lines = clear_file.read_text().splitlines()
+        clear_lines = clear_file.read_text(encoding="utf-8").splitlines()
 
     secret_lines = []
     if secret_file.exists():
-        secret_lines = secret_file.read_text().splitlines()
+        secret_lines = secret_file.read_text(encoding="utf-8").splitlines()
 
     # Build combined content with warning header
     warning = _build_warning_header(env_config.clear_file, env_config.secret_file)
@@ -169,11 +206,11 @@ def combine_files(
 
     new_content = "\n".join(combined_lines) + "\n"
 
-    existing = combined_file.read_text() if combined_file.exists() else None
+    existing = combined_file.read_text(encoding="utf-8") if combined_file.exists() else None
     in_sync = existing == new_content
 
     if write:
-        combined_file.write_text(new_content)
+        combined_file.write_text(new_content, encoding="utf-8")
         in_sync = True
 
     # Count real secret variables (excludes comments and dotenvx public-key line)
@@ -396,8 +433,9 @@ def push_secrets_only(
     for file in files:
         if not file.is_file():
             continue
-        if file.name == _KEYS_FILENAME:
-            # Never encrypt the dotenvx key file, even if it matches the pattern.
+        if _is_excluded_env_file(file.name):
+            # Never encrypt companion files (.example/.sample/.template) or the
+            # dotenvx key file (.keys), even if they match the glob pattern (#358).
             continue
         if is_file_encrypted(file):
             if not check:
@@ -456,8 +494,9 @@ def pull_secrets_only(env_config: PartialEncryptionEnvironmentConfig) -> dict[st
     for file in files:
         if not file.is_file():
             continue
-        if file.name == _KEYS_FILENAME:
-            # Never decrypt the dotenvx key file, even if it matches the pattern.
+        if _is_excluded_env_file(file.name):
+            # Never decrypt companion files (.example/.sample/.template) or the
+            # dotenvx key file (.keys), even if they match the glob pattern (#358).
             continue
         if not is_file_encrypted(file):
             # Already plaintext on disk — still protect it from accidental commit.

--- a/src/envdrift/core/partial_encryption.py
+++ b/src/envdrift/core/partial_encryption.py
@@ -127,7 +127,12 @@ def is_file_encrypted(file_path: Path) -> bool:
     if not file_path.exists():
         return False
 
-    content = file_path.read_text(encoding="utf-8")
+    # errors="replace": a non-UTF-8 file (e.g. a Latin-1 byte in a value) must not
+    # raise UnicodeDecodeError here — is_file_encrypted is called from the push/
+    # pull/encrypt paths with no surrounding handler, so an exception would abort
+    # the whole operation. A real dotenvx/SOPS ciphertext marker is ASCII, so
+    # replacement characters cannot turn a plaintext file into a false positive.
+    content = file_path.read_text(encoding="utf-8", errors="replace")
 
     for raw_line in content.splitlines():
         line = raw_line.strip()

--- a/tests/integration/test_partial_encryption_e2e.py
+++ b/tests/integration/test_partial_encryption_e2e.py
@@ -545,3 +545,161 @@ class TestCombineModeStructure:
         assert "hunter2" not in combined, "plaintext secret leaked into combined file"
         # The .secret source is now encrypted in place.
         assert "encrypted:" in secret.read_text(), secret.read_text()
+
+
+# ---------------------------------------------------------------------------
+# #352: is_file_encrypted / encrypt_secret_file must key off real ciphertext,
+# not the literal substring "encrypted:". Lock -> pull -> lock must re-encrypt.
+# ---------------------------------------------------------------------------
+
+
+class TestIsFileEncryptedRealBinary:
+    """is_file_encrypted against real dotenvx output and tricky plaintext (#352)."""
+
+    def _dotenvx(self, args: list[str], *, cwd: Path) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["dotenvx", *args], cwd=cwd, capture_output=True, text=True, timeout=60
+        )
+
+    def test_genuinely_encrypted_file_is_detected(self, tmp_path: Path):
+        """A real dotenvx-encrypted file => is_file_encrypted True."""
+        from envdrift.core.partial_encryption import is_file_encrypted
+
+        secret = tmp_path / ".env.secret"
+        # Build the fake secret by concatenation so push-protection never sees it.
+        secret.write_text("API_KEY=" + "sk_live_" + "0123456789abcdef" * 2 + "\n")
+        enc = self._dotenvx(["encrypt", "-f", str(secret)], cwd=tmp_path)
+        assert enc.returncode == 0, enc.stdout + enc.stderr
+        assert "encrypted:" in secret.read_text()
+
+        assert is_file_encrypted(secret) is True
+
+    def test_decrypted_file_with_residual_public_key_is_not_encrypted(self, tmp_path: Path):
+        """Lock then pull: values are plaintext but DOTENV_PUBLIC_KEY remains => False.
+
+        Regression for #352: the leftover public-key header must NOT make the file
+        look encrypted; otherwise a real push would skip re-encryption and the
+        plaintext secret would be committed.
+        """
+        from envdrift.core.partial_encryption import is_file_encrypted
+
+        secret = tmp_path / ".env.secret"
+        plaintext = "sk_live_" + "0123456789abcdef" * 2
+        secret.write_text(f"API_KEY={plaintext}\n")
+
+        assert self._dotenvx(["encrypt", "-f", str(secret)], cwd=tmp_path).returncode == 0
+        assert is_file_encrypted(secret) is True
+        assert self._dotenvx(["decrypt", "-f", str(secret)], cwd=tmp_path).returncode == 0
+
+        decrypted = secret.read_text()
+        # dotenvx leaves the public-key header in place but restores plaintext values.
+        assert "DOTENV_PUBLIC_KEY" in decrypted
+        assert plaintext in decrypted
+        assert "encrypted:" not in decrypted
+        # The key assertion of #352:
+        assert is_file_encrypted(secret) is False
+
+    def test_plaintext_value_literally_containing_encrypted_prefix_is_not_encrypted(
+        self, tmp_path: Path
+    ):
+        """A plaintext value that contains the literal text 'encrypted:' => False (#352)."""
+        from envdrift.core.partial_encryption import is_file_encrypted
+
+        secret = tmp_path / ".env.secret"
+        secret.write_text(
+            "NOTE=the password is stored encrypted: see the vault docs\n"
+            "API_KEY=" + "sk_live_" + "0123456789abcdef" * 2 + "\n"
+        )
+        assert is_file_encrypted(secret) is False
+
+
+class TestLockPullLockReEncrypts:
+    """encrypt_secret_file re-encrypts a decrypted-with-residual-header file (#352)."""
+
+    def test_encrypt_secret_file_reencrypts_after_pull(self, git_repo: Path):
+        """lock -> pull -> lock: re-encryption produces ciphertext, no plaintext left."""
+        from envdrift.config import PartialEncryptionEnvironmentConfig
+        from envdrift.core.partial_encryption import (
+            decrypt_secret_file,
+            encrypt_secret_file,
+            is_file_encrypted,
+        )
+
+        work = git_repo
+        secret = work / ".env.production.secret"
+        plaintext = "sk_live_" + "0123456789abcdef" * 2
+        secret.write_text(f"API_KEY={plaintext}\n")
+        cfg = PartialEncryptionEnvironmentConfig(
+            name="production",
+            clear_file=str(work / ".env.production.clear"),
+            secret_file=str(secret),
+            combined_file=str(work / ".env.production"),
+        )
+
+        # lock
+        encrypt_secret_file(cfg)
+        assert is_file_encrypted(secret) is True
+        assert plaintext not in secret.read_text()
+
+        # pull (decrypt in place) -> residual public-key header, plaintext value
+        decrypt_secret_file(cfg)
+        assert is_file_encrypted(secret) is False
+        assert plaintext in secret.read_text()
+
+        # lock again -> MUST re-encrypt despite the residual DOTENV_PUBLIC_KEY header
+        encrypt_secret_file(cfg)
+        assert is_file_encrypted(secret) is True, secret.read_text()
+        assert "encrypted:" in secret.read_text()
+        assert plaintext not in secret.read_text(), "plaintext secret survived re-encryption"
+
+
+# ---------------------------------------------------------------------------
+# #358: secrets-only push must encrypt ONLY the real secret file, never the
+# .env.example / .env.sample / .env.template companions or .env.keys.
+# ---------------------------------------------------------------------------
+
+
+class TestSecretsOnlyCompanionsUntouched:
+    def test_push_secrets_only_encrypts_only_dot_env_not_companions(self, git_repo: Path):
+        """push_secrets_only encrypts .env only; companions + .env.keys stay plaintext (#358)."""
+        from envdrift.config import PartialEncryptionEnvironmentConfig
+        from envdrift.core.partial_encryption import is_file_encrypted, push_secrets_only
+
+        secrets = git_repo / "secrets"
+        secrets.mkdir()
+        real = secrets / ".env"
+        real.write_text("API_KEY=" + "sk_live_" + "0123456789abcdef" * 2 + "\n")
+        companions = {
+            ".env.example": "API_KEY=changeme\n",
+            ".env.sample": "API_KEY=sample\n",
+            ".env.template": "API_KEY=tmpl\n",
+        }
+        for name, body in companions.items():
+            (secrets / name).write_text(body)
+        # No pre-planted .env.keys: dotenvx GENERATES a real one during encrypt,
+        # and our glob loop must skip it (.keys suffix) so the private key is
+        # never itself encrypted. (A hand-written placeholder key would break
+        # dotenvx's keystore and make the encrypt a silent no-op.)
+
+        cfg = PartialEncryptionEnvironmentConfig(
+            name="prod", secrets_only=True, secrets_dir=str(secrets), pattern=".env*"
+        )
+
+        result = push_secrets_only(cfg)
+
+        # Only the real secret file was encrypted.
+        assert result["encrypted"] == 1, result
+        assert is_file_encrypted(real) is True
+        assert "encrypted:" in real.read_text()
+
+        # Companions untouched: byte-for-byte the original plaintext.
+        for name, body in companions.items():
+            assert (secrets / name).read_text() == body, f"{name} was modified"
+            assert is_file_encrypted(secrets / name) is False
+
+        # dotenvx wrote a real private-key file; the loop skipped it (.keys
+        # suffix) so it was never encrypted and still holds the cleartext key.
+        keys_file = secrets / ".env.keys"
+        assert keys_file.exists(), "dotenvx should have generated .env.keys"
+        assert "DOTENV_PRIVATE_KEY" in keys_file.read_text()
+        assert "encrypted:" not in keys_file.read_text()

--- a/tests/integration/test_partial_encryption_e2e.py
+++ b/tests/integration/test_partial_encryption_e2e.py
@@ -703,3 +703,38 @@ class TestSecretsOnlyCompanionsUntouched:
         assert keys_file.exists(), "dotenvx should have generated .env.keys"
         assert "DOTENV_PRIVATE_KEY" in keys_file.read_text()
         assert "encrypted:" not in keys_file.read_text()
+
+    def test_pull_secrets_only_decrypts_only_dot_env_not_companions(self, git_repo: Path):
+        """pull_secrets_only skips companion files too (#358 pull branch)."""
+        from envdrift.config import PartialEncryptionEnvironmentConfig
+        from envdrift.core.partial_encryption import (
+            is_file_encrypted,
+            pull_secrets_only,
+            push_secrets_only,
+        )
+
+        secrets = git_repo / "secrets"
+        secrets.mkdir()
+        real = secrets / ".env"
+        real.write_text("API_KEY=" + "sk_live_" + "0123456789abcdef" * 2 + "\n")
+        companions = {
+            ".env.example": "API_KEY=changeme\n",
+            ".env.sample": "API_KEY=sample\n",
+            ".env.template": "API_KEY=tmpl\n",
+        }
+        for name, body in companions.items():
+            (secrets / name).write_text(body)
+
+        cfg = PartialEncryptionEnvironmentConfig(
+            name="prod", secrets_only=True, secrets_dir=str(secrets), pattern=".env*"
+        )
+        # Encrypt first so there is ciphertext to pull (decrypt).
+        push_secrets_only(cfg)
+        assert is_file_encrypted(real) is True
+
+        pull_secrets_only(cfg)
+
+        # The real secret file was decrypted; companions were never processed.
+        assert is_file_encrypted(real) is False
+        for name, body in companions.items():
+            assert (secrets / name).read_text() == body, f"{name} was modified by pull"

--- a/tests/integration/test_partial_encryption_e2e.py
+++ b/tests/integration/test_partial_encryption_e2e.py
@@ -548,8 +548,19 @@ class TestCombineModeStructure:
 
 
 # ---------------------------------------------------------------------------
-# #352: is_file_encrypted / encrypt_secret_file must key off real ciphertext,
-# not the literal substring "encrypted:". Lock -> pull -> lock must re-encrypt.
+# #352: is_file_encrypted must key off a real ciphertext VALUE, not the bare
+# substring "encrypted:" anywhere in the file. The actual bug: a PLAINTEXT
+# value literally containing "encrypted:" (e.g. NOTE=... stored encrypted: see
+# docs) false-positived under the old check
+# (`"encrypted:" in content or "DOTENV_VAULT" in content`), so
+# encrypt_secret_file early-returned and the real secret was committed in
+# cleartext. The load-bearing #352 regression is
+# `test_plaintext_value_literally_containing_encrypted_prefix_is_not_encrypted`
+# (it fails on the old substring code and passes on the value-scan). The
+# residual-public-key and lock->pull->lock cases below are FORWARD-GUARDS: the
+# old code already returned False for a decrypted file (it holds neither
+# "encrypted:" nor "DOTENV_VAULT"), so they passed pre-fix too — they lock in
+# the value-scan behaviour against future regressions.
 # ---------------------------------------------------------------------------
 
 
@@ -577,9 +588,13 @@ class TestIsFileEncryptedRealBinary:
     def test_decrypted_file_with_residual_public_key_is_not_encrypted(self, tmp_path: Path):
         """Lock then pull: values are plaintext but DOTENV_PUBLIC_KEY remains => False.
 
-        Regression for #352: the leftover public-key header must NOT make the file
-        look encrypted; otherwise a real push would skip re-encryption and the
-        plaintext secret would be committed.
+        FORWARD-GUARD, not a #352 repro. A dotenvx-decrypted file contains
+        neither "encrypted:" nor "DOTENV_VAULT", so the OLD substring check
+        already returned False here — this case passed before the fix. It is
+        kept to lock in that the new value-scan still reads a leftover
+        public-key header (and plaintext values) as NOT encrypted, so a future
+        regression that mistook the header for ciphertext — which would make
+        encrypt_secret_file skip re-encryption — is caught.
         """
         from envdrift.core.partial_encryption import is_file_encrypted
 
@@ -596,13 +611,20 @@ class TestIsFileEncryptedRealBinary:
         assert "DOTENV_PUBLIC_KEY" in decrypted
         assert plaintext in decrypted
         assert "encrypted:" not in decrypted
-        # The key assertion of #352:
+        # Forward-guard: header alone must not read as encrypted.
         assert is_file_encrypted(secret) is False
 
     def test_plaintext_value_literally_containing_encrypted_prefix_is_not_encrypted(
         self, tmp_path: Path
     ):
-        """A plaintext value that contains the literal text 'encrypted:' => False (#352)."""
+        """Plaintext value literally containing 'encrypted:' => False (the real #352 bug).
+
+        This is the load-bearing #352 regression test (real-binary twin). The
+        OLD check (``"encrypted:" in content``) false-positived on the NOTE
+        value below and returned True, so encrypt_secret_file early-returned and
+        the genuinely-secret API_KEY was committed in cleartext. Fails on the
+        old substring code; passes on the value-scan.
+        """
         from envdrift.core.partial_encryption import is_file_encrypted
 
         secret = tmp_path / ".env.secret"
@@ -614,7 +636,14 @@ class TestIsFileEncryptedRealBinary:
 
 
 class TestLockPullLockReEncrypts:
-    """encrypt_secret_file re-encrypts a decrypted-with-residual-header file (#352)."""
+    """encrypt_secret_file re-encrypts a decrypted-with-residual-header file.
+
+    FORWARD-GUARD for the value-scan, not a #352 repro: the decrypted file in
+    the middle of this flow holds neither "encrypted:" nor "DOTENV_VAULT", so
+    the OLD substring check already returned False for it and this flow
+    re-encrypted correctly before the fix too. Kept to ensure lock->pull->lock
+    keeps re-encrypting once the value-scan is in place.
+    """
 
     def test_encrypt_secret_file_reencrypts_after_pull(self, git_repo: Path):
         """lock -> pull -> lock: re-encryption produces ciphertext, no plaintext left."""

--- a/tests/unit/test_partial_cli.py
+++ b/tests/unit/test_partial_cli.py
@@ -425,8 +425,9 @@ def test_push_check_passes_when_combined_in_sync(monkeypatch, tmp_path: Path):
     received_check = []
     monkeypatch.setattr(
         "envdrift.cli_commands.partial.push_partial_encryption",
-        lambda _env, check=False: received_check.append(check)
-        or {"clear_lines": 1, "secret_vars": 1, "in_sync": True},
+        lambda _env, check=False: (
+            received_check.append(check) or {"clear_lines": 1, "secret_vars": 1, "in_sync": True}
+        ),
     )
 
     gitignore_called = []

--- a/tests/unit/test_partial_encryption.py
+++ b/tests/unit/test_partial_encryption.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import os
+import subprocess
+import sys
 from pathlib import Path
 from unittest.mock import patch
 
@@ -83,10 +86,15 @@ def test_is_file_encrypted_with_sops_value(tmp_path: Path):
 
 
 def test_is_file_encrypted_decrypted_file_with_residual_public_key(tmp_path: Path):
-    """A decrypted dotenvx file keeps DOTENV_PUBLIC_KEY but has plaintext values => False (#352).
+    """Decrypted dotenvx file (residual DOTENV_PUBLIC_KEY, plaintext values) => False.
 
-    The leftover public-key header line must NOT make the file look encrypted,
-    otherwise encrypt_secret_file would skip re-encryption and leak cleartext.
+    Forward-guard, NOT a #352 regression. The old substring check
+    (``"encrypted:" in content or "DOTENV_VAULT" in content``) already returned
+    False here — a decrypted dotenvx file contains neither substring — so this
+    case passed before the fix too. It is kept to lock in that the new
+    value-scan still treats a leftover public-key header as plaintext, guarding
+    against a future regression where the header alone is mistaken for
+    ciphertext (which would make encrypt_secret_file skip re-encryption).
     """
     decrypted = tmp_path / ".env.secret"
     decrypted.write_text(
@@ -101,7 +109,16 @@ def test_is_file_encrypted_decrypted_file_with_residual_public_key(tmp_path: Pat
 
 
 def test_is_file_encrypted_plaintext_value_contains_encrypted_word(tmp_path: Path):
-    """A plaintext value literally containing 'encrypted:' must read as NOT encrypted (#352)."""
+    """Plaintext value literally containing 'encrypted:' => NOT encrypted (the real #352 bug).
+
+    This is the load-bearing #352 regression test. The OLD substring check
+    (``"encrypted:" in content``) false-positived on a plaintext value like
+    ``NOTE=... stored encrypted: see docs`` and returned True, so
+    encrypt_secret_file early-returned and the genuinely-secret API_KEY below it
+    was committed in cleartext. The value-scan keys off a VALUE starting with
+    the ciphertext prefix, so the substring buried inside a note no longer
+    counts. Fails on pre-fix code; passes on the fix.
+    """
     note_file = tmp_path / ".env.secret"
     note_file.write_text(
         "NOTE=the password is stored encrypted: see the vault docs\n"
@@ -1029,54 +1046,109 @@ def test_git_unskip_worktree_returns_false_on_git_missing(tmp_path: Path):
 # ---------------------------------------------------------------------------
 # #371: non-ASCII values must round-trip regardless of the platform default
 # encoding. read_text/write_text must pass encoding="utf-8".
+#
+# These run the functions in a CHILD interpreter under a hostile C locale
+# (LC_ALL=C / LANG=C / PYTHONUTF8=0 / PYTHONIOENCODING=ascii). That is the only
+# faithful way to exercise the bug: ``Path.read_text()`` with no ``encoding=``
+# resolves its text-mode codec from the interpreter's startup/UTF-8 state, NOT
+# from a runtime ``monkeypatch`` of ``locale.getpreferredencoding`` — so an
+# in-process monkeypatch leaves ``read_text()`` decoding as UTF-8 and the bug
+# stays hidden. In the child, the PRE-FIX code (no ``encoding=``) raises
+# ``UnicodeDecodeError`` on the 0xC3 byte and exits non-zero; the fixed code
+# (``encoding="utf-8"``) exits 0. We assert on the child exit status.
 # ---------------------------------------------------------------------------
 
+# Hostile, non-UTF-8 child environment. ``LC_ALL``/``LANG`` set the locale to
+# the C codec; ``PYTHONUTF8=0`` disables UTF-8 mode (otherwise CPython would
+# force UTF-8 regardless); ``PYTHONIOENCODING`` keeps stdio ascii too.
+_ASCII_LOCALE_ENV = {
+    "LC_ALL": "C",
+    "LANG": "C",
+    "LC_CTYPE": "C",
+    "PYTHONUTF8": "0",
+    "PYTHONIOENCODING": "ascii",
+}
 
-def _force_ascii_default(monkeypatch):
-    """Make Path.read_text/write_text default to ascii, as a non-utf8 locale would.
 
-    On a UTF-8 box the #371 bug is latent; forcing the default codec to ascii
-    reproduces the UnicodeDecodeError a cp1252 / C-locale CI box would hit.
+def _run_under_ascii_locale(body: str, *, cwd: Path) -> subprocess.CompletedProcess[str]:
+    """Run ``body`` in a child interpreter under a hostile C locale.
+
+    The child imports the REAL functions under test; ``cwd`` is the repo so the
+    package is importable. Returns the completed process so the caller can
+    assert on ``returncode`` (0 == the utf-8 read succeeded under C locale).
     """
-    import locale
+    env = {**os.environ, **_ASCII_LOCALE_ENV}
+    return subprocess.run(  # nosec B603
+        [sys.executable, "-c", body],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        timeout=60,
+        env=env,
+    )
 
-    monkeypatch.setattr(locale, "getpreferredencoding", lambda do_setlocale=True: "ascii")
-    # Python caches the text-IO default via locale; also force the IO encoding.
-    monkeypatch.setenv("PYTHONIOENCODING", "ascii")
-    monkeypatch.setenv("PYTHONUTF8", "0")
+
+# The repo root holds the importable ``src`` layout via the installed package;
+# the child runs from there so ``import envdrift`` resolves.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
-def test_is_file_encrypted_handles_non_ascii_under_ascii_locale(tmp_path, monkeypatch):
-    """is_file_encrypted reads non-ASCII secrets without UnicodeError (#371)."""
-    _force_ascii_default(monkeypatch)
+def test_is_file_encrypted_handles_non_ascii_under_ascii_locale(tmp_path):
+    """is_file_encrypted reads non-ASCII secrets without UnicodeError (#371).
+
+    Fails on the pre-fix code (no ``encoding=``): the child raises
+    ``UnicodeDecodeError`` under LC_ALL=C and exits non-zero.
+    """
     secret = tmp_path / ".env.secret"
-    # Accented + emoji value written as utf-8 bytes.
+    # Accented + emoji value written as utf-8 bytes (0xC3 trips the ascii codec).
     secret.write_bytes("PASSWORD=héllo_café_\U0001f511\n".encode())
 
-    # Must not raise UnicodeDecodeError; plaintext utf-8 is not encrypted.
-    assert is_file_encrypted(secret) is False
+    body = (
+        "import sys\n"
+        "from envdrift.core.partial_encryption import is_file_encrypted\n"
+        "from pathlib import Path\n"
+        f"assert is_file_encrypted(Path(r{str(secret)!r})) is False\n"
+        "sys.exit(0)\n"
+    )
+    result = _run_under_ascii_locale(body, cwd=_REPO_ROOT)
+
+    assert result.returncode == 0, (
+        "is_file_encrypted raised under C locale (pre-fix bug #371):\n" + result.stderr
+    )
 
 
-def test_combine_files_handles_non_ascii_under_ascii_locale(tmp_path, monkeypatch):
-    """combine_files reads/writes non-ASCII values without UnicodeError (#371)."""
-    _force_ascii_default(monkeypatch)
+def test_combine_files_handles_non_ascii_under_ascii_locale(tmp_path):
+    """combine_files reads/writes non-ASCII values without UnicodeError (#371).
+
+    Fails on the pre-fix code (no ``encoding=``): reading the accented .clear /
+    .secret files in the child raises ``UnicodeDecodeError`` under LC_ALL=C.
+    """
     clear = tmp_path / ".env.test.clear"
     secret = tmp_path / ".env.test.secret"
     combined = tmp_path / ".env.test"
     clear.write_bytes("APP_NAME=café\n".encode())
     secret.write_bytes("PASSWORD=héllo_\U0001f511\n".encode())
 
-    config = PartialEncryptionEnvironmentConfig(
-        name="test",
-        clear_file=str(clear),
-        secret_file=str(secret),
-        combined_file=str(combined),
+    body = (
+        "import sys\n"
+        "from envdrift.config import PartialEncryptionEnvironmentConfig\n"
+        "from envdrift.core.partial_encryption import combine_files\n"
+        "cfg = PartialEncryptionEnvironmentConfig(\n"
+        "    name='test',\n"
+        f"    clear_file=r{str(clear)!r},\n"
+        f"    secret_file=r{str(secret)!r},\n"
+        f"    combined_file=r{str(combined)!r},\n"
+        ")\n"
+        "stats = combine_files(cfg)\n"
+        "assert stats['clear_lines'] == 1, stats\n"
+        "assert stats['secret_vars'] == 1, stats\n"
+        "sys.exit(0)\n"
     )
+    result = _run_under_ascii_locale(body, cwd=_REPO_ROOT)
 
-    stats = combine_files(config)  # must not raise UnicodeError
-
-    assert stats["clear_lines"] == 1
-    assert stats["secret_vars"] == 1
+    assert result.returncode == 0, (
+        "combine_files raised under C locale (pre-fix bug #371):\n" + result.stderr
+    )
     # Round-trip preserved the accented/emoji content (read back as utf-8).
     written = combined.read_bytes().decode("utf-8")
     assert "café" in written

--- a/tests/unit/test_partial_encryption.py
+++ b/tests/unit/test_partial_encryption.py
@@ -71,18 +71,45 @@ def test_is_file_encrypted_with_encrypted_prefix(tmp_path: Path):
     assert is_file_encrypted(encrypted_file)
 
 
-def test_is_file_encrypted_with_vault_marker(tmp_path: Path):
-    """Test detection of files with DOTENV_VAULT marker."""
-    vault_file = tmp_path / ".env.vault"
-    vault_file.write_text(
-        """DATABASE_URL=value
-#/---BEGIN DOTENV_VAULT---/
-DOTENV_VAULT_PRODUCTION="vlt_abc123..."
-#/---END DOTENV_VAULT---/
-"""
+def test_is_file_encrypted_with_sops_value(tmp_path: Path):
+    """A SOPS-encrypted dotenv value (quoted ENC[AES256_GCM,...]) => True (#352)."""
+    sops_file = tmp_path / ".env.sops"
+    # Build the ciphertext-shaped value by concatenation (no real secret).
+    sops_file.write_text(
+        'DATABASE_URL="ENC[AES256_GCM,data:' + "ab" * 8 + ',type:str]"\n', encoding="utf-8"
     )
 
-    assert is_file_encrypted(vault_file)
+    assert is_file_encrypted(sops_file)
+
+
+def test_is_file_encrypted_decrypted_file_with_residual_public_key(tmp_path: Path):
+    """A decrypted dotenvx file keeps DOTENV_PUBLIC_KEY but has plaintext values => False (#352).
+
+    The leftover public-key header line must NOT make the file look encrypted,
+    otherwise encrypt_secret_file would skip re-encryption and leak cleartext.
+    """
+    decrypted = tmp_path / ".env.secret"
+    decrypted.write_text(
+        "#/-------------------[DOTENV_PUBLIC_KEY]--------------------/\n"
+        "#/            public-key encryption for .env files          /\n"
+        'DOTENV_PUBLIC_KEY_TEST="024f56daf45b' + "0" * 8 + 'fe"\n'
+        "API_KEY=" + "sk_live_" + "0123456789abcdef" * 2 + "\n",
+        encoding="utf-8",
+    )
+
+    assert is_file_encrypted(decrypted) is False
+
+
+def test_is_file_encrypted_plaintext_value_contains_encrypted_word(tmp_path: Path):
+    """A plaintext value literally containing 'encrypted:' must read as NOT encrypted (#352)."""
+    note_file = tmp_path / ".env.secret"
+    note_file.write_text(
+        "NOTE=the password is stored encrypted: see the vault docs\n"
+        "API_KEY=" + "sk_live_" + "0123456789abcdef" * 2 + "\n",
+        encoding="utf-8",
+    )
+
+    assert is_file_encrypted(note_file) is False
 
 
 def test_combine_files(temp_env_files):
@@ -997,3 +1024,60 @@ def test_git_unskip_worktree_returns_false_on_git_missing(tmp_path: Path):
         side_effect=FileNotFoundError("git not found"),
     ):
         assert _git_unskip_worktree(tmp_path / ".env.secret") is False
+
+
+# ---------------------------------------------------------------------------
+# #371: non-ASCII values must round-trip regardless of the platform default
+# encoding. read_text/write_text must pass encoding="utf-8".
+# ---------------------------------------------------------------------------
+
+
+def _force_ascii_default(monkeypatch):
+    """Make Path.read_text/write_text default to ascii, as a non-utf8 locale would.
+
+    On a UTF-8 box the #371 bug is latent; forcing the default codec to ascii
+    reproduces the UnicodeDecodeError a cp1252 / C-locale CI box would hit.
+    """
+    import locale
+
+    monkeypatch.setattr(locale, "getpreferredencoding", lambda do_setlocale=True: "ascii")
+    # Python caches the text-IO default via locale; also force the IO encoding.
+    monkeypatch.setenv("PYTHONIOENCODING", "ascii")
+    monkeypatch.setenv("PYTHONUTF8", "0")
+
+
+def test_is_file_encrypted_handles_non_ascii_under_ascii_locale(tmp_path, monkeypatch):
+    """is_file_encrypted reads non-ASCII secrets without UnicodeError (#371)."""
+    _force_ascii_default(monkeypatch)
+    secret = tmp_path / ".env.secret"
+    # Accented + emoji value written as utf-8 bytes.
+    secret.write_bytes("PASSWORD=héllo_café_\U0001f511\n".encode())
+
+    # Must not raise UnicodeDecodeError; plaintext utf-8 is not encrypted.
+    assert is_file_encrypted(secret) is False
+
+
+def test_combine_files_handles_non_ascii_under_ascii_locale(tmp_path, monkeypatch):
+    """combine_files reads/writes non-ASCII values without UnicodeError (#371)."""
+    _force_ascii_default(monkeypatch)
+    clear = tmp_path / ".env.test.clear"
+    secret = tmp_path / ".env.test.secret"
+    combined = tmp_path / ".env.test"
+    clear.write_bytes("APP_NAME=café\n".encode())
+    secret.write_bytes("PASSWORD=héllo_\U0001f511\n".encode())
+
+    config = PartialEncryptionEnvironmentConfig(
+        name="test",
+        clear_file=str(clear),
+        secret_file=str(secret),
+        combined_file=str(combined),
+    )
+
+    stats = combine_files(config)  # must not raise UnicodeError
+
+    assert stats["clear_lines"] == 1
+    assert stats["secret_vars"] == 1
+    # Round-trip preserved the accented/emoji content (read back as utf-8).
+    written = combined.read_bytes().decode("utf-8")
+    assert "café" in written
+    assert "héllo_\U0001f511" in written


### PR DESCRIPTION
## Summary

All three fixes are in `core/partial_encryption.py` (one file → conflict-free with every open PR), verified against the **real dotenvx binary**.

### `#352` [SECURITY] — `is_file_encrypted` keyed off a substring, not a real ciphertext value
The old check was `"encrypted:" in content or "DOTENV_VAULT" in content`. The actual bug it caused: a **plaintext** value that merely *contained* the literal substring `encrypted:` — e.g. `NOTE=the password is stored encrypted: see the vault docs` — false-positived as "already encrypted". `encrypt_secret_file` then early-returned, so the genuinely-secret values in that file were **committed in cleartext** (encryption was skipped). That is the real #352 regression.

Note on the decrypted-file case (corrected narrative): a `dotenvx decrypt`-ed file keeps its `DOTENV_PUBLIC_KEY_*` line and header comment while its values revert to plaintext, but it contains **neither** `encrypted:` **nor** `DOTENV_VAULT`, so the **old** substring check already returned `False` for it. It was *not* mis-judged as encrypted by the old code — the earlier description claiming "a decrypted file holding a real secret was judged 'encrypted' → secret committed in cleartext" was wrong.

**Fix:** detection now requires an actual assigned **value** to *start with* a ciphertext prefix — dotenvx `encrypted:` or SOPS `ENC[AES256_GCM,` (quotes stripped first), plus a defensive real-SOPS-metadata check. Dropped the over-broad legacy `DOTENV_VAULT` substring marker.

| input | before (substring) | after (value-scan) | catches #352? |
|---|---|---|---|
| plaintext value containing `encrypted:` (e.g. a NOTE) | ✅ encrypted *(wrong → skip → leak)* | ❌ not encrypted | **yes — load-bearing** |
| decrypted file (public-key header + plaintext value) | ❌ not encrypted | ❌ not encrypted | no (forward-guard) |
| genuine dotenvx / SOPS ciphertext | ✅ | ✅ | no (forward-guard) |

### `#358` — companion files encrypted
`push_secrets_only` globbed `.env*` and skipped only `.env.keys`, so it encrypted `.env.example` / `.env.sample` / `.env.template`. Now uses the canonical `_is_excluded_env_file` / `_EXCLUDED_ENV_SUFFIXES`.

### `#371` — missing UTF-8 encoding
Five `read_text`/`write_text` calls omitted `encoding="utf-8"`, corrupting / failing on non-ASCII values on non-UTF-8 locales. Pinned utf-8 at all 5 IO sites.

## Tests (real dotenvx, no mocks)
- **#352 (load-bearing regression):** `test_plaintext_value_literally_containing_encrypted_prefix_is_not_encrypted` (unit + real-binary twin) — a plaintext value containing the literal `encrypted:` reads as **not** encrypted. **Fails on the old substring code, passes on the value-scan.**
- **#352 (forward-guards, *not* repros):** the decrypted-with-residual-public-key and **lock → pull → lock** re-encryption cases — these already passed on the old code (a decrypted file holds neither substring), so they lock in the value-scan behaviour against future regressions rather than reproducing #352.
- **#358:** dir with `.env` + all companions → only `.env` encrypted, companions byte-identical plaintext.
- **#371:** the two locale tests now run the real functions in a **child interpreter** under a hostile locale (`LC_ALL=C LANG=C PYTHONUTF8=0 PYTHONIOENCODING=ascii`) and assert exit 0. The pre-fix `read_text()` (no `encoding=`) raises `UnicodeDecodeError` in that child and exits non-zero; the fixed `encoding="utf-8"` succeeds. (The earlier in-process `locale.getpreferredencoding` monkeypatch did **not** reproduce the bug — `Path.read_text()` resolves its codec from the interpreter's startup state, not that runtime patch — so the subprocess probe replaces it.)
- Patch (changed-line) coverage **100%**; file 95%. Gates green; fixtures concatenation-built for push-protection.

> Note: a plaintext value that literally *starts with* `encrypted:` is still read as encrypted — irreducible (it's dotenvx's own ciphertext sentinel), and no worse than before; a real secret essentially never starts with that.

Closes #352
Closes #358
Closes #371

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved detection of encrypted files to eliminate false positives from headers, public key artifacts, and plaintext values containing encryption-related strings.
  * Enhanced UTF-8 encoding consistency across file read/write operations.
  * Refined companion file handling during secrets-only push and pull operations.

* **Tests**
  * Added integration tests validating encryption detection accuracy and re-encryption workflows.
  * Added unit tests for non-ASCII character handling and encryption edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR consolidates three correctness fixes into `core/partial_encryption.py`: a security-relevant false-positive in `is_file_encrypted`, companion-file leakage in the secrets-only push/pull loop, and missing `encoding="utf-8"` on five IO sites.

- **#352 — `is_file_encrypted` rewritten**: Replaces the raw `\"encrypted:\" in content` substring check with a per-line value scan that requires an assigned value to *start with* the ciphertext prefix, eliminating the false-positive that caused plaintext files with notes like `NOTE=... stored encrypted: see docs` to skip encryption entirely.
- **#358 — Companion-file exclusion**: Both `push_secrets_only` and `pull_secrets_only` now delegate to `_is_excluded_env_file` (covering `.example`, `.sample`, `.template`, `.keys`) instead of the narrower `file.name == _KEYS_FILENAME` guard.
- **#371 — UTF-8 pinned at all IO sites**: All five `read_text`/`write_text` calls in `combine_files` now carry `encoding=\"utf-8\"`, and `is_file_encrypted` uses `errors=\"replace\"` to prevent aborting on non-UTF-8 input.

<h3>Confidence Score: 5/5</h3>

All three fixes are targeted, well-tested with real dotenvx binary and hostile-locale child subprocesses, and the core encryption-detection logic is strictly tighter than before — no new code paths that could silently skip encryption or expose secrets.

The value-scan correctly closes the false-positive path that caused secrets to be committed in cleartext. The companion-file guard is now backed by the canonical exclusion list. UTF-8 is pinned at every IO site, and the errors=replace fallback in is_file_encrypted prevents aborts on non-UTF-8 input. Tests reproduce every changed behaviour, including the load-bearing #352 regression that fails on the old code.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/envdrift/core/partial_encryption.py | Core logic changes: value-anchored is_file_encrypted, _is_excluded_env_file for companion-file exclusion, and encoding=utf-8 on all IO calls — all three fixes are correct and well-guarded. |
| tests/unit/test_partial_encryption.py | Adds unit tests for the SOPS value case, the residual-public-key forward-guard, the load-bearing #352 regression, and the #371 child-subprocess locale tests — coverage is thorough. |
| tests/integration/test_partial_encryption_e2e.py | New integration test classes cover the genuine-encrypt, decrypted-residual-header, plaintext-substring, re-encrypt, companion-push, and companion-pull scenarios against the real dotenvx binary. |
| tests/unit/test_partial_cli.py | Minor formatting tweak to a lambda (parenthesised expression); no logic change. |

</details>

<sub>Reviews (4): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/partial-enc..."](https://github.com/jainal09/envdrift/commit/cc9d0e10806ac5b1281fc76109a5f0b4ae0e387a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35970454)</sub>

<!-- /greptile_comment -->