### PR TITLE
fix(scanner): structure-aware encryption detection in native scanner

### DIFF
--- a/src/envdrift/scanner/engine.py
+++ b/src/envdrift/scanner/engine.py
@@ -27,9 +27,8 @@ from envdrift.scanner.base import (
 )
 from envdrift.scanner.ignores import IgnoreConfig, IgnoreFilter
 from envdrift.scanner.native import (
-    DOTENVX_MARKERS,
-    SOPS_MARKERS,
     NativeScanner,
+    _content_is_encrypted,
     _is_encrypted_value_line,
 )
 from envdrift.scanner.patterns import hash_secret
@@ -695,11 +694,12 @@ class ScanEngine:
                     # leaked their ciphertext as findings. This matches line_at()
                     # and the native scanner, which both read full content.
                     content = f.read()
-                    # Use markers from native scanner
-                    for marker in DOTENVX_MARKERS + SOPS_MARKERS:
-                        if marker in content:
-                            encrypted_files.add(file_path)
-                            return True
+                    # Structure-aware encryption check (#348): require the dotenvx
+                    # marker in value position / canonical SOPS envelopes, not a bare
+                    # substring (which misfired on plaintext mentioning "encrypted:").
+                    if _content_is_encrypted(content):
+                        encrypted_files.add(file_path)
+                        return True
             except OSError:
                 pass
             return False

