### PR TITLE
docs: fix init --watch, per-mapping providers, and secret/data prefix claims (#366,#367,#375)

### DIFF
--- a/docs/agent-spec.md
+++ b/docs/agent-spec.md
@@ -122,7 +122,7 @@ notify = true
 ```
 
 `[guardian].enabled = true` does **not** auto-register the project. Registration
-is explicit: run `envdrift agent register` (or `envdrift init --watch`) to add
+is explicit: run `envdrift agent register` to add
 the project path to `~/.envdrift/projects.json`. Only then does the daemon load
 the project and apply the `[guardian]` settings — `enabled = false` causes the
 daemon to skip an already-registered project.
@@ -177,7 +177,7 @@ Machine (your laptop)
 
 ### How It Works
 
-1. **User runs** `envdrift agent register` (or `envdrift init --watch`) explicitly — setting `[guardian].enabled = true` alone is not enough
+1. **User runs** `envdrift agent register` explicitly — setting `[guardian].enabled = true` alone is not enough
 2. **CLI adds** the project path to `~/.envdrift/projects.json`
 3. **Agent watches** `projects.json` for changes (via fsnotify)
 4. **Agent reads** each project's `envdrift.toml` for patterns/excludes

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -466,8 +466,8 @@ Per-project configuration for the background agent (envdrift-agent), which
 watches `.env` files and auto-encrypts them after a period of inactivity.
 
 > **Note:** `enabled = true` does **not** auto-register the project with the
-> agent. Registration is explicit — run `envdrift agent register` (or
-> `envdrift init --watch`) from the project root to add it to
+> agent. Registration is explicit — run `envdrift agent register` from the
+> project root to add it to
 > `~/.envdrift/projects.json`. The daemon then loads the project and honors
 > the `[guardian]` settings below. `enabled = false` (the default) tells the
 > daemon to skip an already-registered project.

--- a/docs/support/faq.md
+++ b/docs/support/faq.md
@@ -196,7 +196,12 @@ See [Vault Providers](../concepts/vault-providers.md) for details.
 
 ### Can I use multiple vault providers?
 
-You can specify different providers per mapping, but you'll need to provide credentials for each when syncing.
+The provider is **global per sync command** — it's set once in the `[vault]`
+section (`provider = "aws" | "azure" | "gcp" | "hashicorp"`) and every mapping in
+that run uses it. A `provider` key on an individual `[[vault.sync.mappings]]`
+entry is not supported and is ignored. To sync against a different provider, run
+the command again with that provider configured (e.g. a separate config or
+`--provider`).
 
 ### How do I set up vault access in CI/CD?
 

--- a/docs/support/troubleshooting.md
+++ b/docs/support/troubleshooting.md
@@ -224,7 +224,9 @@ hvac.exceptions.Forbidden: permission denied
 
 1. Check your token has the correct policies
 2. Ensure the token hasn't expired
-3. Verify the secret path is correct — it is **relative to the KV v2 mount**, with **no** `secret/data/` prefix (the client inserts the `data/` segment internally; adding it yourself produces a wrong path)
+3. Verify the secret path is correct — it is **relative to the KV v2 mount**,
+   with **no** `secret/data/` prefix. The client inserts the `data/` segment
+   internally, so adding the prefix yourself produces a wrong path.
 
 ```bash
 export VAULT_TOKEN="hvs.xxx"

--- a/docs/support/troubleshooting.md
+++ b/docs/support/troubleshooting.md
@@ -224,7 +224,7 @@ hvac.exceptions.Forbidden: permission denied
 
 1. Check your token has the correct policies
 2. Ensure the token hasn't expired
-3. Verify the secret path is correct (including `secret/data/` prefix for KV v2)
+3. Verify the secret path is correct — it is **relative to the KV v2 mount**, with **no** `secret/data/` prefix (the client inserts the `data/` segment internally; adding it yourself produces a wrong path)
 
 ```bash
 export VAULT_TOKEN="hvs.xxx"


### PR DESCRIPTION
## Summary

Three documentation-claim fixes, each verified against the code/behavior they contradicted (and consistent with the authoritative `vault-providers.md`).

- **#366** — `configuration.md` documented `envdrift init --watch` for agent registration, but `init` has no `--watch` option (only `--output`/`--class-name`/`--detect-sensitive`/`--force`). Registration is `envdrift agent register`.
- **#367** — `faq.md` claimed you can set a vault provider per mapping, but the provider is **global per sync command** (`[vault] provider`); `SyncMappingConfig` has no `provider` field, so a per-mapping `provider` is silently ignored. `vault-providers.md` already states this correctly.
- **#375** — `troubleshooting.md` told HashiCorp users to include a `secret/data/` prefix, but the read path is **mount-relative** — hvac inserts the `data/` segment internally, so a literal prefix produces a wrong path. `vault-providers.md` already says "no `secret/data/` prefix".

Docs-only; no behavior change.

Closes #366
Closes #367
Closes #375

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified agent registration requires explicit `envdrift agent register` command, not automatic via configuration settings
  * Updated vault provider guidance: configuration applies globally to all sync mappings
  * Clarified HashiCorp vault KV v2 secret path format requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR corrects three documentation inaccuracies that contradicted the actual CLI behavior and the authoritative `vault-providers.md` reference. All changes are docs-only with no behavior impact.

- **`init --watch` removal**: `docs/reference/configuration.md` and `docs/agent-spec.md` no longer claim `envdrift init --watch` is a valid registration alias; only `envdrift agent register` is documented.
- **Per-mapping provider fix**: `docs/support/faq.md` now correctly explains that the vault provider is global per sync command (set in `[vault]`), not configurable per `[[vault.sync.mappings]]` entry.
- **HashiCorp path prefix fix**: `docs/support/troubleshooting.md` now correctly states the secret path is mount-relative with no `secret/data/` prefix, since hvac inserts the `data/` segment internally.

<h3>Confidence Score: 5/5</h3>

Docs-only corrections; no code is changed and the fixes are verified against the authoritative vault-providers.md and actual CLI behavior.

All four changed files are documentation. Each fix removes or replaces a claim that contradicted the real CLI (init --watch doesn't exist), the real config schema (no per-mapping provider field), or the real hvac path-building behavior (no secret/data/ prefix needed). Every correction is consistent with vault-providers.md and the previous thread's resolution.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/agent-spec.md | Removed two prose references to `envdrift init --watch` as a registration alias; the remaining reference is inside an explicitly-labelled Option A design-proposal code block and is not a current-CLI claim. |
| docs/reference/configuration.md | Removed `(or envdrift init --watch)` from the [guardian] registration note; now correctly states only `envdrift agent register`. |
| docs/support/faq.md | Replaced misleading per-mapping provider claim with accurate explanation that the provider is global per sync command, consistent with vault-providers.md. |
| docs/support/troubleshooting.md | Replaced incorrect `secret/data/` prefix instruction with accurate mount-relative path guidance, matching the hvac behavior described in vault-providers.md. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User wants to register project with agent] --> B["Run: envdrift agent register"]
    B --> C["Path added to ~/.envdrift/projects.json"]
    C --> D[Daemon detects projects.json change]
    D --> E[Daemon reads project's envdrift.toml]
    E --> F["[guardian] settings applied"]

    G[User wants to sync secrets] --> H["Configure [vault] provider globally\n(aws | azure | gcp | hashicorp)"]
    H --> I["All [[vault.sync.mappings]] use\nthe same provider"]
    I --> J{Need different provider?}
    J -->|Yes| K["Run command again\nwith --provider flag"]
    J -->|No| L[Sync complete]

    M[HashiCorp KV v2 path] --> N["Use mount-relative path\ne.g. myapp/dotenvx-key"]
    N --> O["hvac inserts data/ segment internally"]
    O --> P["Do NOT add secret/data/ prefix — wrong path"]
```

<sub>Reviews (2): Last reviewed commit: ["docs: wrap long line + remove init --wat..."](https://github.com/jainal09/envdrift/commit/835c1d83d0cd44867677c9cb09d7a974c912111b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35992817)</sub>

<!-- /greptile_comment -->