### PR TITLE
fix(sync): validate DOTENV_PRIVATE_KEY env suffix on vault pull

### DIFF
--- a/docs/cli/vault-pull.md
+++ b/docs/cli/vault-pull.md
@@ -77,7 +77,11 @@ Name of the secret to fetch from the vault.
 `.env.<env>` file is decrypted unless `--no-decrypt` is used.
 
 The secret value may be stored as either `DOTENV_PRIVATE_KEY_<ENV>=<value>`
-(the format written by `vault-push`) or a bare value — both are handled.
+(the format written by `vault-push`) or a bare value — both are handled. When
+the stored value carries a `DOTENV_PRIVATE_KEY_<SUFFIX>=` prefix, the `<SUFFIX>`
+must match `--env`; a mismatch (e.g. a `DOTENV_PRIVATE_KEY_STAGING=` value pulled
+with `--env production`) is rejected rather than silently relabeled, so a key
+for one environment is never installed as another.
 
 ### `--no-decrypt`
 

--- a/src/envdrift/sync/engine.py
+++ b/src/envdrift/sync/engine.py
@@ -112,7 +112,7 @@ class SyncEngine:
             effective_key_name = f"DOTENV_PRIVATE_KEY_{effective_environment.upper()}"
 
             # Fetch secret from vault
-            vault_value = self._fetch_vault_secret(mapping)
+            vault_value = self._fetch_vault_secret(mapping, effective_environment)
             vault_preview = redact_value(vault_value)
 
             # Check for ephemeral mode - skip local file operations
@@ -251,8 +251,18 @@ class SyncEngine:
                 error=str(e),
             )
 
-    def _fetch_vault_secret(self, mapping: ServiceMapping) -> str:
-        """Fetch secret from vault."""
+    def _fetch_vault_secret(self, mapping: ServiceMapping, effective_environment: str) -> str:
+        """Fetch secret from vault.
+
+        ``effective_environment`` is the environment the value will be installed
+        as (derived from the detected ``.env.<env>`` file). When the vault value
+        is a full ``DOTENV_PRIVATE_KEY_<SUFFIX>=...`` line we strip the prefix so
+        it converges with the locally-stored value (#356) — but only after
+        confirming ``<SUFFIX>`` matches the target environment. A mismatch means
+        a key labeled for one environment would be silently relabeled and
+        installed as another (e.g. staging key written as production), so we
+        raise instead of stripping (#348).
+        """
         secret = self.vault_client.get_secret(mapping.secret_name)
         value = secret.value
 
@@ -267,9 +277,16 @@ class SyncEngine:
             (value[0] == '"' and value[-1] == '"') or (value[0] == "'" and value[-1] == "'")
         ):
             value = value[1:-1]
-        match = re.match(r"^DOTENV_PRIVATE_KEY_[A-Za-z0-9_]+=(.+)$", value)
+        match = re.match(r"^DOTENV_PRIVATE_KEY_([A-Za-z0-9_]+)=(.+)$", value)
         if match:
-            value = match.group(1)
+            suffix = match.group(1)
+            if suffix.upper() != effective_environment.upper():
+                raise VaultError(
+                    f"vault key labeled for environment {suffix.upper()} cannot be "
+                    f"installed as environment {effective_environment.upper()} "
+                    f"(secret {mapping.secret_name!r})"
+                )
+            value = match.group(2)
 
         return value
 

--- a/tests/integration/test_e2e_workflows.py
+++ b/tests/integration/test_e2e_workflows.py
@@ -213,16 +213,23 @@ class TestMonorepoMultiService:
             "web": "e2e-test/monorepo/web-key",
         }
 
