### PR TITLE
fix(sync): atomic_write via mkstemp to block predictable-tmp symlink

### DIFF
--- a/src/envdrift/sync/operations.py
+++ b/src/envdrift/sync/operations.py
@@ -8,6 +8,7 @@ import os
 import re
 import secrets
 import shutil
+import stat
 import tempfile
 from datetime import datetime
 from pathlib import Path
@@ -126,36 +127,52 @@ def atomic_write(path: Path, content: str, permissions: int = 0o600) -> None:
     pre-existing symlink) and applies permissions to the *fd we created* with
     ``os.fchmod`` -- not a path-based ``chmod`` that could be redirected through
     a symlinked sibling. The temp file is then atomically renamed onto ``path``.
-    If the destination already exists, its current mode is preserved instead of
-    unconditionally forcing ``permissions``.
+    If the destination already exists as a *real file*, its current mode is
+    preserved instead of unconditionally forcing ``permissions``; a destination
+    that is a symlink is ignored for mode purposes so a pre-planted symlink
+    cannot inject an overly permissive mode onto the new secret.
     """
     # Ensure parent directory exists
     path.parent.mkdir(parents=True, exist_ok=True)
 
-    # Preserve the destination's existing mode if it already exists; otherwise
-    # use the requested default. Resolve before creating the temp file.
+    # Preserve the destination's existing mode if it already exists as a real
+    # file. Use ``lstat`` (does not follow symlinks) and skip preservation when
+    # the destination is a symlink: an attacker who pre-plants a symlink at the
+    # destination pointing at a 0o777 file they own must not be able to force
+    # that permissive mode onto the freshly written secret.
     mode = permissions
     with contextlib.suppress(FileNotFoundError):
-        mode = path.stat().st_mode & 0o777
+        dest_stat = path.lstat()
+        if not stat.S_ISLNK(dest_stat.st_mode):
+            mode = dest_stat.st_mode & 0o777
 
     fd, tmp_name = tempfile.mkstemp(
         dir=str(path.parent), prefix=f".{path.name}.", suffix=".envdrift-tmp"
     )
     tmp_path = Path(tmp_name)
+    # ``mkstemp`` returns an fd we own. Hand it to ``os.fdopen`` *immediately* so
+    # the wrapper owns it for the entire body and closes it exactly once on
+    # ``__exit__`` (success *or* exception). We never close the fd ourselves --
+    # doing so would either double-close (masking the real error with ``EBADF``
+    # and leaking the temp file) or leak it. ``fchmod`` and ``fsync`` operate on
+    # the same fd via ``fileno()`` while the wrapper still owns it.
     try:
-        # ``os.fchmod`` applies to the fd we own, never a symlink target. It is
-        # absent on Windows, where permission bits are largely a no-op anyway.
-        if hasattr(os, "fchmod"):
-            os.fchmod(fd, mode)
         with os.fdopen(fd, "w") as tmp_file:
+            # ``os.fchmod`` applies to the fd we own, never a symlink target. It
+            # is absent on Windows, where permission bits are largely a no-op.
+            if hasattr(os, "fchmod"):
+                os.fchmod(tmp_file.fileno(), mode)
             tmp_file.write(content)
-        # fdopen has consumed the fd; closing it again would error.
-        fd = -1
+            tmp_file.flush()
+            os.fsync(tmp_file.fileno())
+        # The fdopen wrapper has closed the fd; the rename promotes the temp
+        # file atomically onto the destination (``Path.replace`` delegates to
+        # ``os.replace``).
         tmp_path.replace(path)
     except BaseException:
-        if fd != -1:
-            os.close(fd)
-        # Only ever unlink the temp file we created, never the destination.
+        # The fd is owned/closed by the fdopen wrapper, so we never close it
+        # here. Only ever unlink the temp file we created, never the
+        # destination; suppress its absence so the original error propagates.
         with contextlib.suppress(FileNotFoundError):
             tmp_path.unlink()
         raise

--- a/src/envdrift/sync/operations.py
+++ b/src/envdrift/sync/operations.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import contextlib
 import hashlib
+import os
 import re
 import secrets
 import shutil
+import tempfile
 from datetime import datetime
 from pathlib import Path
 
@@ -118,18 +121,43 @@ def atomic_write(path: Path, content: str, permissions: int = 0o600) -> None:
     """
     Write file atomically with proper permissions.
 
