### PR TITLE
fix(ci): test env + vault image + fail-closed checksums + SHA pins + key cleanup (#331,#332,#334,#365,#374,#348)

### DIFF
--- a/.github/workflows/agent-release.yml
+++ b/.github/workflows/agent-release.yml
@@ -113,6 +113,16 @@ jobs:
           find dist -type f -exec mv {} release/ \;
           ls -la release/
 
+      - name: Generate checksums
+        working-directory: .
+        run: |
+          # install.sh / install.ps1 verify the agent binary against this file;
+          # without it the installers' (now fail-closed) checksum step aborts.
+          # `sha256sum`'s "<hash>  <filename>" format is exactly what they parse.
+          cd release
+          sha256sum * > checksums.txt
+          cat checksums.txt
+
       - name: Get version from tag
         id: version
         env:

--- a/.github/workflows/agent-release.yml
+++ b/.github/workflows/agent-release.yml
@@ -120,6 +120,9 @@ jobs:
           # without it the installers' (now fail-closed) checksum step aborts.
           # `sha256sum`'s "<hash>  <filename>" format is exactly what they parse.
           cd release
+          # rm first so a retry's stale checksums.txt isn't hashed into itself
+          # (the glob expands after the rm, so it only covers the binaries).
+          rm -f checksums.txt
           sha256sum * > checksums.txt
           cat checksums.txt
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -59,7 +59,8 @@ jobs:
           --health-start-period=10s
 
       vault:
-        image: hashicorp/vault:2.0
+        # Keep in sync with tests/docker-compose.test.yml (hashicorp/vault:1.18).
+        image: hashicorp/vault:1.18
         ports:
           - 8200:8200
         env:
@@ -307,13 +308,17 @@ jobs:
         env:
           GCP_KEY_CONTENT: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
         run: |
-          echo "$GCP_KEY_CONTENT" > gcp_key.json
-          export GOOGLE_APPLICATION_CREDENTIALS=$(pwd)/gcp_key.json
+          # Guarantee the plaintext SA key is shredded even if pytest (or the
+          # project-id parse) fails — `bash -e` would otherwise skip a trailing
+          # `rm` on non-zero exit, leaking the key onto the runner FS.
+          cleanup() { rm -f gcp_key.json; }
+          trap cleanup EXIT
+          printf '%s' "$GCP_KEY_CONTENT" > gcp_key.json
+          export GOOGLE_APPLICATION_CREDENTIALS="$(pwd)/gcp_key.json"
           # The real-backend GCP tests also gate on GOOGLE_CLOUD_PROJECT; derive it
           # from the service-account key so the round-trip suite actually runs here.
-          export GOOGLE_CLOUD_PROJECT=$(python -c "import json; print(json.load(open('gcp_key.json'))['project_id'])")
+          export GOOGLE_CLOUD_PROJECT="$(python -c "import json; print(json.load(open('gcp_key.json'))['project_id'])")"
           uv run pytest tests/integration/ -v -m gcp --timeout=120
-          rm gcp_key.json
 
       - name: Run Azure tests (if configured)
         if: env.ENVDRIFT_TEST_AZURE == '1'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,6 +49,16 @@ jobs:
       contents: write
       id-token: write
     steps:
+      - name: Verify bare-semver release tag
+        # Belt-and-suspenders over the job `if`: refuse to publish unless the ref
+        # is a strict bare-semver tag vX.Y.Z (rejects v1, v1.2, v1.2.3-rc1, vfoo,
+        # and any workflow_dispatch ref that isn't such a tag).
+        run: |
+          if [[ ! "${GITHUB_REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Refusing to publish: '${GITHUB_REF_NAME}' is not a bare-semver tag (vX.Y.Z)."
+            exit 1
+          fi
+
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,10 @@ name: Publish
 
 on:
   push:
-    tags: ["v*"]
+    # Only bare-semver tags (vX.Y.Z). `v[0-9]*` excludes the component release
+    # tags `vscode-v*` / `agent-v*` (they start with `vs` / `ag`), so a VS Code
+    # or agent release never triggers the PyPI publish.
+    tags: ["v[0-9]*"]
   workflow_dispatch:
 
 permissions:
@@ -19,15 +22,15 @@ jobs:
         python-version: ["3.11", "3.12", "3.13", "3.14"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.2.0
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 
       - name: Install dependencies
         run: uv sync --all-extras
@@ -39,22 +42,25 @@ jobs:
     name: Publish to PyPI
     runs-on: ubuntu-latest
     needs: test
+    # Only ever publish from a bare-semver tag ref. A `workflow_dispatch` from a
+    # branch (no tag) can re-run the test matrix but must never publish to PyPI.
+    if: ${{ startsWith(github.ref, 'refs/tags/v') && !startsWith(github.ref_name, 'vscode-') && !startsWith(github.ref_name, 'agent-') }}
     permissions:
       contents: write
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0  # Fetch all history for hatch-vcs to determine version
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.14"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.2.0
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 
       - name: Install dependencies
         run: uv sync --all-extras

--- a/.github/workflows/vscode-release.yml
+++ b/.github/workflows/vscode-release.yml
@@ -177,7 +177,10 @@ jobs:
           path: release
 
       - name: Publish to VS Code Marketplace
+        # Skip cleanly when the PAT is not configured, but do NOT swallow a real
+        # publish failure (expired/insufficient PAT, network, etc.) — those must
+        # fail the job so a silent non-publish is visible.
+        if: ${{ secrets.VSCE_PAT != '' }}
         run: npx vsce publish --packagePath ../release/envdrift-${{ steps.version.outputs.VERSION }}.vsix
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
-        continue-on-error: true  # Don't fail if marketplace publish fails (may need PAT setup)

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -19,6 +19,9 @@ curl -sSL https://raw.githubusercontent.com/jainal09/envdrift/main/install.sh | 
 # Install a specific version
 curl -sSL https://raw.githubusercontent.com/jainal09/envdrift/main/install.sh | sh -s -- --version 1.2.3
 
+# Skip agent checksum verification (unsafe — installs an unverified binary)
+curl -sSL https://raw.githubusercontent.com/jainal09/envdrift/main/install.sh | sh -s -- --insecure-skip-checksum
+
 # Uninstall
 curl -sSL https://raw.githubusercontent.com/jainal09/envdrift/main/install.sh | sh -s -- --uninstall
 ```
@@ -38,6 +41,9 @@ $env:ENVDRIFT_NO_AGENT = "1"; irm https://raw.githubusercontent.com/jainal09/env
 # Install a specific version
 $env:ENVDRIFT_VERSION = "1.2.3"; irm https://raw.githubusercontent.com/jainal09/envdrift/main/install.ps1 | iex
 
+# Skip agent checksum verification (unsafe — installs an unverified binary)
+$env:ENVDRIFT_INSECURE_SKIP_CHECKSUM = "1"; irm https://raw.githubusercontent.com/jainal09/envdrift/main/install.ps1 | iex
+
 # Uninstall
 $env:ENVDRIFT_UNINSTALL = "1"; irm https://raw.githubusercontent.com/jainal09/envdrift/main/install.ps1 | iex
 ```
@@ -47,6 +53,7 @@ If running the script directly (saved locally), you can use parameters instead:
 ```powershell
 .\install.ps1 -NoAgent
 .\install.ps1 -Version 1.2.3
+.\install.ps1 -InsecureSkipChecksum
 .\install.ps1 -Uninstall
 ```
 
@@ -57,7 +64,9 @@ If running the script directly (saved locally), you can use parameters instead:
 3. Creates an isolated virtual environment at `~/.envdrift/venv`
 4. Installs `envdrift[vault]` (all vault backends)
 5. Creates a wrapper script at `~/.envdrift/bin/envdrift`
-6. Optionally downloads the envdrift-agent binary (with checksum verification)
+6. Optionally downloads the envdrift-agent binary (SHA256-verified against the
+   release `checksums.txt`; the install **aborts** if the checksum is missing or
+   does not match, unless you pass `--insecure-skip-checksum`)
 
 Add `~/.envdrift/bin` to your `PATH` to use `envdrift` from anywhere.
 

--- a/install.ps1
+++ b/install.ps1
@@ -13,6 +13,7 @@
 #   -NoAgent            Skip downloading the envdrift-agent binary
 #   -Version X.Y.Z      Install a specific envdrift version
 #   -AgentVersion X.Y.Z Install a specific agent version
+#   -InsecureSkipChecksum  Skip SHA256 verification of the agent binary (unsafe)
 #   -Uninstall          Remove envdrift installation
 #   -Help               Show this help message
 
@@ -20,6 +21,7 @@ param(
     [switch]$NoAgent,
     [string]$Version = "",
     [string]$AgentVersion = "",
+    [switch]$InsecureSkipChecksum,
     [switch]$Uninstall,
     [switch]$Help
 )
@@ -32,6 +34,7 @@ $ErrorActionPreference = "Stop"
 if ($env:ENVDRIFT_NO_AGENT -eq "1") { $NoAgent = [switch]::new($true) }
 if ($env:ENVDRIFT_VERSION) { $Version = $env:ENVDRIFT_VERSION }
 if ($env:ENVDRIFT_AGENT_VERSION) { $AgentVersion = $env:ENVDRIFT_AGENT_VERSION }
+if ($env:ENVDRIFT_INSECURE_SKIP_CHECKSUM -eq "1") { $InsecureSkipChecksum = [switch]::new($true) }
 if ($env:ENVDRIFT_UNINSTALL -eq "1") { $Uninstall = [switch]::new($true) }
 
 # -------------------------------------------------------------------
@@ -83,17 +86,19 @@ Usage:
     `$env:ENVDRIFT_NO_AGENT = "1"; irm https://raw.githubusercontent.com/jainal09/envdrift/main/install.ps1 | iex
 
 Options:
-  -NoAgent              Skip downloading the envdrift-agent binary
-  -Version X.Y.Z        Install a specific envdrift Python package version
-  -AgentVersion X.Y.Z   Install a specific agent binary version
-  -Uninstall            Remove the envdrift installation (~/.envdrift)
-  -Help                 Show this help message
+  -NoAgent                 Skip downloading the envdrift-agent binary
+  -Version X.Y.Z           Install a specific envdrift Python package version
+  -AgentVersion X.Y.Z      Install a specific agent binary version
+  -InsecureSkipChecksum    Skip SHA256 verification of the agent binary (unsafe)
+  -Uninstall               Remove the envdrift installation (~/.envdrift)
+  -Help                    Show this help message
 
 Environment Variables (for irm | iex):
-  ENVDRIFT_NO_AGENT=1         Same as -NoAgent
-  ENVDRIFT_VERSION=X.Y.Z      Same as -Version
-  ENVDRIFT_AGENT_VERSION=X.Y.Z Same as -AgentVersion
-  ENVDRIFT_UNINSTALL=1         Same as -Uninstall
+  ENVDRIFT_NO_AGENT=1               Same as -NoAgent
+  ENVDRIFT_VERSION=X.Y.Z            Same as -Version
+  ENVDRIFT_AGENT_VERSION=X.Y.Z      Same as -AgentVersion
+  ENVDRIFT_INSECURE_SKIP_CHECKSUM=1 Same as -InsecureSkipChecksum
+  ENVDRIFT_UNINSTALL=1              Same as -Uninstall
 "@
     exit 0
 }
@@ -332,7 +337,7 @@ function Install-Agent {
             return
         }
 
-        # Verify checksum (best-effort)
+        # Verify checksum (fail-closed unless -InsecureSkipChecksum was passed)
         Test-Checksum -File $tmpBinary -Name $binaryName -Url $checksumUrl
 
         try {
@@ -354,14 +359,20 @@ function Install-Agent {
 function Test-Checksum {
     param([string]$File, [string]$Name, [string]$Url)
 
+    # Fail-closed: an unverified binary is refused unless the user explicitly
+    # opts out. This is a supply-chain integrity gate, not a best-effort hint.
+    if ($InsecureSkipChecksum) {
+        Write-Warn "Skipping checksum verification (-InsecureSkipChecksum)"
+        return
+    }
+
     $tmpChecksums = [System.IO.Path]::GetTempFileName()
     try {
         Get-Download -Url $Url -Dest $tmpChecksums
     }
     catch {
-        Write-Warn "Checksums file not available - skipping verification"
         Remove-Item $tmpChecksums -Force -ErrorAction SilentlyContinue
-        return
+        Stop-WithError "Checksums file not available at $Url - refusing to install an unverified binary (use -InsecureSkipChecksum to override)."
     }
 
     $expected = $null
@@ -375,8 +386,7 @@ function Test-Checksum {
     Remove-Item $tmpChecksums -Force -ErrorAction SilentlyContinue
 
     if (-not $expected) {
-        Write-Warn "No checksum entry for $Name - skipping verification"
-        return
+        Stop-WithError "No checksum entry for $Name - refusing to install an unverified binary (use -InsecureSkipChecksum to override)."
     }
 
     $hash = (Get-FileHash -Path $File -Algorithm SHA256).Hash.ToLower()

--- a/install.sh
+++ b/install.sh
@@ -7,6 +7,7 @@
 #   --no-agent          Skip downloading the envdrift-agent binary
 #   --version X.Y.Z     Install a specific envdrift version
 #   --agent-version X.Y.Z  Install a specific agent version
+#   --insecure-skip-checksum  Skip SHA256 verification of the agent binary (unsafe)
 #   --uninstall         Remove envdrift installation
 #   --help              Show this help message
 
@@ -29,6 +30,7 @@ INSTALL_AGENT=1
 ENVDRIFT_VERSION=""
 AGENT_VERSION=""
 UNINSTALL=0
+SKIP_CHECKSUM=0
 
 # -------------------------------------------------------------------
 # Cleanup trap
@@ -82,11 +84,12 @@ Usage:
   install.sh [options]
 
 Options:
-  --no-agent              Skip downloading the envdrift-agent binary
-  --version X.Y.Z         Install a specific envdrift Python package version
-  --agent-version X.Y.Z   Install a specific agent binary version
-  --uninstall             Remove the envdrift installation (~/.envdrift)
-  --help                  Show this help message
+  --no-agent                  Skip downloading the envdrift-agent binary
+  --version X.Y.Z             Install a specific envdrift Python package version
+  --agent-version X.Y.Z       Install a specific agent binary version
+  --insecure-skip-checksum    Skip SHA256 verification of the agent binary (unsafe)
+  --uninstall                 Remove the envdrift installation (~/.envdrift)
+  --help                      Show this help message
 EOF
 }
 
@@ -105,6 +108,10 @@ while [ $# -gt 0 ]; do
             [ $# -ge 2 ] || die "--agent-version requires a value"
             AGENT_VERSION="$2"
             shift 2
+            ;;
+        --insecure-skip-checksum)
+            SKIP_CHECKSUM=1
+            shift
             ;;
         --uninstall)
             UNINSTALL=1
@@ -347,7 +354,7 @@ for r in releases:
         return
     fi
 
-    # Verify checksum (best-effort)
+    # Verify checksum (fail-closed unless --insecure-skip-checksum was passed)
     verify_checksum "${tmp_binary}" "${binary_name}" "${checksum_url}"
 
     mv "${tmp_binary}" "${dest}"
@@ -363,12 +370,18 @@ verify_checksum() {
     name="$2"
     url="$3"
 
+    # Fail-closed: an unverified binary is refused unless the user explicitly
+    # opts out. This is a supply-chain integrity gate, not a best-effort hint.
+    if [ "${SKIP_CHECKSUM:-0}" = "1" ]; then
+        warn "Skipping checksum verification (--insecure-skip-checksum)"
+        return
+    fi
+
     tmp_checksums="$(mktemp)"
     add_tmp "${tmp_checksums}"
 
-    if ! download "${url}" "${tmp_checksums}" 2>/dev/null; then
-        warn "Checksums file not available — skipping verification"
-        return
+    if ! download "${url}" "${tmp_checksums}"; then
+        die "Checksums file not available at ${url} — refusing to install an unverified binary (use --insecure-skip-checksum to override)."
     fi
 
     expected=""
@@ -383,8 +396,7 @@ verify_checksum() {
     done < "${tmp_checksums}"
 
     if [ -z "${expected}" ]; then
-        warn "No checksum entry for ${name} — skipping verification"
-        return
+        die "No checksum entry for ${name} — refusing to install an unverified binary (use --insecure-skip-checksum to override)."
     fi
 
     # Compute SHA256
@@ -393,8 +405,7 @@ verify_checksum() {
     elif command -v shasum >/dev/null 2>&1; then
         actual="$(shasum -a 256 "${file}" | awk '{print $1}')"
     else
-        warn "No sha256sum or shasum found — skipping verification"
-        return
+        die "No sha256sum or shasum found — cannot verify the agent binary. Install one or pass --insecure-skip-checksum."
     fi
 
     if [ "${actual}" != "${expected}" ]; then

--- a/tests/docker-compose.test.yml
+++ b/tests/docker-compose.test.yml
@@ -24,6 +24,9 @@ services:
 
   vault:
     image: hashicorp/vault:1.18  # Pin to v1.18.x for stability
+    # Match integration-tests.yml (`--user root`) so the setcap/IPC_LOCK
+    # behavior is identical between the local compose stack and CI.
+    user: root
     ports:
       - "8200:8200"
     environment:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -311,6 +311,25 @@ def integration_pythonpath() -> str:
 
 
 @pytest.fixture
+def integration_env(integration_pythonpath: str) -> dict[str, str]:
+    """Return the child env for running the envdrift CLI as a subprocess.
+
+    Regression for #331: integration tests previously built the child env as a
+    bare ``{"PYTHONPATH": ...}`` dict, which strips ``PATH``/``HOME`` so the
+    child cannot resolve ``uv``/``dotenvx``/``sops`` (PATH) or auto-install
+    binaries under ``$HOME``. Building from ``os.environ.copy()`` preserves the
+    parent environment and layers ``PYTHONPATH`` on top.
+
+    Function-scoped: returns a *fresh* dict each call. Call sites that need to
+    add more env keys must start from a copy (``dict(integration_env)``) so the
+    shared fixture value is never mutated.
+    """
+    env = os.environ.copy()
+    env["PYTHONPATH"] = integration_pythonpath
+    return env
+
+
+@pytest.fixture
 def work_dir(tmp_path: Path) -> Path:
     """Create a temporary working directory for a test."""
     return tmp_path

--- a/tests/integration/test_error_handling.py
+++ b/tests/integration/test_error_handling.py
@@ -14,7 +14,6 @@ Requires: docker-compose -f tests/docker-compose.test.yml up -d
 from __future__ import annotations
 
 import contextlib
-import os
 import subprocess
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -34,7 +33,7 @@ class TestNetworkTimeoutVault:
     def test_vault_unreachable_timeout(
         self,
         work_dir: Path,
-        integration_pythonpath: str,
+        integration_env: dict[str, str],
         envdrift_cmd: list[str],
     ) -> None:
         """Test that operations timeout gracefully when vault is unreachable.
@@ -65,8 +64,7 @@ environment = "production"
         (work_dir / "envdrift.toml").write_text(config_content)
         (work_dir / ".env.production").write_text('SECRET="encrypted:..."')
 
-        env = os.environ.copy()
-        env["PYTHONPATH"] = integration_pythonpath
+        env = integration_env
 
         # Run with a timeout - the command should fail gracefully, not hang
         result = subprocess.run(
@@ -98,7 +96,7 @@ environment = "production"
     def test_aws_endpoint_unreachable(
         self,
         work_dir: Path,
-        integration_pythonpath: str,
+        integration_env: dict[str, str],
         envdrift_cmd: list[str],
     ) -> None:
         """Test AWS client handles unreachable endpoint gracefully."""
@@ -122,11 +120,12 @@ environment = "production"
         (work_dir / ".env.production").write_text('SECRET="encrypted:..."')
 
         # Build environment with unreachable endpoint (port that's not listening)
-        # Using localhost with wrong port fails fast (connection refused)
-        env = os.environ.copy()
+        # Using localhost with wrong port fails fast (connection refused).
+        # Copy the shared fixture (which carries PATH/HOME/PYTHONPATH — #331) so
+        # the fixture value is not mutated, then layer the AWS overrides on top.
+        env = dict(integration_env)
         env.update(
             {
-                "PYTHONPATH": integration_pythonpath,
                 "AWS_ENDPOINT_URL": "http://127.0.0.1:59999",  # Port not listening
                 "AWS_ACCESS_KEY_ID": "test",
                 "AWS_SECRET_ACCESS_KEY": "test",
@@ -254,7 +253,7 @@ class TestCorruptEnvFile:
     def test_malformed_env_file_parsing(
         self,
         work_dir: Path,
-        integration_pythonpath: str,
+        integration_env: dict[str, str],
         envdrift_cmd: list[str],
     ) -> None:
         """
@@ -282,8 +281,7 @@ backend = "dotenvx"
 """
         (work_dir / "envdrift.toml").write_text(config_content)
 
-        env = os.environ.copy()
-        env["PYTHONPATH"] = integration_pythonpath
+        env = integration_env
 
         # Run lock --check which will parse the .env file
         result = subprocess.run(
@@ -304,7 +302,7 @@ backend = "dotenvx"
     def test_binary_content_in_env_file(
         self,
         work_dir: Path,
-        integration_pythonpath: str,
+        integration_env: dict[str, str],
         envdrift_cmd: list[str],
     ) -> None:
         """Test handling of binary content in .env files."""
@@ -318,8 +316,7 @@ backend = "dotenvx"
 """
         (work_dir / "envdrift.toml").write_text(config_content)
 
-        env = os.environ.copy()
-        env["PYTHONPATH"] = integration_pythonpath
+        env = integration_env
 
         result = subprocess.run(
             [*envdrift_cmd, "lock", "--check"],
@@ -338,7 +335,7 @@ backend = "dotenvx"
     def test_empty_env_file(
         self,
         work_dir: Path,
-        integration_pythonpath: str,
+        integration_env: dict[str, str],
         envdrift_cmd: list[str],
     ) -> None:
         """
@@ -354,8 +351,7 @@ backend = "dotenvx"
 """
         (work_dir / "envdrift.toml").write_text(config_content)
 
-        env = os.environ.copy()
-        env["PYTHONPATH"] = integration_pythonpath
+        env = integration_env
 
         result = subprocess.run(
             [*envdrift_cmd, "lock", "--check"],
@@ -376,7 +372,7 @@ class TestCorruptEncryptedFile:
     def test_tampered_ciphertext_detection(
         self,
         work_dir: Path,
-        integration_pythonpath: str,
+        integration_env: dict[str, str],
         envdrift_cmd: list[str],
     ) -> None:
         """Test that tampered encrypted content is detected."""
@@ -402,8 +398,7 @@ backend = "dotenvx"
 """
         (work_dir / "envdrift.toml").write_text(config_content)
 
-        env = os.environ.copy()
-        env["PYTHONPATH"] = integration_pythonpath
+        env = integration_env
 
         # Try to decrypt - should fail gracefully
         result = subprocess.run(
@@ -421,7 +416,7 @@ backend = "dotenvx"
     def test_incomplete_encryption_markers(
         self,
         work_dir: Path,
-        integration_pythonpath: str,
+        integration_env: dict[str, str],
         envdrift_cmd: list[str],
     ) -> None:
         """Test handling of files with incomplete encryption markers."""
@@ -441,8 +436,7 @@ backend = "dotenvx"
 """
         (work_dir / "envdrift.toml").write_text(config_content)
 
-        env = os.environ.copy()
-        env["PYTHONPATH"] = integration_pythonpath
+        env = integration_env
 
         result = subprocess.run(
             [*envdrift_cmd, "lock", "--check"],
@@ -523,7 +517,7 @@ class TestFilePermissionErrors:
     def test_readonly_env_keys_file(
         self,
         work_dir: Path,
-        integration_pythonpath: str,
+        integration_env: dict[str, str],
         envdrift_cmd: list[str],
     ) -> None:
         """Test handling when .env.keys is read-only."""
@@ -556,8 +550,7 @@ environment = "production"
             (work_dir / "envdrift.toml").write_text(config_content)
             (work_dir / ".env.production").write_text('SECRET="encrypted:..."')
 
-            env = os.environ.copy()
-            env["PYTHONPATH"] = integration_pythonpath
+            env = integration_env
 
             # This would try to write to .env.keys
             # Should handle permission error gracefully

--- a/tests/integration/test_error_handling.py
+++ b/tests/integration/test_error_handling.py
@@ -14,6 +14,7 @@ Requires: docker-compose -f tests/docker-compose.test.yml up -d
 from __future__ import annotations
 
 import contextlib
+import os
 import subprocess
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -64,7 +65,8 @@ environment = "production"
         (work_dir / "envdrift.toml").write_text(config_content)
         (work_dir / ".env.production").write_text('SECRET="encrypted:..."')
 
-        env = {"PYTHONPATH": integration_pythonpath}
+        env = os.environ.copy()
+        env["PYTHONPATH"] = integration_pythonpath
 
         # Run with a timeout - the command should fail gracefully, not hang
         result = subprocess.run(
@@ -121,15 +123,18 @@ environment = "production"
 
         # Build environment with unreachable endpoint (port that's not listening)
         # Using localhost with wrong port fails fast (connection refused)
-        env = {
-            "PYTHONPATH": integration_pythonpath,
-            "AWS_ENDPOINT_URL": "http://127.0.0.1:59999",  # Port not listening
-            "AWS_ACCESS_KEY_ID": "test",
-            "AWS_SECRET_ACCESS_KEY": "test",
-            "AWS_DEFAULT_REGION": "us-east-1",
-            "AWS_MAX_ATTEMPTS": "1",
-            "AWS_RETRY_MODE": "standard",
-        }
+        env = os.environ.copy()
+        env.update(
+            {
+                "PYTHONPATH": integration_pythonpath,
+                "AWS_ENDPOINT_URL": "http://127.0.0.1:59999",  # Port not listening
+                "AWS_ACCESS_KEY_ID": "test",
+                "AWS_SECRET_ACCESS_KEY": "test",
+                "AWS_DEFAULT_REGION": "us-east-1",
+                "AWS_MAX_ATTEMPTS": "1",
+                "AWS_RETRY_MODE": "standard",
+            }
+        )
 
         result = subprocess.run(
             [*envdrift_cmd, "pull"],
@@ -277,7 +282,8 @@ backend = "dotenvx"
 """
         (work_dir / "envdrift.toml").write_text(config_content)
 
-        env = {"PYTHONPATH": integration_pythonpath}
+        env = os.environ.copy()
+        env["PYTHONPATH"] = integration_pythonpath
 
         # Run lock --check which will parse the .env file
         result = subprocess.run(
@@ -312,7 +318,8 @@ backend = "dotenvx"
 """
         (work_dir / "envdrift.toml").write_text(config_content)
 
-        env = {"PYTHONPATH": integration_pythonpath}
+        env = os.environ.copy()
+        env["PYTHONPATH"] = integration_pythonpath
 
         result = subprocess.run(
             [*envdrift_cmd, "lock", "--check"],
@@ -347,7 +354,8 @@ backend = "dotenvx"
 """
         (work_dir / "envdrift.toml").write_text(config_content)
 
-        env = {"PYTHONPATH": integration_pythonpath}
+        env = os.environ.copy()
+        env["PYTHONPATH"] = integration_pythonpath
 
         result = subprocess.run(
             [*envdrift_cmd, "lock", "--check"],
@@ -394,7 +402,8 @@ backend = "dotenvx"
 """
         (work_dir / "envdrift.toml").write_text(config_content)
 
-        env = {"PYTHONPATH": integration_pythonpath}
+        env = os.environ.copy()
+        env["PYTHONPATH"] = integration_pythonpath
 
         # Try to decrypt - should fail gracefully
         result = subprocess.run(
@@ -432,7 +441,8 @@ backend = "dotenvx"
 """
         (work_dir / "envdrift.toml").write_text(config_content)
 
-        env = {"PYTHONPATH": integration_pythonpath}
+        env = os.environ.copy()
+        env["PYTHONPATH"] = integration_pythonpath
 
         result = subprocess.run(
             [*envdrift_cmd, "lock", "--check"],
@@ -546,7 +556,8 @@ environment = "production"
             (work_dir / "envdrift.toml").write_text(config_content)
             (work_dir / ".env.production").write_text('SECRET="encrypted:..."')
 
-            env = {"PYTHONPATH": integration_pythonpath}
+            env = os.environ.copy()
+            env["PYTHONPATH"] = integration_pythonpath
 
             # This would try to write to .env.keys
             # Should handle permission error gracefully

--- a/tests/integration/test_validation_edge_cases.py
+++ b/tests/integration/test_validation_edge_cases.py
@@ -73,7 +73,8 @@ class TestNestedPydanticModel:
         """)
         )
 
-        env = {"PYTHONPATH": integration_pythonpath}
+        env = os.environ.copy()
+        env["PYTHONPATH"] = integration_pythonpath
 
         # Run validate command
         result = subprocess.run(
@@ -146,7 +147,8 @@ class TestCustomValidators:
         env_file = tmp_path / ".env"
         env_file.write_text("EMAIL=test@example.com\nPORT=8080\n")
 
-        env = {"PYTHONPATH": integration_pythonpath}
+        env = os.environ.copy()
+        env["PYTHONPATH"] = integration_pythonpath
 
         result = subprocess.run(
             [
@@ -200,7 +202,8 @@ class TestOptionalVsRequired:
         env_file = tmp_path / ".env"
         env_file.write_text("REQUIRED_FIELD=present\n")
 
-        env = {"PYTHONPATH": integration_pythonpath}
+        env = os.environ.copy()
+        env["PYTHONPATH"] = integration_pythonpath
 
         result = subprocess.run(
             [
@@ -248,7 +251,8 @@ class TestOptionalVsRequired:
         env_file = tmp_path / ".env"
         env_file.write_text("API_KEY=secret123\n")
 
-        env = {"PYTHONPATH": integration_pythonpath}
+        env = os.environ.copy()
+        env["PYTHONPATH"] = integration_pythonpath
 
         result = subprocess.run(
             [
@@ -309,7 +313,8 @@ class TestExtraForbid:
         """)
         )
 
-        env = {"PYTHONPATH": integration_pythonpath}
+        env = os.environ.copy()
+        env["PYTHONPATH"] = integration_pythonpath
 
         result = subprocess.run(
             [
@@ -373,7 +378,8 @@ class TestSensitivePatterns:
         """)
         )
 
-        env = {"PYTHONPATH": integration_pythonpath}
+        env = os.environ.copy()
+        env["PYTHONPATH"] = integration_pythonpath
 
         # Run with encryption check enabled
         result = subprocess.run(
@@ -435,7 +441,8 @@ class TestTypeCoercion:
         env_file = tmp_path / ".env"
         env_file.write_text("DEBUG_MODE=true\nVERBOSE_MODE=False\n")
 
-        env = {"PYTHONPATH": integration_pythonpath}
+        env = os.environ.copy()
+        env["PYTHONPATH"] = integration_pythonpath
 
         result = subprocess.run(
             [
@@ -480,7 +487,8 @@ class TestTypeCoercion:
         env_file = tmp_path / ".env"
         env_file.write_text("PORT=8080\nMAX_CONNECTIONS=100\n")
 
-        env = {"PYTHONPATH": integration_pythonpath}
+        env = os.environ.copy()
+        env["PYTHONPATH"] = integration_pythonpath
 
         result = subprocess.run(
             [
@@ -524,7 +532,8 @@ class TestTypeCoercion:
         env_file = tmp_path / ".env"
         env_file.write_text("PORT=not_a_number\n")
 
-        env = {"PYTHONPATH": integration_pythonpath}
+        env = os.environ.copy()
+        env["PYTHONPATH"] = integration_pythonpath
 
         result = subprocess.run(
             [
@@ -567,7 +576,8 @@ class TestValidateCommand:
         env_file = tmp_path / ".env"
         env_file.write_text("API_KEY=secret\n")
 
-        env = {"PYTHONPATH": integration_pythonpath}
+        env = os.environ.copy()
+        env["PYTHONPATH"] = integration_pythonpath
 
         result = subprocess.run(
             [sys.executable, "-m", "envdrift.cli", "validate", str(env_file)],
@@ -605,7 +615,8 @@ class TestValidateCommand:
         env_file = tmp_path / ".env"
         env_file.write_text("API_KEY=secret123\n")
 
-        env = {"PYTHONPATH": integration_pythonpath}
+        env = os.environ.copy()
+        env["PYTHONPATH"] = integration_pythonpath
 
         result = subprocess.run(
             [
@@ -656,7 +667,8 @@ class TestValidateCommand:
         env_file = tmp_path / ".env"
         env_file.write_text("")
 
-        env = {"PYTHONPATH": integration_pythonpath}
+        env = os.environ.copy()
+        env["PYTHONPATH"] = integration_pythonpath
 
         result = subprocess.run(
             [
@@ -697,7 +709,8 @@ class TestValidateCommand:
         """)
         )
 
-        env = {"PYTHONPATH": integration_pythonpath}
+        env = os.environ.copy()
+        env["PYTHONPATH"] = integration_pythonpath
 
         result = subprocess.run(
             [
@@ -735,7 +748,8 @@ class TestValidateCommand:
         env_file = tmp_path / ".env"
         env_file.write_text("API_KEY=secret\n")
 
-        env = {"PYTHONPATH": integration_pythonpath}
+        env = os.environ.copy()
+        env["PYTHONPATH"] = integration_pythonpath
 
         result = subprocess.run(
             [
@@ -823,6 +837,32 @@ def _run_validate(
         env=env,
         capture_output=True,
         text=True,
+    )
+
+
+def test_subprocess_env_carries_path_and_home(integration_pythonpath: str) -> None:
+    """Regression for #331: a constructed test env must keep PATH and HOME.
+
+    Integration tests build the child env from ``os.environ.copy()`` then add
+    ``PYTHONPATH``. A bare ``{"PYTHONPATH": ...}`` dict strips PATH/HOME, so the
+    child cannot resolve ``uv``/``dotenvx``/``sops`` (PATH) or auto-install
+    binaries under ``$HOME`` — the exact failure mode #331 describes. This
+    asserts the contract the fix restores.
+    """
+    env = os.environ.copy()
+    env["PYTHONPATH"] = integration_pythonpath
+    out = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import os;print(os.environ.get('PATH') is not None, os.environ.get('HOME') is not None)",
+        ],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert out.stdout.strip() == "True True", (
+        f"PATH/HOME must survive into the child env. stdout: {out.stdout!r} stderr: {out.stderr!r}"
     )
 
 

--- a/tests/integration/test_validation_edge_cases.py
+++ b/tests/integration/test_validation_edge_cases.py
@@ -33,7 +33,7 @@ class TestNestedPydanticModel:
     def test_validate_nested_pydantic_model(
         self,
         tmp_path: Path,
-        integration_pythonpath: str,
+        integration_env: dict[str, str],
     ) -> None:
         """Test validation of nested BaseSettings with sub-models.
 
@@ -73,8 +73,7 @@ class TestNestedPydanticModel:
         """)
         )
 
-        env = os.environ.copy()
-        env["PYTHONPATH"] = integration_pythonpath
+        env = integration_env
 
         # Run validate command
         result = subprocess.run(
@@ -109,7 +108,7 @@ class TestCustomValidators:
     def test_validate_custom_validators(
         self,
         tmp_path: Path,
-        integration_pythonpath: str,
+        integration_env: dict[str, str],
     ) -> None:
         """Test validation with custom field validators.
 
@@ -147,8 +146,7 @@ class TestCustomValidators:
         env_file = tmp_path / ".env"
         env_file.write_text("EMAIL=test@example.com\nPORT=8080\n")
 
-        env = os.environ.copy()
-        env["PYTHONPATH"] = integration_pythonpath
+        env = integration_env
 
         result = subprocess.run(
             [
@@ -179,7 +177,7 @@ class TestOptionalVsRequired:
     def test_validate_optional_vs_required(
         self,
         tmp_path: Path,
-        integration_pythonpath: str,
+        integration_env: dict[str, str],
     ) -> None:
         """Test that optional fields with defaults don't fail validation,
         but required fields without values do.
@@ -202,8 +200,7 @@ class TestOptionalVsRequired:
         env_file = tmp_path / ".env"
         env_file.write_text("REQUIRED_FIELD=present\n")
 
-        env = os.environ.copy()
-        env["PYTHONPATH"] = integration_pythonpath
+        env = integration_env
 
         result = subprocess.run(
             [
@@ -232,7 +229,7 @@ class TestOptionalVsRequired:
     def test_validate_missing_required_field(
         self,
         tmp_path: Path,
-        integration_pythonpath: str,
+        integration_env: dict[str, str],
     ) -> None:
         """Test that missing required fields are reported."""
         settings_module = tmp_path / "settings.py"
@@ -251,8 +248,7 @@ class TestOptionalVsRequired:
         env_file = tmp_path / ".env"
         env_file.write_text("API_KEY=secret123\n")
 
-        env = os.environ.copy()
-        env["PYTHONPATH"] = integration_pythonpath
+        env = integration_env
 
         result = subprocess.run(
             [
@@ -286,7 +282,7 @@ class TestExtraForbid:
     def test_validate_extra_forbid(
         self,
         tmp_path: Path,
-        integration_pythonpath: str,
+        integration_env: dict[str, str],
     ) -> None:
         """Test that extra variables are rejected when strict_extra is enabled."""
         settings_module = tmp_path / "settings.py"
@@ -313,8 +309,7 @@ class TestExtraForbid:
         """)
         )
 
-        env = os.environ.copy()
-        env["PYTHONPATH"] = integration_pythonpath
+        env = integration_env
 
         result = subprocess.run(
             [
@@ -350,7 +345,7 @@ class TestSensitivePatterns:
     def test_validate_sensitive_patterns(
         self,
         tmp_path: Path,
-        integration_pythonpath: str,
+        integration_env: dict[str, str],
     ) -> None:
         """Test that sensitive patterns are detected."""
         settings_module = tmp_path / "settings.py"
@@ -378,8 +373,7 @@ class TestSensitivePatterns:
         """)
         )
 
-        env = os.environ.copy()
-        env["PYTHONPATH"] = integration_pythonpath
+        env = integration_env
 
         # Run with encryption check enabled
         result = subprocess.run(
@@ -418,7 +412,7 @@ class TestTypeCoercion:
     def test_validate_type_coercion_bool(
         self,
         tmp_path: Path,
-        integration_pythonpath: str,
+        integration_env: dict[str, str],
     ) -> None:
         """Test that string 'true'/'false' values coerce to bool.
 
@@ -441,8 +435,7 @@ class TestTypeCoercion:
         env_file = tmp_path / ".env"
         env_file.write_text("DEBUG_MODE=true\nVERBOSE_MODE=False\n")
 
-        env = os.environ.copy()
-        env["PYTHONPATH"] = integration_pythonpath
+        env = integration_env
 
         result = subprocess.run(
             [
@@ -469,7 +462,7 @@ class TestTypeCoercion:
     def test_validate_type_coercion_int(
         self,
         tmp_path: Path,
-        integration_pythonpath: str,
+        integration_env: dict[str, str],
     ) -> None:
         """Test that string numbers coerce to int."""
         settings_module = tmp_path / "settings.py"
@@ -487,8 +480,7 @@ class TestTypeCoercion:
         env_file = tmp_path / ".env"
         env_file.write_text("PORT=8080\nMAX_CONNECTIONS=100\n")
 
-        env = os.environ.copy()
-        env["PYTHONPATH"] = integration_pythonpath
+        env = integration_env
 
         result = subprocess.run(
             [
@@ -515,7 +507,7 @@ class TestTypeCoercion:
     def test_validate_type_error_invalid_int(
         self,
         tmp_path: Path,
-        integration_pythonpath: str,
+        integration_env: dict[str, str],
     ) -> None:
         """Test that invalid int values are caught."""
         settings_module = tmp_path / "settings.py"
@@ -532,8 +524,7 @@ class TestTypeCoercion:
         env_file = tmp_path / ".env"
         env_file.write_text("PORT=not_a_number\n")
 
-        env = os.environ.copy()
-        env["PYTHONPATH"] = integration_pythonpath
+        env = integration_env
 
         result = subprocess.run(
             [
@@ -570,14 +561,13 @@ class TestValidateCommand:
     def test_validate_missing_schema_arg(
         self,
         tmp_path: Path,
-        integration_pythonpath: str,
+        integration_env: dict[str, str],
     ) -> None:
         """Test that validate fails gracefully without --schema."""
         env_file = tmp_path / ".env"
         env_file.write_text("API_KEY=secret\n")
 
-        env = os.environ.copy()
-        env["PYTHONPATH"] = integration_pythonpath
+        env = integration_env
 
         result = subprocess.run(
             [sys.executable, "-m", "envdrift.cli", "validate", str(env_file)],
@@ -595,7 +585,7 @@ class TestValidateCommand:
     def test_validate_fix_template(
         self,
         tmp_path: Path,
-        integration_pythonpath: str,
+        integration_env: dict[str, str],
     ) -> None:
         """Test that --fix generates a template for missing variables."""
         settings_module = tmp_path / "settings.py"
@@ -615,8 +605,7 @@ class TestValidateCommand:
         env_file = tmp_path / ".env"
         env_file.write_text("API_KEY=secret123\n")
 
-        env = os.environ.copy()
-        env["PYTHONPATH"] = integration_pythonpath
+        env = integration_env
 
         result = subprocess.run(
             [
@@ -649,7 +638,7 @@ class TestValidateCommand:
     def test_validate_ci_mode_exit_code(
         self,
         tmp_path: Path,
-        integration_pythonpath: str,
+        integration_env: dict[str, str],
     ) -> None:
         """Test that --ci returns non-zero exit on failure."""
         settings_module = tmp_path / "settings.py"
@@ -667,8 +656,7 @@ class TestValidateCommand:
         env_file = tmp_path / ".env"
         env_file.write_text("")
 
-        env = os.environ.copy()
-        env["PYTHONPATH"] = integration_pythonpath
+        env = integration_env
 
         result = subprocess.run(
             [
@@ -696,7 +684,7 @@ class TestValidateCommand:
     def test_validate_nonexistent_env_file(
         self,
         tmp_path: Path,
-        integration_pythonpath: str,
+        integration_env: dict[str, str],
     ) -> None:
         """Test graceful handling of missing env file."""
         settings_module = tmp_path / "settings.py"
@@ -709,8 +697,7 @@ class TestValidateCommand:
         """)
         )
 
-        env = os.environ.copy()
-        env["PYTHONPATH"] = integration_pythonpath
+        env = integration_env
 
         result = subprocess.run(
             [
@@ -742,14 +729,13 @@ class TestValidateCommand:
     def test_validate_invalid_schema_path(
         self,
         tmp_path: Path,
-        integration_pythonpath: str,
+        integration_env: dict[str, str],
     ) -> None:
         """Test graceful handling of invalid schema path."""
         env_file = tmp_path / ".env"
         env_file.write_text("API_KEY=secret\n")
 
-        env = os.environ.copy()
-        env["PYTHONPATH"] = integration_pythonpath
+        env = integration_env
 
         result = subprocess.run(
             [
@@ -795,7 +781,7 @@ class TestValidateCommand:
 def _run_validate(
     *,
     tmp_path: Path,
-    integration_pythonpath: str,
+    integration_env: dict[str, str],
     settings_src: str,
     env_text: str,
     extra_args: list[str] | None = None,
@@ -806,6 +792,9 @@ def _run_validate(
     Writes ``settings.py`` and ``.env`` into ``tmp_path`` and invokes the CLI
     against them. ``COLUMNS`` is pinned wide so Rich does not wrap section
     headers / value lines, keeping output assertions stable in a non-TTY pipe.
+    The child env is built from the shared ``integration_env`` fixture (which
+    carries PATH/HOME — see #331); we copy it before adding ``COLUMNS`` so the
+    fixture value is not mutated.
     """
     settings_module = tmp_path / "settings.py"
     settings_module.write_text(textwrap.dedent(settings_src))
@@ -813,8 +802,7 @@ def _run_validate(
     env_file = tmp_path / ".env"
     env_file.write_text(textwrap.dedent(env_text))
 
-    env = os.environ.copy()
-    env["PYTHONPATH"] = integration_pythonpath
+    env = dict(integration_env)
     env["COLUMNS"] = "200"
 
     cmd = [
@@ -840,24 +828,37 @@ def _run_validate(
     )
 
 
-def test_subprocess_env_carries_path_and_home(integration_pythonpath: str) -> None:
-    """Regression for #331: a constructed test env must keep PATH and HOME.
+def test_subprocess_env_carries_path_and_home(
+    integration_env: dict[str, str],
+    integration_pythonpath: str,
+) -> None:
+    """Regression for #331: the shared child env must keep PATH and HOME.
 
-    Integration tests build the child env from ``os.environ.copy()`` then add
-    ``PYTHONPATH``. A bare ``{"PYTHONPATH": ...}`` dict strips PATH/HOME, so the
-    child cannot resolve ``uv``/``dotenvx``/``sops`` (PATH) or auto-install
-    binaries under ``$HOME`` — the exact failure mode #331 describes. This
-    asserts the contract the fix restores.
+    Every integration call site builds its subprocess env from the shared
+    ``integration_env`` fixture. A bare ``{"PYTHONPATH": ...}`` dict (the #331
+    bug) strips PATH/HOME, so the child cannot resolve ``uv``/``dotenvx``/
+    ``sops`` (PATH) or auto-install binaries under ``$HOME``. This guards the
+    fixture's contract directly: revert ``integration_env`` to a bare dict and
+    this test fails. Because all ~22 call sites build from this fixture, no site
+    can reintroduce the bug without bypassing the fixture entirely.
     """
-    env = os.environ.copy()
-    env["PYTHONPATH"] = integration_pythonpath
+    # 1. Contract at the fixture: PATH/HOME are inherited from the parent env
+    #    and PYTHONPATH points at the repo's src dir.
+    assert "PATH" in integration_env, "integration_env must inherit PATH (#331)"
+    assert "HOME" in integration_env, "integration_env must inherit HOME (#331)"
+    assert integration_env["PATH"] == os.environ["PATH"]
+    assert integration_env["HOME"] == os.environ["HOME"]
+    assert integration_env["PYTHONPATH"] == integration_pythonpath
+
+    # 2. Real child subprocess launched with the fixture env confirms PATH/HOME
+    #    actually reach the child process.
     out = subprocess.run(
         [
             sys.executable,
             "-c",
             "import os;print(os.environ.get('PATH') is not None, os.environ.get('HOME') is not None)",
         ],
-        env=env,
+        env=integration_env,
         capture_output=True,
         text=True,
     )
@@ -872,7 +873,7 @@ class TestValidateRealEdgeCases:
     def test_validate_extra_ignore_emits_warning_not_error(
         self,
         tmp_path: Path,
-        integration_pythonpath: str,
+        integration_env: dict[str, str],
     ) -> None:
         """HP-06: extra='ignore' downgrades an unknown var to a warning.
 
@@ -882,7 +883,7 @@ class TestValidateRealEdgeCases:
         """
         result = _run_validate(
             tmp_path=tmp_path,
-            integration_pythonpath=integration_pythonpath,
+            integration_env=integration_env,
             settings_src='''
                 from pydantic_settings import BaseSettings
 
@@ -915,7 +916,7 @@ class TestValidateRealEdgeCases:
     def test_validate_extra_forbid_reports_error_matching_case(
         self,
         tmp_path: Path,
-        integration_pythonpath: str,
+        integration_env: dict[str, str],
     ) -> None:
         """BP-04: extra='forbid' with a case-matching extra var is an ERROR.
 
@@ -924,7 +925,7 @@ class TestValidateRealEdgeCases:
         """
         result = _run_validate(
             tmp_path=tmp_path,
-            integration_pythonpath=integration_pythonpath,
+            integration_env=integration_env,
             settings_src='''
                 from pydantic_settings import BaseSettings
 
@@ -952,12 +953,12 @@ class TestValidateRealEdgeCases:
     def test_validate_type_errors_for_float_and_bool(
         self,
         tmp_path: Path,
-        integration_pythonpath: str,
+        integration_env: dict[str, str],
     ) -> None:
         """BP-03: invalid float and non-canonical bool produce TYPE ERRORS."""
         result = _run_validate(
             tmp_path=tmp_path,
-            integration_pythonpath=integration_pythonpath,
+            integration_env=integration_env,
             settings_src='''
                 from pydantic_settings import BaseSettings
 
@@ -986,7 +987,7 @@ class TestValidateRealEdgeCases:
     def test_validate_fix_template_encrypted_placeholder_for_sensitive_required(
         self,
         tmp_path: Path,
-        integration_pythonpath: str,
+        integration_env: dict[str, str],
     ) -> None:
         """HP-12: --fix uses an encrypted placeholder for sensitive required fields.
 
@@ -996,7 +997,7 @@ class TestValidateRealEdgeCases:
         """
         result = _run_validate(
             tmp_path=tmp_path,
-            integration_pythonpath=integration_pythonpath,
+            integration_env=integration_env,
             settings_src='''
                 from pydantic_settings import BaseSettings
                 from pydantic import Field
@@ -1028,12 +1029,12 @@ class TestValidateRealEdgeCases:
     def test_validate_fix_is_noop_when_validation_passes(
         self,
         tmp_path: Path,
-        integration_pythonpath: str,
+        integration_env: dict[str, str],
     ) -> None:
         """EC-22: --fix is a no-op when validation passes."""
         result = _run_validate(
             tmp_path=tmp_path,
-            integration_pythonpath=integration_pythonpath,
+            integration_env=integration_env,
             settings_src='''
                 from pydantic_settings import BaseSettings
 
@@ -1062,12 +1063,12 @@ class TestValidateRealEdgeCases:
     def test_validate_encrypted_value_skips_type_check(
         self,
         tmp_path: Path,
-        integration_pythonpath: str,
+        integration_env: dict[str, str],
     ) -> None:
         """EC-09: an encrypted value for an int field produces no type error."""
         result = _run_validate(
             tmp_path=tmp_path,
-            integration_pythonpath=integration_pythonpath,
+            integration_env=integration_env,
             settings_src='''
                 from pydantic_settings import BaseSettings
 
@@ -1096,7 +1097,7 @@ class TestValidateRealEdgeCases:
     def test_validate_suspicious_token_warns_even_when_not_in_schema(
         self,
         tmp_path: Path,
-        integration_pythonpath: str,
+        integration_env: dict[str, str],
     ) -> None:
         """EC-21: a GitHub-token-shaped value not in schema warns under --check-encryption.
 
@@ -1106,7 +1107,7 @@ class TestValidateRealEdgeCases:
         """
         result = _run_validate(
             tmp_path=tmp_path,
-            integration_pythonpath=integration_pythonpath,
+            integration_env=integration_env,
             settings_src='''
                 from pydantic_settings import BaseSettings
 
@@ -1136,12 +1137,12 @@ class TestValidateRealEdgeCases:
     def test_validate_rejects_malformed_dotted_path(
         self,
         tmp_path: Path,
-        integration_pythonpath: str,
+        integration_env: dict[str, str],
     ) -> None:
         """BP-05: a schema path missing the ':' separator is rejected, exit 1."""
         result = _run_validate(
             tmp_path=tmp_path,
-            integration_pythonpath=integration_pythonpath,
+            integration_env=integration_env,
             settings_src="""
                 from pydantic_settings import BaseSettings
 
@@ -1168,12 +1169,12 @@ class TestValidateRealEdgeCases:
     def test_validate_rejects_non_basesettings_class(
         self,
         tmp_path: Path,
-        integration_pythonpath: str,
+        integration_env: dict[str, str],
     ) -> None:
         """BP-07: --schema pointing at a non-BaseSettings class exits 1 cleanly."""
         result = _run_validate(
             tmp_path=tmp_path,
-            integration_pythonpath=integration_pythonpath,
+            integration_env=integration_env,
             settings_src='''
                 class Plain:
                     """Not a Pydantic BaseSettings subclass."""
@@ -1196,12 +1197,12 @@ class TestValidateRealEdgeCases:
     def test_validate_empty_value_parsed_as_empty_skips_type_check(
         self,
         tmp_path: Path,
-        integration_pythonpath: str,
+        integration_env: dict[str, str],
     ) -> None:
         """EC-01: an empty value (KEY=) is EMPTY status, so an int field passes."""
         result = _run_validate(
             tmp_path=tmp_path,
-            integration_pythonpath=integration_pythonpath,
+            integration_env=integration_env,
             settings_src='''
                 from pydantic_settings import BaseSettings
 


### PR DESCRIPTION
## Summary

CI/release-integrity fixes — closes #331/#332/#334/#365/#374 and the CI findings of #348.

| Fix | What | Verified |
|---|---|---|
| **#331** | 22 integration-test subprocess calls built a bare `env={"PYTHONPATH":…}` that stripped PATH/HOME → child couldn't resolve `uv`/`dotenvx`/`sops`. Now `os.environ.copy()` + overlay. | ✅ **38 tests pass** |
| **#332** | CI pinned `hashicorp/vault:2.0` — an **invalid tag** — while compose used `1.18`. Align both to `1.18`; add `user: root` to compose for setcap/IPC_LOCK parity. | ✅ YAML + integration job |
| **#334** | `install.sh`/`install.ps1` **failed open** on missing/absent/unverifiable checksums. Now **fail closed** (abort) with an explicit `--insecure-skip-checksum` opt-out; `agent-release.yml` now emits a `sha256sum checksums.txt` over the assets (the URL the installers already fetch). | ✅ `bash -n`; ⚠️ ps1 + agent-release review-only |
| **#365** | Pin all 6 third-party actions in `publish.yml` (the `id-token:write` trusted-publish job) to **verified** 40-char commit SHAs (each checked via `gh api`, matches its tag comment). No placeholder SHAs. | ✅ SHAs verified |
| **#374** | `integration-tests.yml` removed the GCP key only on success; now a cleanup step runs **on failure too** (no plaintext key left on disk). | ⚠️ gcp job |
| **#348 (CI)** | `publish.yml` now publishes only from a bare-semver `v*` tag — a job-level guard rejects `vscode-*`/`agent-*` tags and arbitrary `workflow_dispatch` refs; `vscode-release.yml` drops `continue-on-error` so a Marketplace failure surfaces (gated on `VSCE_PAT`). | ⚠️ release-only review |

## ⚠️ For your review (couldn't be executed locally — these run only on tags)
- **`publish.yml`, `agent-release.yml`, `vscode-release.yml`** changes are **review-validated only** (YAML parses + reviewed; they don't run on a PR). Please eyeball the publish guard and the `checksums.txt` step before the next release.
- **install.ps1** validated by review (no PowerShell on the runner).
- **#365 scope:** only `publish.yml` (the trusted-publish job) is SHA-pinned. `agent-release.yml`/`vscode-release.yml` still use tag refs — consistent with the issue's scope, but flag if you want full supply-chain pinning.
- Pre-existing yamllint trailing-space warnings in `integration-tests.yml` are untouched.

PR-CI workflow, `install.sh`, and the #331 tests are validated here.

Closes #331
Closes #332
Closes #334
Closes #365
Closes #374

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bundles six CI/release-integrity fixes: subprocess environments in integration tests now inherit `PATH`/`HOME` via `os.environ.copy()` (fixing silent tool-resolution failures), the vault image tag is aligned to `1.18` across CI and compose, the installer checksum step is now fail-closed with an explicit opt-out flag, `publish.yml` third-party actions are pinned to 40-char commit SHAs, a `trap cleanup EXIT` ensures the GCP service-account key is always shredded, and a belt-and-suspenders semver guard prevents accidental PyPI publishes from non-release tags.

- **`integration_env` fixture** (`conftest.py`): replaces all 22 bare `{\"PYTHONPATH\": ...}` subprocess envs with `os.environ.copy()` + overlay, backed by a dedicated regression test that asserts `PATH` and `HOME` survive into the child process.
- **Fail-closed checksums** (`install.sh`, `install.ps1`): missing or unverifiable checksums now call `die`/`Stop-WithError` rather than silently continuing; `--insecure-skip-checksum` / `-InsecureSkipChecksum` provide an explicit, documented opt-out; `agent-release.yml` emits the `checksums.txt` the installers consume.
- **`publish.yml` guards**: tag filter narrowed to `v[0-9]*`, a job-level `if:` blocks non-semver refs, and a regex step rejects anything not matching `vX.Y.Z` exactly.

<h3>Confidence Score: 5/5</h3>

All changes are targeted bug fixes with no new code paths that introduce incorrect behaviour; safe to merge.

Each fix is narrow in scope and well-evidenced: the subprocess-env bug is guarded by a dedicated regression test, the checksum hardening is symmetric across bash and PowerShell, the GCP key trap is a standard POSIX pattern, the vault image tag is now consistent between CI and compose, and the publish guards have two independent layers. No pre-existing behaviour is regressed and no new failure modes are introduced.

No files require special attention. The release-path changes in publish.yml, agent-release.yml, and vscode-release.yml can only be exercised on real tags, so a quick manual eyeball of the publish guard and checksum-upload step before the next release is the only remaining verification gap acknowledged in the PR description.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| tests/integration/conftest.py | Adds `integration_env` fixture that builds subprocess env from `os.environ.copy()` + PYTHONPATH overlay, fixing the #331 PATH/HOME stripping bug across all 22 call sites. |
| install.sh | Adds `SKIP_CHECKSUM` flag and hardens `verify_checksum` to `die` on missing/unverifiable checksums; `SKIP_CHECKSUM=0` default at script top prevents accidental env-variable bypass. |
| install.ps1 | PowerShell mirror of the bash hardening: adds `-InsecureSkipChecksum` param and `ENVDRIFT_INSECURE_SKIP_CHECKSUM` env var; `Test-Checksum` now calls `Stop-WithError` instead of silently skipping. |
| .github/workflows/publish.yml | Tag filter narrowed to `v[0-9]*`, publish job guarded with `if:` and a regex belt-and-suspenders step, all six third-party actions pinned to verified 40-char SHAs. |
| .github/workflows/integration-tests.yml | Vault image corrected from invalid `2.0` to `1.18`; GCP key cleanup moved to a `trap cleanup EXIT` so the plaintext key is always shredded on test failure as well as success. |
| .github/workflows/agent-release.yml | Adds a Generate checksums step: `rm -f checksums.txt` before `sha256sum *` prevents stale hashes on retry; output file is uploaded alongside binaries for installer verification. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.github/workflows/agent-release.yml`, line 54-106 ([link](https://github.com/jainal09/envdrift/blob/e50c5a761a7ea2ac2a81eaa532f4fbf51f84dbe5/.github/workflows/agent-release.yml#L54-L106)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Unpinned action tags in the same release workflow**

   `publish.yml` now uses verified 40-char commit SHAs for all its third-party actions (the fix for #365), but `agent-release.yml` still uses floating tag refs (`actions/checkout@v6`, `actions/setup-go@v6`, `actions/upload-artifact@v7`, `actions/download-artifact@v8`, `softprops/action-gh-release@v3`). This means the agent-release job can have its actions silently updated by the upstream maintainer without any review — the same supply-chain risk the SHA-pinning effort was addressing. The PR description notes this is intentionally out of scope for the current issue, but it's worth tracking for a follow-up.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (4): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/ci-release"](https://github.com/jainal09/envdrift/commit/fa8fe6443b1bdaec06e4fb768436c03b7d34bc7e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36000840)</sub>

<!-- /greptile_comment -->