+        # Each service uses a plain ``.env`` (which resolves to the ``production``
+        # environment), so the vault-stored key line is labeled
+        # ``DOTENV_PRIVATE_KEY_PRODUCTION`` to match. envdrift now rejects a key
+        # whose ``DOTENV_PRIVATE_KEY_<SUFFIX>`` doesn't match the target
+        # environment (so a staging key can't be installed as production), so the
+        # label must agree with the file's environment — anything else is the
+        # cross-environment misinstall guarded against in test_sync_engine.py.
         for service_name, secret_name in services.items():
             try:
                 aws_secrets_client.create_secret(
                     Name=secret_name,
-                    SecretString=f"DOTENV_PRIVATE_KEY_{service_name.upper()}=key-{service_name}-123",
+                    SecretString=f"DOTENV_PRIVATE_KEY_PRODUCTION=key-{service_name}-123",
                 )
             except aws_secrets_client.exceptions.ResourceExistsException:
                 aws_secrets_client.put_secret_value(
                     SecretId=secret_name,
-                    SecretString=f"DOTENV_PRIVATE_KEY_{service_name.upper()}=key-{service_name}-123",
+                    SecretString=f"DOTENV_PRIVATE_KEY_PRODUCTION=key-{service_name}-123",
                 )
 
         # Step 2: Create monorepo structure

--- a/tests/unit/test_sync_engine.py
+++ b/tests/unit/test_sync_engine.py
@@ -843,14 +843,20 @@ class TestSyncEngineFetchVaultSecret:
         assert "DOTENV_PRIVATE_KEY_PRODUCTION=actual_secret" in content
         assert "DOTENV_PRIVATE_KEY_PRODUCTION=DOTENV_PRIVATE_KEY" not in content
 
-    def test_strips_any_key_prefix_from_value(
+    def test_rejects_cross_environment_key_prefix(
         self, mock_vault_client: MagicMock, tmp_path: Path
     ) -> None:
-        """Test that any DOTENV_PRIVATE_KEY_*= prefix is stripped from vault value."""
-        # Vault stores key with different environment than config
+        """#348: a vault value labeled for one environment must NOT be relabeled.
+
+        A ``DOTENV_PRIVATE_KEY_STAGING=...`` value fetched for a ``production``
+        mapping previously had its prefix stripped and was re-written as
+        ``DOTENV_PRIVATE_KEY_PRODUCTION=...`` — silently installing the staging
+        key as the production key. The engine must error instead.
+        """
+        # Vault stores a key labeled STAGING, mapping targets production.
         mock_vault_client.get_secret.return_value = SecretValue(
             name="test-key",
-            value="DOTENV_PRIVATE_KEY_SOAK=actual_secret",
+            value="DOTENV_PRIVATE_KEY_STAGING=actual_secret",
         )
 
         service_dir = tmp_path / "service1"
@@ -868,12 +874,75 @@ class TestSyncEngineFetchVaultSecret:
         )
 
         engine = SyncEngine(config=config, vault_client=mock_vault_client)
-        engine.sync_all()
+        result = engine.sync_all()
 
+        # Mismatch -> ERROR, and NOTHING is written under the production label.
+        assert result.services[0].action == SyncAction.ERROR
+        assert result.services[0].error is not None
+        assert "STAGING" in result.services[0].error
+        assert "PRODUCTION" in result.services[0].error
+        assert not (service_dir / ".env.keys").exists()
+
+    def test_matching_environment_key_prefix_is_stripped(
+        self, mock_vault_client: MagicMock, tmp_path: Path
+    ) -> None:
+        """#348: when the suffix matches the target env, strip and write normally."""
+        mock_vault_client.get_secret.return_value = SecretValue(
+            name="test-key",
+            value="DOTENV_PRIVATE_KEY_PRODUCTION=actual_secret",
+        )
+
+        service_dir = tmp_path / "service1"
+        service_dir.mkdir()
+        (service_dir / ".env.production").write_text("DB_URL=encrypted:xyz\n")
+
+        config = SyncConfig(
+            mappings=[
+                ServiceMapping(
+                    secret_name="test-key",
+                    folder_path=service_dir,
+                    environment="production",
+                ),
+            ],
+        )
+
+        engine = SyncEngine(config=config, vault_client=mock_vault_client)
+        result = engine.sync_all()
+
+        assert result.services[0].action == SyncAction.CREATED
         content = (service_dir / ".env.keys").read_text()