-    Uses a temporary file and rename to ensure atomicity.
+    Creates the temp file in the destination directory with an unguessable name
+    via ``tempfile.mkstemp`` (``O_EXCL``, owned by us, never following a
+    pre-existing symlink) and applies permissions to the *fd we created* with
+    ``os.fchmod`` -- not a path-based ``chmod`` that could be redirected through
+    a symlinked sibling. The temp file is then atomically renamed onto ``path``.
+    If the destination already exists, its current mode is preserved instead of
+    unconditionally forcing ``permissions``.
     """
     # Ensure parent directory exists
     path.parent.mkdir(parents=True, exist_ok=True)
 
-    tmp_path = path.with_suffix(".tmp")
+    # Preserve the destination's existing mode if it already exists; otherwise
+    # use the requested default. Resolve before creating the temp file.
+    mode = permissions
+    with contextlib.suppress(FileNotFoundError):
+        mode = path.stat().st_mode & 0o777
+
+    fd, tmp_name = tempfile.mkstemp(
+        dir=str(path.parent), prefix=f".{path.name}.", suffix=".envdrift-tmp"
+    )
+    tmp_path = Path(tmp_name)
     try:
-        tmp_path.write_text(content)
-        tmp_path.chmod(permissions)
+        # ``os.fchmod`` applies to the fd we own, never a symlink target. It is
+        # absent on Windows, where permission bits are largely a no-op anyway.
+        if hasattr(os, "fchmod"):
+            os.fchmod(fd, mode)
+        with os.fdopen(fd, "w") as tmp_file:
+            tmp_file.write(content)
+        # fdopen has consumed the fd; closing it again would error.
+        fd = -1
         tmp_path.replace(path)
-    except Exception:
-        tmp_path.unlink(missing_ok=True)
+    except BaseException:
+        if fd != -1:
+            os.close(fd)
+        # Only ever unlink the temp file we created, never the destination.
+        with contextlib.suppress(FileNotFoundError):
+            tmp_path.unlink()
         raise
 
 

--- a/tests/unit/test_sync_operations.py
+++ b/tests/unit/test_sync_operations.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -247,37 +248,125 @@ class TestAtomicWrite:
         assert not dest.is_symlink()
 
     @pytest.mark.skipif(os.name == "nt", reason="symlink/fchmod semantics differ on non-POSIX")
-    def test_atomic_write_does_not_use_literal_predictable_tmp_name(self, tmp_path: Path) -> None:
-        """The temp file used is not the literal ``path.with_suffix('.tmp')``.
+    def test_atomic_write_does_not_write_through_predictable_tmp_name(self, tmp_path: Path) -> None:
+        """A symlink planted at the predictable temp name is never written through.
 
-        We block ``os.replace`` from completing so the temp file is left behind,
-        then assert the leftover is an unguessable ``mkstemp`` name rather than
-        the predictable sibling the vulnerable code used.
+        The vulnerable implementation wrote to ``path.with_suffix('.tmp')`` (i.e.
+        ``secret.tmp``) via a path-based ``write_text``, which follows a symlink
+        and clobbers its target. ``mkstemp`` instead picks an unguessable name
+        with ``O_EXCL``, so a symlink pre-planted at the predictable sibling is
+        left untouched. This assertion fails against the old code (it follows the
+        symlink and overwrites the victim) and passes against the mkstemp fix.
+        """
+        dest = tmp_path / "secret.txt"
+        predictable = dest.with_suffix(".tmp")  # 'secret.tmp'
+
+        victim = tmp_path / "victim"
+        victim.write_text("ORIGINAL_VICTIM")
+        predictable.symlink_to(victim)
+
+        atomic_write(dest, "SECRET_DEST_CONTENT")
+
+        # The destination got the content; the predictable-name symlink's target
+        # was never written through and the symlink itself still dangles intact.
+        assert dest.read_text() == "SECRET_DEST_CONTENT"
+        assert victim.read_text() == "ORIGINAL_VICTIM"
+        assert predictable.is_symlink()
+
+    @pytest.mark.skipif(os.name == "nt", reason="symlink/fchmod semantics differ on non-POSIX")
+    def test_atomic_write_uses_unguessable_tmp_name_and_cleans_up_on_failure(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The temp file is an unguessable ``mkstemp`` name, removed on failure.
+
+        We capture the temp name actually created (while it still exists) and
+        block ``os.replace`` so the temp file is left for cleanup. The captured
+        name must be the ``mkstemp`` form, never the predictable
+        ``path.with_suffix('.tmp')`` the vulnerable code used, and the cleanup
+        path must leave nothing behind.
         """
         dest = tmp_path / "secret.txt"
         predictable = dest.with_suffix(".tmp")
 
-        # Make os.replace fail so the temp file is not consumed/renamed away.
-        original_replace = os.replace
+        # Capture the temp name(s) created during the write, before cleanup runs.
+        real_mkstemp = tempfile.mkstemp
+        created: list[str] = []
+
+        def spy_mkstemp(*args: object, **kwargs: object) -> tuple[int, str]:
+            fd, name = real_mkstemp(*args, **kwargs)  # type: ignore[arg-type]
+            created.append(name)
+            return fd, name
+
+        monkeypatch.setattr(tempfile, "mkstemp", spy_mkstemp)
 
         def boom(src: str | os.PathLike[str], dst: str | os.PathLike[str]) -> None:
             raise OSError("blocked replace for test")
 
-        os.replace = boom  # type: ignore[assignment]
-        try:
-            with pytest.raises(OSError, match="blocked replace"):
-                atomic_write(dest, "data")
-        finally:
-            os.replace = original_replace  # type: ignore[assignment]
+        monkeypatch.setattr(os, "replace", boom)
+        with pytest.raises(OSError, match="blocked replace"):
+            atomic_write(dest, "data")
 
-        # The vulnerable predictable name must never have been created...
+        # An unguessable mkstemp name was used, never the predictable sibling.
+        assert len(created) == 1
+        tmp_name = Path(created[0]).name
+        assert tmp_name != predictable.name
+        assert tmp_name.startswith(".secret.txt.")
+        assert tmp_name.endswith(".envdrift-tmp")
+        # The predictable name was never created, and the temp file is gone.
         assert not predictable.exists()
-        # ...and atomic_write cleans up its own (unguessable) temp file on failure.
         leftovers = [
             p
             for p in tmp_path.iterdir()
             if p.name.startswith(".secret.txt.") and p.name.endswith(".envdrift-tmp")
         ]
+        assert leftovers == []
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX fd/error semantics")
+    def test_atomic_write_propagates_write_error_without_leaking_temp(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A write failure propagates the *original* error and leaves no temp file.
+
+        Regression for the fd double-close/leak: the vulnerable code closed the
+        fd a second time in the failure path (after ``fdopen`` had already closed
+        it), raising ``EBADF`` -- which both masked the real error (e.g. ENOSPC)
+        and aborted cleanup before the temp file was unlinked, leaking it. The fix
+        lets the ``fdopen`` wrapper own/close the fd exactly once, so the original
+        error survives and the temp file is always cleaned up.
+        """
+        dest = tmp_path / "secret.txt"
+
+        real_open = os.fdopen
+
+        class FailingWriter:
+            """Wraps a real file object but raises on ``write`` (disk-full sim)."""
+
+            def __init__(self, fileobj: object) -> None:
+                self._f = fileobj
+
+            def __enter__(self) -> FailingWriter:
+                return self
+
+            def __exit__(self, *exc: object) -> None:
+                self._f.__exit__(*exc)  # type: ignore[attr-defined]
+
+            def fileno(self) -> int:
+                return self._f.fileno()  # type: ignore[attr-defined]
+
+            def write(self, _data: str) -> int:
+                raise OSError("No space left on device")
+
+        def fake_fdopen(fd: int, *args: object, **kwargs: object) -> FailingWriter:
+            return FailingWriter(real_open(fd, *args, **kwargs))  # type: ignore[arg-type]
+
+        monkeypatch.setattr(os, "fdopen", fake_fdopen)
+
+        with pytest.raises(OSError, match="No space left on device"):
+            atomic_write(dest, "secret-data")
+
+        # The destination was never created, and no mkstemp temp file leaked.
+        assert not dest.exists()
+        leftovers = [p for p in tmp_path.iterdir() if p.name.endswith(".envdrift-tmp")]
         assert leftovers == []
 
     @pytest.mark.skipif(os.name == "nt", reason="symlink/fchmod semantics differ on non-POSIX")
@@ -310,6 +399,36 @@ class TestAtomicWrite:
 
         assert dest.read_text() == "new"
         assert dest.stat().st_mode & 0o777 == 0o640
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX mode/symlink semantics")
+    def test_atomic_write_symlinked_destination_does_not_inject_permissive_mode(
+        self, tmp_path: Path
+    ) -> None:
+        """A pre-planted destination symlink cannot force a permissive mode.
+
+        Regression for the ``path.stat()`` (symlink-following) mode preservation:
+        if an attacker plants a symlink at the destination pointing at a 0o777
+        file they own, the vulnerable code copied that 0o777 onto the freshly
+        written secret. The fix uses ``lstat`` and skips mode preservation for a
+        symlinked destination, so the requested tight default is applied instead.
+        """
+        attacker_owned = tmp_path / "attacker_owned"
+        attacker_owned.write_text("attacker content")
+        attacker_owned.chmod(0o777)
+
+        dest = tmp_path / "secret.txt"
+        dest.symlink_to(attacker_owned)
+
+        atomic_write(dest, "TOPSECRET", permissions=0o600)
+
+        # The new secret got the tight requested mode, not the injected 0o777,
+        # and the destination is a real file (the symlink was replaced).
+        assert not dest.is_symlink()
+        assert dest.read_text() == "TOPSECRET"
+        assert dest.stat().st_mode & 0o777 == 0o600
+        # The attacker's file is untouched (content and mode).
+        assert attacker_owned.read_text() == "attacker content"
+        assert attacker_owned.stat().st_mode & 0o777 == 0o777
 
 
 class TestRedactValue:

--- a/tests/unit/test_sync_operations.py
+++ b/tests/unit/test_sync_operations.py
@@ -219,6 +219,98 @@ class TestAtomicWrite:
 
         assert file_path.read_text() == "New content"
 
+    @pytest.mark.skipif(os.name == "nt", reason="symlink/fchmod semantics differ on non-POSIX")
+    def test_atomic_write_does_not_follow_predictable_tmp_symlink(self, tmp_path: Path) -> None:
+        """A pre-planted symlink at the predictable temp name is not written through.
+
+        The old implementation wrote to ``path.with_suffix('.tmp')`` with
+        ``write_text``, which follows a symlink and clobbers its target. An
+        attacker who can create ``<dest>.tmp`` (or ``.env.tmp`` for ``.env.keys``)
+        as a symlink to a file they don't own could redirect the secret write.
+        """
+        dest = tmp_path / ".env.keys"
+
+        outside = tmp_path / "outside_target"
+        outside.write_text("ORIGINAL_OUTSIDE")
+
+        # Plant symlinks at every predictable sibling the old code could pick.
+        for predictable in (dest.with_suffix(".tmp"), Path(str(dest) + ".tmp")):
+            if not predictable.exists():
+                predictable.symlink_to(outside)
+
+        atomic_write(dest, "SECRET_DEST_CONTENT")
+
+        # The real destination got the content; the outside target is untouched.
+        assert dest.read_text() == "SECRET_DEST_CONTENT"
+        assert outside.read_text() == "ORIGINAL_OUTSIDE"
+        # The destination is a real file, not a symlink to the outside file.
+        assert not dest.is_symlink()
+
+    @pytest.mark.skipif(os.name == "nt", reason="symlink/fchmod semantics differ on non-POSIX")
+    def test_atomic_write_does_not_use_literal_predictable_tmp_name(self, tmp_path: Path) -> None:
+        """The temp file used is not the literal ``path.with_suffix('.tmp')``.
+
+        We block ``os.replace`` from completing so the temp file is left behind,
+        then assert the leftover is an unguessable ``mkstemp`` name rather than
+        the predictable sibling the vulnerable code used.
+        """
+        dest = tmp_path / "secret.txt"
+        predictable = dest.with_suffix(".tmp")
+
+        # Make os.replace fail so the temp file is not consumed/renamed away.
+        original_replace = os.replace
+
+        def boom(src: str | os.PathLike[str], dst: str | os.PathLike[str]) -> None:
+            raise OSError("blocked replace for test")
+
+        os.replace = boom  # type: ignore[assignment]
+        try:
+            with pytest.raises(OSError, match="blocked replace"):
+                atomic_write(dest, "data")
+        finally:
+            os.replace = original_replace  # type: ignore[assignment]
+
+        # The vulnerable predictable name must never have been created...
+        assert not predictable.exists()
+        # ...and atomic_write cleans up its own (unguessable) temp file on failure.
+        leftovers = [
+            p
+            for p in tmp_path.iterdir()
+            if p.name.startswith(".secret.txt.") and p.name.endswith(".envdrift-tmp")
+        ]
+        assert leftovers == []
+
+    @pytest.mark.skipif(os.name == "nt", reason="symlink/fchmod semantics differ on non-POSIX")
+    def test_atomic_write_chmod_targets_destination_not_symlink(self, tmp_path: Path) -> None:
+        """chmod is applied to the file we create, not a followed symlink target."""
+        dest = tmp_path / "new_secret.txt"
+
+        outside = tmp_path / "victim"
+        outside.write_text("victim content")
+        outside.chmod(0o644)
+
+        # Plant a symlink at the predictable temp name pointing at the victim.
+        dest.with_suffix(".tmp").symlink_to(outside)
+
+        atomic_write(dest, "secret", permissions=0o600)
+
+        # Destination has the tight mode; the victim's mode is unchanged.
+        assert dest.stat().st_mode & 0o777 == 0o600
+        assert outside.stat().st_mode & 0o777 == 0o644
+        assert outside.read_text() == "victim content"
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX mode semantics")
+    def test_atomic_write_preserves_existing_destination_mode(self, tmp_path: Path) -> None:
+        """Overwriting an existing file preserves its current mode (no force 0o600)."""
+        dest = tmp_path / "existing.txt"
+        dest.write_text("old")
+        dest.chmod(0o640)
+
+        atomic_write(dest, "new", permissions=0o600)
+
+        assert dest.read_text() == "new"
+        assert dest.stat().st_mode & 0o777 == 0o640
+
 
 class TestRedactValue:
     """Tests for redact_value -- the non-reversible secret discriminator."""


### PR DESCRIPTION
Deep-review finding (#348): `atomic_write` used a predictable `.tmp` path; a precreated symlink in an attacker-writable service dir could redirect the write. Fix: `tempfile.mkstemp` + `os.fchmod(fd)` + atomic rename (preserves an existing destination's mode). POSIX load-bearing regression tests added. Part of #348.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces the vulnerable predictable-name `.tmp` temp-file pattern in `atomic_write` with `tempfile.mkstemp` (`O_EXCL`, unguessable name, fd owned by us), `os.fchmod` on the fd rather than a path-based chmod, and `path.lstat()` with a symlink guard for mode preservation, closing three symlink-redirection attack vectors. Six POSIX-only regression tests were added, each annotated to fail against the previous implementation.

- **`operations.py`**: the entire write path — mkstemp, fchmod, flush, fsync, replace — is wired through the fd we own; mode preservation now uses `lstat` and skips symlinked destinations so a pre-planted symlink cannot inject a permissive mode onto the new secret.
- **`test_sync_operations.py`**: covers predictable-name symlink, mode-injection via destination symlink, unguessable temp-name + cleanup-on-failure, fd-leak/original-error propagation, mode preservation for real existing files, and the tight-mode default when destination is a symlink.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the production fix is correct and all three symlink attack vectors are closed; the only note is a test portability nuance on Python ≤3.11 that fails loudly rather than silently.

The `atomic_write` rewrite is technically sound: mkstemp with O_EXCL eliminates the predictable-name race, fd-based fchmod cannot be redirected through a symlink, and lstat with the symlink guard prevents mode injection. The BaseException cleanup handler is intentional and correct. The six regression tests each verify a specific attack scenario and are annotated to fail against the prior implementation. The one flag is that `monkeypatch.setattr(os, "replace", boom)` does not intercept `Path.replace()` on Python ≤3.11 due to pathlib's cached accessor — a test that breaks loudly, not silently, but still worth addressing if older Python versions are supported.

The test in `tests/unit/test_sync_operations.py` that patches `os.replace` to simulate a rename failure deserves a second look if Python 3.11 is in the support matrix.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/envdrift/sync/operations.py | Replaces predictable `.tmp` path with `tempfile.mkstemp`, uses `os.fchmod` (fd-based), `path.lstat()` for symlink-safe mode preservation, and `BaseException` cleanup handler — security fix is well-structured and correct. |
| tests/unit/test_sync_operations.py | Six new POSIX-only regression tests covering the symlink, mode-injection, unguessable-name, fd-leak, and cleanup scenarios; the `monkeypatch.setattr(os, "replace", boom)` interception of `Path.replace()` is Python-version-dependent (works on 3.12+, breaks on ≤3.11 where pathlib caches the reference). |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant C as Caller
    participant AW as atomic_write()
    participant FS as Filesystem

    C->>AW: atomic_write(path, content, permissions)
    AW->>FS: "path.parent.mkdir(parents=True)"
    AW->>FS: path.lstat() [no symlink follow]
    alt destination is real file
        FS-->>AW: stat with mode
        AW->>AW: "mode = dest_stat.st_mode & 0o777"
    else destination is symlink or missing
        AW->>AW: "mode = permissions (tight default)"
    end
    AW->>FS: "mkstemp(dir=parent, prefix=.name., suffix=.envdrift-tmp)"
    FS-->>AW: (fd, tmp_name) — O_EXCL, unguessable
    AW->>FS: os.fchmod(fd, mode) [fd-based, no symlink follow]
    AW->>FS: write(content) via fdopen wrapper
    AW->>FS: flush() + fsync(fd)
    AW->>FS: fdopen wrapper closes fd
    AW->>FS: tmp_path.replace(path) — atomic rename
    FS-->>C: success

    note over AW,FS: On any BaseException
    AW->>FS: tmp_path.unlink() [suppress FileNotFoundError]
    AW->>C: re-raise original exception
```

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/348-ops-tmp..."](https://github.com/jainal09/envdrift/commit/ee078cb59af72e1e0a5b925f12e32142603ba72a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36051855)</sub>

<!-- /greptile_comment -->