--- a/src/envdrift/scanner/native.py
+++ b/src/envdrift/scanner/native.py
@@ -81,9 +81,19 @@ _DOTENVX_VALUE_RE = re.compile(
 # SOPS: a canonical ``ENC[AES256_GCM,...]`` value envelope (dotenv- or YAML-style).
 _SOPS_ENC_RE = re.compile(r"ENC\[AES256_GCM,")
 
-# SOPS: a top-level ``sops:`` mapping key at column 0 (the metadata block YAML/JSON
-# SOPS appends), e.g. ``sops:`` or ``"sops":`` / ``sops_*`` JSON keys.
-_SOPS_TOPLEVEL_RE = re.compile(r"^\"?sops[:_]")
+# SOPS metadata block markers, matched per (non-comment) line. These mirror the
+# canonical set in ``envdrift.encryption.sops.SopsBackend.SOPS_METADATA_PATTERNS``
+# so the scanner and the encryption backend agree on what a real SOPS file is. A
+# bare ``^sops[:_]`` prefix was too loose: it matched plaintext dotenv assignments
+# like ``sops_token=...`` / ``sops_enabled=...`` (vars that merely *start with*
+# ``sops_``), misclassifying an unencrypted file as encrypted (#348). SOPS only
+# emits ``sops_version`` / ``sops_mac`` keys in its dotenv metadata trailer.
+_SOPS_METADATA_RES = (
+    re.compile(r"^sops:\s*$"),  # YAML: top-level ``sops:`` mapping key (col 0)
+    re.compile(r'^\s*"sops"\s*:'),  # JSON: ``"sops":`` (allows indent)
+    re.compile(r"^sops_version\s*="),  # dotenv: flat ``sops_version=``
+    re.compile(r"^sops_mac\s*="),  # dotenv: flat ``sops_mac=``
+)
 
 
 def _line_is_dotenvx_encrypted(line: str) -> bool:
@@ -91,22 +101,40 @@ def _line_is_dotenvx_encrypted(line: str) -> bool:
     return bool(_DOTENVX_VALUE_RE.match(line))
 
 
+def _line_is_sops_metadata(line: str) -> bool:
+    """True if ``line`` is a canonical SOPS metadata-block marker."""
+    return any(pattern.match(line) for pattern in _SOPS_METADATA_RES)
+
+
 def _content_has_sops_markers(content: str) -> bool:
     """True if ``content`` carries canonical SOPS structural markers.
 
-    Requires either an ``ENC[AES256_GCM,...]`` value envelope or a top-level
-    ``sops:``/``sops_*`` metadata key (column 0), not a loose substring match.
+    Requires either an ``ENC[AES256_GCM,...]`` value envelope or a canonical SOPS
+    metadata key (top-level ``sops:`` / ``"sops":`` / ``sops_version=`` /
+    ``sops_mac=``), each on a non-comment line — not a loose substring match and
+    not an arbitrary ``sops_*`` plaintext var. Comment lines are skipped so the
+    SOPS path is consistent with the dotenvx path in ``_content_is_encrypted``.
     """
-    if _SOPS_ENC_RE.search(content):
-        return True
-    return any(_SOPS_TOPLEVEL_RE.match(line) for line in content.splitlines())
+    for line in content.splitlines():
+        if line.lstrip().startswith("#"):
+            continue
+        if _SOPS_ENC_RE.search(line):
+            return True
+        if _line_is_sops_metadata(line):
+            return True
+    return False
 
 
 def _content_is_encrypted(content: str) -> bool:
     """True if ``content`` is dotenvx- or SOPS-encrypted (structure-aware).
 
-    Comment lines (stripped form starts with ``#``) never count, and the dotenvx
-    marker must sit in value position on an assignment line.
+    Comment lines (stripped form starts with ``#``) never count on any path, so
+    the dotenvx, SOPS-envelope, and SOPS-metadata checks stay consistent: a plain
+    comment that merely *mentions* ``encrypted:`` / ``ENC[AES256_GCM,`` / ``sops:``
+    does not suppress the unencrypted-file policy (#348). The dotenvx marker must
+    sit in value position on an assignment line; SOPS detection (envelope or
+    canonical metadata key) is delegated to ``_content_has_sops_markers``, which
+    applies the same comment filter.
     """
     for line in content.splitlines():
         if line.lstrip().startswith("#"):

--- a/src/envdrift/scanner/native.py
+++ b/src/envdrift/scanner/native.py
@@ -64,6 +64,58 @@ SOPS_MARKERS = (
     "ENC[AES256_GCM,",
 )
 
+# Structure-aware encryption detection (#348). A bare ``"encrypted:" in content``
+# / ``"sops:" in content`` substring check misfires on plaintext that merely
+# mentions the marker — e.g. a comment ``# this is not encrypted: true`` or a
+# value ``MESSAGE=not encrypted: yes`` would suppress the unencrypted-env-file
+# policy and hide a real leak. We instead require the marker in its real
+# structural position.
+
+# dotenvx: ``encrypted:`` must be the (optionally quoted) start of an assignment's
+# *value* — ``NAME="encrypted:..."`` / ``NAME=encrypted:...`` — not anywhere in the
+# line (and never inside a comment line, which is excluded separately).
+_DOTENVX_VALUE_RE = re.compile(
+    r"^\s*[A-Za-z_][A-Za-z0-9_]*\s*=\s*[\"']?encrypted:",
+)
+
+# SOPS: a canonical ``ENC[AES256_GCM,...]`` value envelope (dotenv- or YAML-style).
+_SOPS_ENC_RE = re.compile(r"ENC\[AES256_GCM,")
+
+# SOPS: a top-level ``sops:`` mapping key at column 0 (the metadata block YAML/JSON
+# SOPS appends), e.g. ``sops:`` or ``"sops":`` / ``sops_*`` JSON keys.
+_SOPS_TOPLEVEL_RE = re.compile(r"^\"?sops[:_]")
+
+
+def _line_is_dotenvx_encrypted(line: str) -> bool:
+    """True if ``line`` assigns an actual dotenvx-encrypted value."""
+    return bool(_DOTENVX_VALUE_RE.match(line))
+
+
+def _content_has_sops_markers(content: str) -> bool:
+    """True if ``content`` carries canonical SOPS structural markers.
+
+    Requires either an ``ENC[AES256_GCM,...]`` value envelope or a top-level
+    ``sops:``/``sops_*`` metadata key (column 0), not a loose substring match.
+    """
+    if _SOPS_ENC_RE.search(content):
+        return True
+    return any(_SOPS_TOPLEVEL_RE.match(line) for line in content.splitlines())
+
+
+def _content_is_encrypted(content: str) -> bool:
+    """True if ``content`` is dotenvx- or SOPS-encrypted (structure-aware).
+
+    Comment lines (stripped form starts with ``#``) never count, and the dotenvx
+    marker must sit in value position on an assignment line.
+    """
+    for line in content.splitlines():
+        if line.lstrip().startswith("#"):
+            continue
+        if _line_is_dotenvx_encrypted(line):
+            return True
+    return _content_has_sops_markers(content)
+
+
 # Default patterns to ignore - comprehensive list for all major languages and tools
 DEFAULT_IGNORE_PATTERNS = (
     # Env file examples/templates
@@ -790,17 +842,11 @@ class NativeScanner(ScannerBackend):
         Returns:
             True if encryption markers are present.
         """
-        # Check dotenvx markers
-        for marker in DOTENVX_MARKERS:
-            if marker in content:
-                return True
-
-        # Check SOPS markers
-        for marker in SOPS_MARKERS:
-            if marker in content:
-                return True
-
-        return False
+        # Structure-aware (#348): the dotenvx ``encrypted:`` marker must appear in
+        # value position on an assignment line (not in a comment or arbitrary text),
+        # and SOPS needs its canonical envelope/top-level metadata key — a bare
+        # substring match falsely suppressed the unencrypted-env-file policy.
+        return _content_is_encrypted(content)
 
     def _has_sops_markers(self, content: str) -> bool:
         """Return True if content has SOPS encryption markers.
@@ -810,7 +856,7 @@ class NativeScanner(ScannerBackend):
         positives. Used to skip pattern scanning for them while still scanning
         dotenvx combined files line-by-line.
         """
-        return any(marker in content for marker in SOPS_MARKERS)
+        return _content_has_sops_markers(content)
 
     def _scan_patterns(self, file_path: Path, content: str) -> list[ScanFinding]:
         """Scan content for secret patterns.

--- a/tests/scanner/test_engine.py
+++ b/tests/scanner/test_engine.py
@@ -1351,6 +1351,56 @@ class TestFilterEncryptedFiles:
         result = engine._filter_encrypted_files([cleartext_finding])
         assert result == [cleartext_finding]
 
+    def test_filter_keeps_lineless_finding_in_plaintext_file_mentioning_marker(self, tmp_path):
+        """#348 engine regression: a plaintext file that merely *mentions* an
+        encryption marker must NOT have its findings dropped as "encrypted".
+
+        ``_filter_encrypted_files`` drops findings from files it deems encrypted
+        when the finding has no line info (the external-scanner ciphertext-blob
+        case). The old code used ``marker in content`` over ``DOTENVX_MARKERS +
+        SOPS_MARKERS``, so a plaintext env file whose comment said
+        ``# this file is not encrypted: yet`` (or a value ``NOTE=ask sops:``) was
+        classed as encrypted and a real lineless finding was silently dropped — a
+        false negative that hides a leak. The structure-aware
+        ``_content_is_encrypted`` delegation classes the file as plaintext, so the
+        finding survives.
+
+        Load-bearing for the engine.py change specifically: reverting
+        ``is_file_encrypted`` to the substring loop (while keeping native.py)
+        makes ``is_file_encrypted`` return True here, dropping the lineless
+        finding and failing this assertion. A line-numbered finding would survive
+        either way (the line-aware filter keeps cleartext lines), so the lineless
+        shape is what exercises the drop path.
+        """
+        config = GuardConfig(use_native=True, use_gitleaks=False)
+        engine = ScanEngine(config)
+
+        plaintext = tmp_path / ".env.production"
+        # Comment mentions ``encrypted:`` and a value mentions ``sops:`` mid-line —
+        # both are loose substrings the old loop matched, but neither is a real
+        # structural marker. The file is genuinely plaintext.
+        plaintext.write_text(
+            "# remember: this file is not encrypted: yet\n"  # line 1
+            "NOTE=ask sops: team about rotation\n"  # line 2
+            "API_KEY=plaintext-leak\n"  # line 3
+        )
+
+        finding = ScanFinding(
+            file_path=plaintext,
+            line_number=None,  # external-scanner blob: no line info -> drop path
+            rule_id="high-entropy-string",
+            rule_description="entropy",
+            description="secret in plaintext file mentioning a marker",
+            severity=FindingSeverity.HIGH,
+            scanner="detect-secrets",
+        )
+
+        result = engine._filter_encrypted_files([finding])
+        assert result == [finding], (
+            "a finding in a plaintext file that only mentions 'encrypted:'/'sops:' "
+            "must survive the encrypted-file filter (must not be dropped as a false negative)"
+        )
+
 
 class TestFilterPublicKeys:
     """Tests for _filter_public_keys (#370).

--- a/tests/scanner/test_native.py
+++ b/tests/scanner/test_native.py
@@ -466,6 +466,59 @@ class TestStructureAwareEncryptionDetection:
         unencrypted = [f for f in result.findings if f.rule_id == "unencrypted-env-file"]
         assert len(unencrypted) == 1, "inline 'sops:' must not suppress the policy"
 
+    def test_var_starting_with_sops_underscore_does_not_suppress(
+        self, scanner: NativeScanner, tmp_path: Path
+    ):
+        """A plaintext var like ``sops_token=...`` must NOT mark the file encrypted.
+
+        Regression for the over-loose ``^sops[:_]`` marker: SOPS only emits
+        ``sops_version`` / ``sops_mac`` keys in its dotenv metadata trailer, so a
+        user var that merely *starts with* ``sops_`` (``sops_token``,
+        ``sops_enabled``, ...) is plaintext and must still be flagged.
+        """
+        env_file = tmp_path / ".env"
+        env_file.write_text("sops_token=plaintext-leak\nsops_enabled=true\n")
+
+        result = scanner.scan([tmp_path])
+
+        unencrypted = [f for f in result.findings if f.rule_id == "unencrypted-env-file"]
+        assert len(unencrypted) == 1, "a var starting with 'sops_' must not suppress the policy"
+
+    def test_comment_mentioning_enc_envelope_does_not_suppress(
+        self, scanner: NativeScanner, tmp_path: Path
+    ):
+        """A comment mentioning ``ENC[AES256_GCM,`` must NOT mark the file encrypted.
+
+        Regression for the SOPS-envelope path being unfiltered for comments while
+        the dotenvx path skipped them: a doc comment describing the SOPS ciphertext
+        envelope must not suppress the unencrypted-env-file policy.
+        """
+        env_file = tmp_path / ".env"
+        env_file.write_text(
+            "# SOPS wraps ciphertext as ENC[AES256_GCM,data:...,type:str]\n"
+            "DB_PASSWORD=plaintext-leak\n"
+        )
+
+        result = scanner.scan([tmp_path])
+
+        unencrypted = [f for f in result.findings if f.rule_id == "unencrypted-env-file"]
+        assert len(unencrypted) == 1, "a comment mentioning 'ENC[AES256_GCM,' must not suppress"
+
+    def test_genuine_sops_dotenv_metadata_still_encrypted(
+        self, scanner: NativeScanner, tmp_path: Path
+    ):
+        """A real SOPS dotenv file (``sops_version=`` / ``sops_mac=`` trailer) stays encrypted."""
+        env_file = tmp_path / ".env"
+        env_file.write_text(
+            "DATABASE_URL=ENC[AES256_GCM,data:xyz789,type:str]\n"
+            "sops_version=3.7.0\n"
+            "sops_mac=ENC[AES256_GCM,data:abc,type:str]\n"
+        )
+
+        result = scanner.scan([tmp_path])
+
+        assert not [f for f in result.findings if f.rule_id == "unencrypted-env-file"]
+
     def test_genuine_dotenvx_file_still_encrypted(self, scanner: NativeScanner, tmp_path: Path):
         """A real dotenvx-encrypted value (``KEY="encrypted:BASE64..."``) is still encrypted."""
         env_file = tmp_path / ".env"

--- a/tests/scanner/test_native.py
+++ b/tests/scanner/test_native.py
@@ -400,6 +400,96 @@ sops:
         assert not [f for f in result.findings if f.rule_id == "unencrypted-env-file"]
 
 
+class TestStructureAwareEncryptionDetection:
+    """Structure-aware encryption marker detection (#348).
+
+    A bare substring check (``"encrypted:" in content`` / ``"sops:" in content``)
+    falsely treated plaintext that merely *mentions* a marker as encrypted, which
+    suppressed the unencrypted-env-file / unencrypted-secret-file policy and hid a
+    real leak. Detection must require the marker in its real structural position:
+    the dotenvx marker in value position on an assignment line (never a comment),
+    and SOPS via a canonical ``ENC[AES256_GCM,...]`` envelope or a top-level
+    ``sops:`` metadata key.
+    """
+
+    @pytest.fixture
+    def scanner(self) -> NativeScanner:
+        """Create a native scanner instance."""
+        return NativeScanner()
+
+    def test_comment_mentioning_marker_does_not_suppress(
+        self, scanner: NativeScanner, tmp_path: Path
+    ):
+        """A comment ``# ... not encrypted: true`` must NOT mark the file encrypted."""
+        env_file = tmp_path / ".env"
+        env_file.write_text(
+            "# this is not encrypted: true\nDATABASE_URL=postgres://user:hunter2@localhost/db\n"
+        )
+
+        result = scanner.scan([tmp_path])
+
+        unencrypted = [f for f in result.findings if f.rule_id == "unencrypted-env-file"]
+        assert len(unencrypted) == 1, "comment mentioning 'encrypted:' must not suppress the policy"
+
+    def test_comment_marker_in_secret_file_still_flagged(
+        self, scanner: NativeScanner, tmp_path: Path
+    ):
+        """A plaintext .secret with a misleading comment stays unencrypted-secret-file."""
+        secret = tmp_path / ".env.production.secret"
+        secret.write_text("# this is not encrypted: true\nAPI_KEY=plaintext-leak\n")
+
+        result = scanner.scan([tmp_path])
+
+        secret_findings = [f for f in result.findings if f.rule_id == "unencrypted-secret-file"]
+        assert len(secret_findings) == 1
+        assert secret_findings[0].severity == FindingSeverity.CRITICAL
+
+    def test_value_mentioning_marker_does_not_suppress(
+        self, scanner: NativeScanner, tmp_path: Path
+    ):
+        """A value like ``MESSAGE=not encrypted: yes`` must NOT mark the file encrypted."""
+        env_file = tmp_path / ".env"
+        env_file.write_text("MESSAGE=not encrypted: yes\nDB_PASSWORD=hunter2\n")
+
+        result = scanner.scan([tmp_path])
+
+        unencrypted = [f for f in result.findings if f.rule_id == "unencrypted-env-file"]
+        assert len(unencrypted) == 1, "'encrypted:' mid-value must not suppress the policy"
+
+    def test_loose_sops_substring_does_not_suppress(self, scanner: NativeScanner, tmp_path: Path):
+        """A plaintext value mentioning ``sops:`` mid-line must NOT mark file encrypted."""
+        env_file = tmp_path / ".env"
+        env_file.write_text("NOTE=ask sops: about the deploy\nSECRET_KEY=plaintext-leak\n")
+
+        result = scanner.scan([tmp_path])
+
+        unencrypted = [f for f in result.findings if f.rule_id == "unencrypted-env-file"]
+        assert len(unencrypted) == 1, "inline 'sops:' must not suppress the policy"
+
+    def test_genuine_dotenvx_file_still_encrypted(self, scanner: NativeScanner, tmp_path: Path):
+        """A real dotenvx-encrypted value (``KEY="encrypted:BASE64..."``) is still encrypted."""
+        env_file = tmp_path / ".env"
+        env_file.write_text(
+            '#/---[DOTENV_PUBLIC_KEY]---/\nDOTENV_PUBLIC_KEY="abc123"\n'
+            'DATABASE_URL="encrypted:vault1AbCdEfGhIjKlMnOpQrStUvWxYz0123456789"\n'
+        )
+
+        result = scanner.scan([tmp_path])
+
+        assert not [f for f in result.findings if f.rule_id == "unencrypted-env-file"]
+
+    def test_genuine_sops_file_still_encrypted(self, scanner: NativeScanner, tmp_path: Path):
+        """A real SOPS file (ENC[...] envelope + top-level sops:) is still encrypted."""
+        env_file = tmp_path / ".env"
+        env_file.write_text(
+            "DATABASE_URL=ENC[AES256_GCM,data:xyz789,type:str]\nsops:\n    version: 3.7.0\n"
+        )
+
+        result = scanner.scan([tmp_path])
+
+        assert not [f for f in result.findings if f.rule_id == "unencrypted-env-file"]
+
+
 class TestUnencryptedSecretFile:
     """Tests for the dedicated plaintext .secret rule (Severity 2 hard block).
 


### PR DESCRIPTION
Deep-review finding (#348): the native scanner treated any `encrypted:`/SOPS marker substring anywhere in a file as proof it's encrypted, so a plaintext env file containing that substring could suppress the unencrypted-file policy. (Distinct location from #378, which fixed core/partial_encryption.py.)

Fix: structure-aware detection so genuine dotenvx/SOPS files stay encrypted but a plaintext mention doesn't. Load-bearing tests proven fail-without/pass-with. Part of #348.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the loose `marker in content` substring check in both the native scanner and the scan engine with a structure-aware `_content_is_encrypted` function that requires dotenvx's `encrypted:` marker in value position and SOPS markers only in their canonical structural form (ENC envelope or `sops_version`/`sops_mac` metadata keys).

- `native.py` gains `_content_is_encrypted` / `_content_has_sops_markers` backed by targeted regexes; `NativeScanner._is_encrypted` and `_has_sops_markers` are thin delegates to these functions.
- `engine.py` swaps its inline `DOTENVX_MARKERS + SOPS_MARKERS` loop for a single `_content_is_encrypted(content)` call, removing the false-negative that hid lineless findings from plaintext files mentioning the marker.
- Nine new load-bearing tests prove the false-positive cases fail without the fix and pass with it.

<h3>Confidence Score: 5/5</h3>

The change is a targeted false-positive fix with no regressions in the happy path — genuine dotenvx and SOPS files are still detected, and the new structure-aware check is well-guarded by nine load-bearing tests.

Both the native scanner and the engine now consistently delegate to `_content_is_encrypted`, which is thoroughly unit-tested for both false-positive suppression and true-positive preservation. The only leftover is the now-unreferenced `DOTENVX_MARKERS` / `SOPS_MARKERS` constants, which are dead code rather than a correctness issue.

No files require special attention; the dead-code constants in `native.py` are the only item worth a follow-up cleanup.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/envdrift/scanner/native.py | Adds structure-aware `_content_is_encrypted`, `_content_has_sops_markers`, and supporting regexes; replaces the old substring-loop in `NativeScanner._is_encrypted` and `_has_sops_markers`. `DOTENVX_MARKERS` and `SOPS_MARKERS` constants are now unreferenced dead code. |
| src/envdrift/scanner/engine.py | Replaces the old `marker in content` loop with a single `_content_is_encrypted(content)` call in `is_file_encrypted`; removes the now-unused `DOTENVX_MARKERS` / `SOPS_MARKERS` imports and adds `_content_is_encrypted` to the import list. |
| tests/scanner/test_native.py | Adds `TestStructureAwareEncryptionDetection` with 9 load-bearing cases covering false-positive suppression (comments, mid-value markers, `sops_` prefix vars, `ENC[` in comments) and true-positive preservation (genuine dotenvx / SOPS dotenv / SOPS YAML). |
| tests/scanner/test_engine.py | Adds `test_filter_keeps_lineless_finding_in_plaintext_file_mentioning_marker` to exercise the engine-side `is_file_encrypted` path with a lineless finding that the old substring loop would have dropped. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[File content] --> B[_content_is_encrypted]
    B --> C{Iterate non-comment lines\nfor dotenvx check}
    C -->|Line matches\n_DOTENVX_VALUE_RE| D[Return True\n✅ dotenvx encrypted]
    C -->|No match after\nall lines| E[_content_has_sops_markers]
    E --> F{Iterate non-comment lines\nfor SOPS check}
    F -->|_SOPS_ENC_RE match\nENC AES256_GCM| G[Return True\n✅ SOPS encrypted]
    F -->|_line_is_sops_metadata match\nsops_version / sops_mac / sops: / sops JSON| G
    F -->|No match after\nall lines| H[Return False\n🔓 plaintext]

    style D fill:#90EE90
    style G fill:#90EE90
    style H fill:#FFB6C1
```

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/348-native-..."](https://github.com/jainal09/envdrift/commit/e51e514699c6f3def796abf7861905e15e8fe8b5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36051853)</sub>

<!-- /greptile_comment -->