-        # Should strip the SOAK prefix and write with PRODUCTION key
         assert "DOTENV_PRIVATE_KEY_PRODUCTION=actual_secret" in content
-        assert "DOTENV_PRIVATE_KEY_SOAK" not in content
+        assert "DOTENV_PRIVATE_KEY_PRODUCTION=DOTENV_PRIVATE_KEY" not in content
+
+    def test_bare_value_without_prefix_is_unaffected(
+        self, mock_vault_client: MagicMock, tmp_path: Path
+    ) -> None:
+        """#348: a bare value (no DOTENV_PRIVATE_KEY_* prefix) is written as-is."""
+        mock_vault_client.get_secret.return_value = SecretValue(
+            name="test-key",
+            value="actual_secret",
+        )
+
+        service_dir = tmp_path / "service1"
+        service_dir.mkdir()
+        (service_dir / ".env.production").write_text("DB_URL=encrypted:xyz\n")
+
+        config = SyncConfig(
+            mappings=[
+                ServiceMapping(
+                    secret_name="test-key",
+                    folder_path=service_dir,
+                    environment="production",
+                ),
+            ],
+        )
+
+        engine = SyncEngine(config=config, vault_client=mock_vault_client)
+        result = engine.sync_all()
+
+        assert result.services[0].action == SyncAction.CREATED
+        content = (service_dir / ".env.keys").read_text()
+        assert "DOTENV_PRIVATE_KEY_PRODUCTION=actual_secret" in content
 
     def test_strips_lowercase_key_prefix_from_value(
         self, mock_vault_client: MagicMock, tmp_path: Path
@@ -971,17 +1040,30 @@ class TestSyncEngineFetchVaultSecret:
         mapping = ServiceMapping(secret_name="test-key", folder_path=tmp_path)
         engine = SyncEngine(config=SyncConfig(mappings=[mapping]), vault_client=client)
 
-        assert engine._fetch_vault_secret(mapping) == secret
+        assert engine._fetch_vault_secret(mapping, "production") == secret
 
     def test_fetch_vault_secret_quoted_full_line_strips_prefix(self, tmp_path: Path) -> None:
         """#356 review: a quoted full `KEY=value` line strips quotes BEFORE the
-        DOTENV_PRIVATE_KEY_*= prefix, so the prefix doesn't leak; whitespace too."""
+        DOTENV_PRIVATE_KEY_*= prefix, so the prefix doesn't leak; whitespace too.
+
+        The prefix suffix (PROD) matches the effective environment, so it strips.
+        """
         secret = "abc" + "123"
         client = _StoredVaultClient({"k": f'  "DOTENV_PRIVATE_KEY_PROD={secret}"  '})
         mapping = ServiceMapping(secret_name="k", folder_path=tmp_path)
         engine = SyncEngine(config=SyncConfig(mappings=[mapping]), vault_client=client)
 
-        assert engine._fetch_vault_secret(mapping) == secret
+        assert engine._fetch_vault_secret(mapping, "prod") == secret
+
+    def test_fetch_vault_secret_cross_environment_raises(self, tmp_path: Path) -> None:
+        """#348 (direct): a prefix labeled for a different env raises VaultError."""
+        secret = "abc" + "123"
+        client = _StoredVaultClient({"k": f"DOTENV_PRIVATE_KEY_STAGING={secret}"})
+        mapping = ServiceMapping(secret_name="k", folder_path=tmp_path)
+        engine = SyncEngine(config=SyncConfig(mappings=[mapping]), vault_client=client)
+
+        with pytest.raises(VaultError, match=r"STAGING.*PRODUCTION"):
+            engine._fetch_vault_secret(mapping, "production")
 
 
 class TestSyncResult:


### PR DESCRIPTION
Deep-review finding (#348): `_fetch_vault_secret` stripped **any** `DOTENV_PRIVATE_KEY_<ENV>=` prefix and stored the value under the mapping's target environment without validating the suffix — so a vault value labeled e.g. `DOTENV_PRIVATE_KEY_STAGING` could be installed as the **production** key.

Fix: capture the suffix and reject (`VaultError` → `SyncAction.ERROR`) when it doesn't match the effective environment. Load-bearing regression tests added (cross-env → ERROR fails without the fix, passes with it). Part of #348.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a security bug (#348) where `_fetch_vault_secret` would silently strip any `DOTENV_PRIVATE_KEY_<SUFFIX>=` prefix from a vault value regardless of whether the suffix matched the target environment, allowing a staging key to be installed as the production key. The fix captures the suffix with a new regex capture group and rejects mismatches by raising `VaultError`, which the existing `_sync_service` error handler maps to `SyncAction.ERROR`.

- **`engine.py`**: `_fetch_vault_secret` now accepts `effective_environment`, captures the prefix suffix via `match.group(1)`, and raises `VaultError` when the suffix (uppercased) does not equal the target environment (uppercased); a matching suffix still strips normally.
- **`test_sync_engine.py`**: The old \"strip any prefix\" test is replaced by a cross-environment rejection test, and two new direct-call tests cover the matching and bare-value paths.
- **`test_e2e_workflows.py`**: The integration test fixture is updated so vault secrets are labeled `DOTENV_PRIVATE_KEY_PRODUCTION` (matching the plain `.env` file, which resolves to the \"production\" default) instead of `DOTENV_PRIVATE_KEY_{SERVICE_NAME}`.

<h3>Confidence Score: 5/5</h3>

The change is safe to merge — it tightens a validation gate without altering any success path, and the existing VaultError catch block already handles the new raise site correctly.

The fix is narrow and surgical: one new parameter propagated through a single call chain, one extra comparison before an already-idiomatic raise, and three regression tests that would have caught the original bug. All previously passing tests that rely on matching suffixes still pass; the only test that changes behaviour is the one that was documenting the wrong behaviour.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/envdrift/sync/engine.py | Core fix: `_fetch_vault_secret` now validates the env suffix before stripping the `DOTENV_PRIVATE_KEY_<SUFFIX>=` prefix; mismatches raise `VaultError` which is caught upstream and mapped to `SyncAction.ERROR`. |
| tests/unit/test_sync_engine.py | Old "strip any prefix" test replaced with a cross-env rejection test; two new tests cover the matching-suffix path and bare-value path; direct `_fetch_vault_secret` call sites updated to pass `effective_environment`. |
| tests/integration/test_e2e_workflows.py | Vault secret labels corrected from `DOTENV_PRIVATE_KEY_{SERVICE_NAME}` to `DOTENV_PRIVATE_KEY_PRODUCTION` to match the effective environment resolved from plain `.env` files. |
| docs/cli/vault-pull.md | Documentation updated to describe the new suffix-validation behaviour and rejection of mismatched environment labels. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[_sync_service called] --> B[Detect effective_environment from .env file]
    B --> C[Call _fetch_vault_secret with effective_environment]
    C --> D[Fetch raw value from vault]
    D --> E[Strip whitespace and surrounding quotes]
    E --> F{Matches DOTENV_PRIVATE_KEY_SUFFIX= pattern?}
    F -- No --> H[Return bare value as-is]
    F -- Yes --> I{suffix matches effective_environment?}
    I -- Yes --> J[Strip prefix, return value]
    I -- No --> K[Raise VaultError - env mismatch]
    K --> L[_sync_service catches VaultError]
    L --> M[Return SyncAction.ERROR, no file written]
    J --> N[Write .env.keys and return SyncAction.CREATED]
    H --> N
```

<sub>Reviews (2): Last reviewed commit: ["test(sync): label monorepo e2e vault key..."](https://github.com/jainal09/envdrift/commit/5329915144e29e88a0bcf4e5ccd45b7270559bd8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36051851)</sub>

<!-- /greptile_comment -->