### PR TITLE
fix(ci): gate vscode publish on env, not secrets, in step if

### DIFF
--- a/.github/workflows/vscode-release.yml
+++ b/.github/workflows/vscode-release.yml
@@ -142,6 +142,12 @@ jobs:
     name: Publish to Marketplace
     runs-on: ubuntu-latest
     needs: release
+    # `secrets` is not available in a step `if:` (causes "Unrecognized named-value:
+    # 'secrets'"), which breaks workflow validation when release-please.yml reuses
+    # this file. Expose the PAT as job-level env so the publish step can gate on
+    # `env.VSCE_PAT` instead.
+    env:
+      VSCE_PAT: ${{ secrets.VSCE_PAT }}
     # Only publish stable releases to marketplace (no -rc, -beta, -alpha suffixes)
     # Use tag from release job instead of github.ref_name, which is 'main' in workflow_call runs
     if: ${{ !contains(needs.release.outputs.tag, '-rc') && !contains(needs.release.outputs.tag, '-beta') && !contains(needs.release.outputs.tag, '-alpha') }}
@@ -179,8 +185,9 @@ jobs:
       - name: Publish to VS Code Marketplace
         # Skip cleanly when the PAT is not configured, but do NOT swallow a real
         # publish failure (expired/insufficient PAT, network, etc.) — those must
-        # fail the job so a silent non-publish is visible.
-        if: ${{ secrets.VSCE_PAT != '' }}
+        # fail the job so a silent non-publish is visible. Gate on env (job-level)
+        # rather than secrets, which is not a valid context in a step `if:`.
+        if: ${{ env.VSCE_PAT != '' }}
         run: npx vsce publish --packagePath ../release/envdrift-${{ steps.version.outputs.VERSION }}.vsix
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}


### PR DESCRIPTION
## Problem
`release-please` has been failing on every run since the merge batch (5×), so the release PR #396 stopped updating and is stale/behind main. The dispatch error:

```
./.github/workflows/vscode-release.yml (Line 183): Unrecognized named-value: 'secrets'.
  ...within expression: secrets.VSCE_PAT != ''
```

`release-please.yml` reuses `vscode-release.yml` via `uses:`, so GitHub validates it at parse time. A step-level `if: secrets.VSCE_PAT != ''` is invalid (`secrets` isn't a valid context in a step `if:`), which broke validation of the **entire** release-please workflow. Introduced by #394.

## Fix
Expose `VSCE_PAT` as **job-level env** on the `publish` job and gate the publish step on `env.VSCE_PAT != ''`. Same behavior (skip cleanly when the PAT is unconfigured; fail loudly on a real publish error), valid syntax.

Unblocks release-please so #396 (release 10.13.7) can regenerate and be cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the VS Code extension release workflow to ensure reliable publishing process without validation issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a GitHub Actions workflow validation error introduced by #394, where using `secrets.VSCE_PAT` in a step-level `if:` condition broke parse-time validation of `release-please.yml` (which reuses this workflow via `workflow_call`). The fix lifts `VSCE_PAT` into a job-level `env:` block and gates the publish step on `env.VSCE_PAT != ''` instead.

- Adds `env.VSCE_PAT: ${{ secrets.VSCE_PAT }}` at the `publish` job level so the value is accessible through the `env` context, which is a valid context in step `if:` expressions.
- Changes the publish step's guard from `secrets.VSCE_PAT != ''` → `env.VSCE_PAT != ''`, unblocking workflow validation and unblocking the stalled release-please run.
- The step-level `env.VSCE_PAT: ${{ secrets.VSCE_PAT }}` that was already present is now redundant (the step inherits the value from the job env), but it is harmless.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is minimal, targeted, and directly unblocks the broken release-please workflow.

The change is a single, well-understood workaround for a GitHub Actions context restriction. Moving the secret into a job-level env and referencing it via `env.VSCE_PAT` in the step `if:` is the canonical fix for this class of problem. The publish behavior is preserved exactly: the step is skipped when the PAT is absent and runs (and can fail loudly) when it is present.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/vscode-release.yml | Moves VSCE_PAT exposure from a step-level secrets reference (invalid in reusable workflow step `if:`) to a job-level env block, then gates the publish step on `env.VSCE_PAT != ''`; fixes CI validation failure. The step-level `env.VSCE_PAT` is now redundant but harmless. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant RP as release-please.yml
    participant VR as vscode-release.yml (publish job)
    participant GH as GitHub Actions parser

    Note over RP,GH: Before fix — validation failure
    RP->>GH: workflow_call vscode-release.yml
    GH->>VR: "Parse step if: secrets.VSCE_PAT != ''"
    GH-->>RP: ❌ Unrecognized named-value: 'secrets'

    Note over RP,GH: After fix — valid syntax
    RP->>GH: workflow_call vscode-release.yml
    GH->>VR: "Parse job env: VSCE_PAT = secrets.VSCE_PAT"
    GH->>VR: "Parse step if: env.VSCE_PAT != ''"
    GH-->>RP: ✅ Workflow validation passes
    VR->>VR: "env.VSCE_PAT == '' → skip publish step"
    VR->>VR: "env.VSCE_PAT != '' → run npx vsce publish"
```

<sub>Reviews (1): Last reviewed commit: ["fix(ci): gate vscode publish on env, not..."](https://github.com/jainal09/envdrift/commit/db70a1b55e3d1f08d53dd03f965808e7f6cdaaf5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36050210)</sub>

<!-- /greptile_comment -->