### PR TITLE
fix(sync): skip lone mismatched .env.<env> in auto-detect

### DIFF
--- a/docs/guides/env-file-sync.md
+++ b/docs/guides/env-file-sync.md
@@ -359,8 +359,11 @@ the environment — `<prefix>.env.<environment>` (e.g.
 `<prefix>.<environment>.env` / `<prefix>_<environment>.env` (e.g.
 `dotnet-service-template-local.env`), or, for the default `production`
 environment, a plain `<prefix>.env` (e.g. `postgresql.env`); and finally a
-fallback to plain `.env` or a single `.env.*` file. Companion files (`.example`,
-`.sample`, `.template`, `.keys`) are never picked. Set `env_file` only for a name
+fallback to plain `.env`, or a single `.env.<environment>` whose suffix matches
+the mapping's environment. A lone `.env.*` for a *different* environment is not
+adopted — the mapping is skipped rather than synced under the wrong key. Companion
+files (`.example`, `.sample`, `.template`, `.keys`) are never picked. Set
+`env_file` only for a name
 that matches none of these conventions. `environment` remains the source of truth
 for key names, so these files still use keys like `DOTENV_PRIVATE_KEY_PRODUCTION`
 and `DOTENV_PRIVATE_KEY_STAGING`.

--- a/src/envdrift/env_files.py
+++ b/src/envdrift/env_files.py
@@ -75,7 +75,12 @@ def detect_env_file(folder_path: Path, default_environment: str = "production") 
 
     Checks for:
     1. Plain .env file (returns default environment)
-    2. Single .env.* file (returns environment from suffix)
+    2. Single .env.* file, but only when its suffix matches ``default_environment``
+
+    A single ``.env.<suffix>`` whose suffix differs from ``default_environment``
+    is *not* adopted: returning it would let a ``production`` lookup sync, say,
+    ``.env.staging`` under ``DOTENV_PRIVATE_KEY_STAGING`` (see #395). Such a
+    mismatch reports "not_found" so the caller skips instead.
 
     Custom service-prefixed names (e.g. ``service.env.docker``) are intentionally
     not handled here; that requires the mapping's environment and lives in
@@ -85,7 +90,7 @@ def detect_env_file(folder_path: Path, default_environment: str = "production") 
     - "found": env file found
     - "folder_not_found": folder doesn't exist (or isn't a directory)
     - "multiple_found": multiple .env.* files exist (ambiguous)
-    - "not_found": no env files found
+    - "not_found": no env files found (or the only .env.* file is for another env)
     """
     if not folder_path.is_dir():
         return EnvFileDetection(None, None, "folder_not_found")
@@ -105,7 +110,14 @@ def detect_env_file(folder_path: Path, default_environment: str = "production") 
         env_file = env_files[0]
         # Extract environment from filename: .env.soak -> soak
         environment = env_file.name[len(".env.") :]
-        return EnvFileDetection(env_file, environment, "found")
+        # Only adopt the suffix's environment when it matches the requested one.
+        # A single ``.env.staging`` must NOT be claimed by a ``production`` lookup:
+        # doing so would sync that file under the wrong DOTENV_PRIVATE_KEY_<ENV>
+        # (see #395). Mismatches fall through to "not_found" so the caller SKIPS
+        # rather than silently operating on a different environment.
+        if environment == default_environment:
+            return EnvFileDetection(env_file, environment, "found")
+        return EnvFileDetection(None, None, "not_found")
 
     if len(env_files) > 1:
         return EnvFileDetection(None, None, "multiple_found")
@@ -144,7 +156,10 @@ def resolve_mapping_env_file(mapping: Any) -> EnvFileDetection:
     3. A custom-named file that belongs to the environment, such as
        ``service.env.<env>`` or ``service-<env>.env`` (and, for a default
        environment, a plain ``service.env``).
-    4. Legacy auto-detection for ``.env`` or a single ``.env.*`` file.
+    4. Legacy auto-detection for a plain ``.env`` (default env) or a single
+       ``.env.<effective_environment>`` file. A lone ``.env.*`` for a *different*
+       environment is not adopted, so the mapping is skipped rather than synced
+       under the wrong key (see #395).
 
     Custom filenames matched via steps 2-3 keep ``mapping.effective_environment``
     as the environment of record. This preserves canonical vault key names even

--- a/src/envdrift/env_files.py
+++ b/src/envdrift/env_files.py
@@ -45,11 +45,16 @@ def _name_encodes_environment(name: str, environment: str) -> bool:
     environment-specific lookup (e.g. "docker") from grabbing a plain file, and
     avoids relabeling a plain file under a non-default environment.
     """
-    if name.endswith(f".env.{environment}"):
-        return True
-    if name == f"{environment}.env":
-        return True
-    if any(name.endswith(f"{sep}{environment}.env") for sep in ("-", ".", "_")):
+    # Suffix conventions ".env.<env>"/"<prefix>.env.<env>" and infix forms
+    # "<prefix>-<env>.env" / ".<env>.env" / "_<env>.env". ``str.endswith`` accepts
+    # a tuple, so all the encoded forms collapse to one check.
+    encoded_suffixes = (
+        f".env.{environment}",
+        f"-{environment}.env",
+        f".{environment}.env",
+        f"_{environment}.env",
+    )
+    if name == f"{environment}.env" or name.endswith(encoded_suffixes):
         return True
     # Plain ".env" / "<prefix>.env" carries no encoded environment -> default only.
     return environment == _DEFAULT_ENVIRONMENT and name.endswith(".env")
@@ -152,6 +157,23 @@ def resolve_custom_env_file(folder_path: Path, env_file: Path | str) -> Path:
     return folder_path / env_file_path
 
 
+def _resolve_explicit_env_file(
+    folder_path: Path, env_file: Any, environment: str
+) -> EnvFileDetection:
+    """Resolve an explicitly-configured ``mapping.env_file`` under ``folder_path``.
+
+    Returns "folder_not_found" when the folder is missing, "found" when the
+    configured file exists, else "not_found" (the path is still surfaced so the
+    caller can report where it looked).
+    """
+    if not folder_path.exists():
+        return EnvFileDetection(None, environment, "folder_not_found")
+    resolved = resolve_custom_env_file(folder_path, env_file)
+    if resolved.exists() and resolved.is_file():
+        return EnvFileDetection(resolved, environment, "found")
+    return EnvFileDetection(resolved, environment, "not_found")
+
+
 def resolve_mapping_env_file(mapping: Any) -> EnvFileDetection:
     """Resolve the env file for a sync mapping.
 
@@ -175,13 +197,7 @@ def resolve_mapping_env_file(mapping: Any) -> EnvFileDetection:
     env_file = getattr(mapping, "env_file", None)
 
     if env_file is not None:
-        if not folder_path.exists():
-            return EnvFileDetection(None, effective_environment, "folder_not_found")
-
-        resolved = resolve_custom_env_file(folder_path, env_file)
-        if resolved.exists() and resolved.is_file():
-            return EnvFileDetection(resolved, effective_environment, "found")
-        return EnvFileDetection(resolved, effective_environment, "not_found")
+        return _resolve_explicit_env_file(folder_path, env_file, effective_environment)
 
     exact_env = folder_path / f".env.{effective_environment}"
     if exact_env.exists() and exact_env.is_file():

--- a/src/envdrift/env_files.py
+++ b/src/envdrift/env_files.py
@@ -69,6 +69,21 @@ def _match_env_files_for_environment(folder_path: Path, environment: str) -> lis
     return sorted(matches)
 
 
+def _resolve_lone_env_file(env_file: Path, default_environment: str) -> EnvFileDetection:
+    """Resolve a single ``.env.<suffix>`` file against the requested environment.
+
+    Only adopt the suffix's environment when it matches ``default_environment``.
+    A single ``.env.staging`` must NOT be claimed by a ``production`` lookup:
+    doing so would sync that file under the wrong ``DOTENV_PRIVATE_KEY_<ENV>``
+    (see #395). Mismatches report "not_found" so the caller SKIPS rather than
+    silently operating on a different environment.
+    """
+    environment = env_file.name[len(".env.") :]  # .env.soak -> soak
+    if environment == default_environment:
+        return EnvFileDetection(env_file, environment, "found")
+    return EnvFileDetection(None, None, "not_found")
+
+
 def detect_env_file(folder_path: Path, default_environment: str = "production") -> EnvFileDetection:
     """
     Auto-detect a canonical .env file in a folder.
@@ -107,17 +122,7 @@ def detect_env_file(folder_path: Path, default_environment: str = "production") 
     ]
 
     if len(env_files) == 1:
-        env_file = env_files[0]
-        # Extract environment from filename: .env.soak -> soak
-        environment = env_file.name[len(".env.") :]
-        # Only adopt the suffix's environment when it matches the requested one.
-        # A single ``.env.staging`` must NOT be claimed by a ``production`` lookup:
-        # doing so would sync that file under the wrong DOTENV_PRIVATE_KEY_<ENV>
-        # (see #395). Mismatches fall through to "not_found" so the caller SKIPS
-        # rather than silently operating on a different environment.
-        if environment == default_environment:
-            return EnvFileDetection(env_file, environment, "found")
-        return EnvFileDetection(None, None, "not_found")
+        return _resolve_lone_env_file(env_files[0], default_environment)
 
     if len(env_files) > 1:
         return EnvFileDetection(None, None, "multiple_found")

--- a/src/envdrift/env_files.py
+++ b/src/envdrift/env_files.py
@@ -60,18 +60,33 @@ def _name_encodes_environment(name: str, environment: str) -> bool:
     return environment == _DEFAULT_ENVIRONMENT and name.endswith(".env")
 
 
-def _match_env_files_for_environment(folder_path: Path, environment: str) -> list[Path]:
-    """Return env files in ``folder_path`` whose name belongs to ``environment``."""
+def _candidate_env_files(folder_path: Path) -> list[Path]:
+    """Files in ``folder_path`` that could be the env file (excludes companions).
+
+    Returns an empty list when the folder is missing. Shared by the detectors so
+    the "real file, not an .example/.sample/.template/.keys companion" filter
+    lives in one place.
+    """
     if not folder_path.is_dir():
         return []
+    return [f for f in folder_path.iterdir() if f.is_file() and not _is_excluded_env_file(f.name)]
+
+
+def _match_env_files_for_environment(folder_path: Path, environment: str) -> list[Path]:
+    """Return env files in ``folder_path`` whose name belongs to ``environment``."""
     matches = [
         f
-        for f in folder_path.iterdir()
-        if f.is_file()
-        and not _is_excluded_env_file(f.name)
-        and _name_encodes_environment(f.name, environment)
+        for f in _candidate_env_files(folder_path)
+        if _name_encodes_environment(f.name, environment)
     ]
     return sorted(matches)
+
+
+def _one_or_ambiguous(matches: list[Path], environment: str | None) -> EnvFileDetection:
+    """Classify a non-empty match list: exactly one -> found, several -> ambiguous."""
+    if len(matches) == 1:
+        return EnvFileDetection(matches[0], environment, "found")
+    return EnvFileDetection(None, environment, "multiple_found")
 
 
 def _resolve_lone_env_file(env_file: Path, default_environment: str) -> EnvFileDetection:
@@ -120,18 +135,12 @@ def detect_env_file(folder_path: Path, default_environment: str = "production") 
     if plain_env.is_file():
         return EnvFileDetection(plain_env, default_environment, "found")
 
-    env_files = [
-        f
-        for f in folder_path.iterdir()
-        if f.is_file() and f.name.startswith(".env.") and not _is_excluded_env_file(f.name)
-    ]
+    env_files = [f for f in _candidate_env_files(folder_path) if f.name.startswith(".env.")]
 
     if len(env_files) == 1:
         return _resolve_lone_env_file(env_files[0], default_environment)
-
     if len(env_files) > 1:
         return EnvFileDetection(None, None, "multiple_found")
-
     return EnvFileDetection(None, None, "not_found")
 
 
@@ -207,9 +216,7 @@ def resolve_mapping_env_file(mapping: Any) -> EnvFileDetection:
     # "service.env.docker" or "service-local.env"). The configured environment
     # stays canonical so vault/dotenvx key names remain config-driven.
     env_matches = _match_env_files_for_environment(folder_path, effective_environment)
-    if len(env_matches) == 1:
-        return EnvFileDetection(env_matches[0], effective_environment, "found")
-    if len(env_matches) > 1:
-        return EnvFileDetection(None, effective_environment, "multiple_found")
+    if env_matches:
+        return _one_or_ambiguous(env_matches, effective_environment)
 
     return detect_env_file(folder_path, effective_environment)

--- a/tests/unit/coverage/test_cov_sync_engine.py
+++ b/tests/unit/coverage/test_cov_sync_engine.py
@@ -81,17 +81,18 @@ class TestSyncAllSchemaValidation:
 
 
 class TestAutoDetectEnvFile:
-    """When .env.<env> is missing, a matching detected file is used (lines 93-95)."""
+    """A .env.<env> matching the mapping's environment drives the key name."""
 
     def test_uses_detected_env_file_for_key_name(
         self, mock_vault_client: MagicMock, tmp_path: Path
     ) -> None:
-        """A lone .env.<env> matching the mapping env drives the key name written."""
+        """A .env.<env> matching the mapping env drives the key name written."""
         mock_vault_client.get_secret.return_value = SecretValue(name="k", value="secret")
 
         service_dir = tmp_path / "service"
         service_dir.mkdir()
-        # No .env.staging via the exact path, but a single matching file exists.
+        # .env.staging matches the mapping's environment ("staging"), so it is
+        # resolved via the exact-match path and its suffix drives the key name.
         (service_dir / ".env.staging").write_text("DB_URL=encrypted:xyz\n")
 
         mapping = ServiceMapping(secret_name="k", folder_path=service_dir, environment="staging")

--- a/tests/unit/coverage/test_cov_sync_engine.py
+++ b/tests/unit/coverage/test_cov_sync_engine.py
@@ -81,19 +81,20 @@ class TestSyncAllSchemaValidation:
 
 
 class TestAutoDetectEnvFile:
-    """When .env.<env> is missing, a detected file is used (lines 93-95)."""
+    """When .env.<env> is missing, a matching detected file is used (lines 93-95)."""
 
     def test_uses_detected_env_file_for_key_name(
         self, mock_vault_client: MagicMock, tmp_path: Path
     ) -> None:
+        """A lone .env.<env> matching the mapping env drives the key name written."""
         mock_vault_client.get_secret.return_value = SecretValue(name="k", value="secret")
 
         service_dir = tmp_path / "service"
         service_dir.mkdir()
-        # No .env.production, but a single .env.staging file exists.
+        # No .env.staging via the exact path, but a single matching file exists.
         (service_dir / ".env.staging").write_text("DB_URL=encrypted:xyz\n")
 
-        mapping = ServiceMapping(secret_name="k", folder_path=service_dir)
+        mapping = ServiceMapping(secret_name="k", folder_path=service_dir, environment="staging")
         config = SyncConfig(mappings=[mapping])
         engine = SyncEngine(config=config, vault_client=mock_vault_client)
 
@@ -103,6 +104,33 @@ class TestAutoDetectEnvFile:
         # Detected environment "staging" should drive the key name written.
         content = (service_dir / ".env.keys").read_text()
         assert "DOTENV_PRIVATE_KEY_STAGING=secret" in content
+
+    def test_lone_other_env_file_is_skipped_not_synced(
+        self, mock_vault_client: MagicMock, tmp_path: Path
+    ) -> None:
+        """Regression for #395: a production mapping must not sync a lone .env.staging.
+
+        With no .env.production (and no custom match) but a single .env.staging,
+        the engine previously fell through to detection and synced staging under
+        DOTENV_PRIVATE_KEY_STAGING. It must now SKIP and write no .env.keys.
+        """
+        mock_vault_client.get_secret.return_value = SecretValue(name="k", value="secret")
+
+        service_dir = tmp_path / "service"
+        service_dir.mkdir()
+        # No .env.production; only a single .env.staging for a *different* env.
+        (service_dir / ".env.staging").write_text("DB_URL=encrypted:xyz\n")
+
+        # No environment -> effective_environment defaults to "production".
+        mapping = ServiceMapping(secret_name="k", folder_path=service_dir)
+        config = SyncConfig(mappings=[mapping])
+        engine = SyncEngine(config=config, vault_client=mock_vault_client)
+
+        result = engine.sync_all()
+
+        assert result.services[0].action == SyncAction.SKIPPED
+        # The staging key must never be written for a production mapping.
+        assert not (service_dir / ".env.keys").exists()
 
 
 class TestFolderDoesNotExist:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -4335,6 +4335,31 @@ class TestDetectEnvFile:
         assert detection.path == env_file
         assert detection.environment == "production"
 
+    def test_single_env_file_mismatched_environment_is_not_found(self, tmp_path: Path):
+        """A lone .env.<other> must not be adopted for a different env (see #395)."""
+        from envdrift.env_files import detect_env_file
+
+        (tmp_path / ".env.staging").write_text("SECRET=value")
+
+        detection = detect_env_file(tmp_path, default_environment="production")
+
+        assert detection.status == "not_found"
+        assert detection.path is None
+        assert detection.environment is None
+
+    def test_single_env_file_matching_environment_is_found(self, tmp_path: Path):
+        """A lone .env.<env> is adopted when the requested env matches its suffix."""
+        from envdrift.env_files import detect_env_file
+
+        env_file = tmp_path / ".env.staging"
+        env_file.write_text("SECRET=value")
+
+        detection = detect_env_file(tmp_path, default_environment="staging")
+
+        assert detection.status == "found"
+        assert detection.path == env_file
+        assert detection.environment == "staging"
+
     def test_returns_multiple_found_status(self, tmp_path: Path):
         """Test that multiple .env.* files return multiple_found status."""
         from envdrift.env_files import detect_env_file

--- a/tests/unit/test_cli_vault_push.py
+++ b/tests/unit/test_cli_vault_push.py
@@ -16,6 +16,53 @@ from tests.helpers import DummyEncryptionBackend
 runner = CliRunner()
 
 
+def _setup_push_all_single_mapping(tmp_path, mocks, *, environment, env_filename):
+    """Scaffold a single-mapping ``vault-push --all`` run.
+
+    ``mocks`` is the ``(loader, resolve_backend, keys_file)`` patch triple. Wires
+    them for one DOTENVX mapping "my-secret" at ``tmp_path/service1`` for
+    ``environment``, creates the service dir with ``env_filename`` plus a
+    ``.env.keys``, and makes the client report the secret missing. Returns
+    ``(dummy_backend, mock_client, mock_keys_instance, env_file)`` to assert on.
+    """
+    mock_loader, mock_resolve_backend, mock_keys_file = mocks
+
+    mock_client = MagicMock()
+    mock_loader.return_value = (
+        SyncConfig(
+            mappings=[
+                ServiceMapping(
+                    secret_name="my-secret",
+                    folder_path=tmp_path / "service1",
+                    environment=environment,
+                )
+            ]
+        ),
+        mock_client,
+        "azure",
+        None,
+        None,
+        None,
+    )
+
+    dummy_backend = DummyEncryptionBackend()
+    mock_resolve_backend.return_value = (dummy_backend, EncryptionProvider.DOTENVX, None)
+
+    service_dir = tmp_path / "service1"
+    service_dir.mkdir()
+    env_file = service_dir / env_filename
+    env_file.write_text("PLAIN=text")
+    (service_dir / ".env.keys").write_text("DOTENV_PRIVATE_KEY_STAGING=secret123")
+
+    mock_keys_instance = MagicMock()
+    mock_keys_instance.read_key.return_value = "secret123"
+    mock_keys_file.return_value = mock_keys_instance
+
+    mock_client.get_secret.side_effect = SecretNotFoundError("missing")
+
+    return dummy_backend, mock_client, mock_keys_instance, env_file
+
+
 class TestVaultPushAll:
     """Tests for vault-push --all."""
 
@@ -375,36 +422,12 @@ class TestVaultPushAll:
         tmp_path,
     ):
         """vault-push --all should auto-detect a lone env file matching the env."""
-        mock_client = MagicMock()
-        mock_sync_config = SyncConfig(
-            mappings=[
-                ServiceMapping(
-                    secret_name="my-secret",
-                    folder_path=tmp_path / "service1",
-                    environment="staging",
-                )
-            ]
+        dummy_backend, mock_client, mock_keys_instance, env_file = _setup_push_all_single_mapping(
+            tmp_path,
+            (mock_loader, mock_resolve_backend, mock_keys_file),
+            environment="staging",
+            env_filename=".env.staging",
         )
-        mock_loader.return_value = (mock_sync_config, mock_client, "azure", None, None, None)
-
-        dummy_backend = DummyEncryptionBackend()
-        mock_resolve_backend.return_value = (
-            dummy_backend,
-            EncryptionProvider.DOTENVX,
-            None,
-        )
-
-        service_dir = tmp_path / "service1"
-        service_dir.mkdir()
-        env_file = service_dir / ".env.staging"
-        env_file.write_text("PLAIN=text")
-        (service_dir / ".env.keys").write_text("DOTENV_PRIVATE_KEY_STAGING=secret123")
-
-        mock_keys_instance = MagicMock()
-        mock_keys_instance.read_key.return_value = "secret123"
-        mock_keys_file.return_value = mock_keys_instance
-
-        mock_client.get_secret.side_effect = SecretNotFoundError("missing")
 
         result = runner.invoke(app, ["vault-push", "--all"])
 
@@ -431,36 +454,13 @@ class TestVaultPushAll:
         NOT be auto-detected and pushed under DOTENV_PRIVATE_KEY_STAGING. The push
         must skip: nothing is encrypted and no secret is written to the vault.
         """
-        mock_client = MagicMock()
-        mock_sync_config = SyncConfig(
-            mappings=[
-                ServiceMapping(
-                    secret_name="my-secret",
-                    folder_path=tmp_path / "service1",
-                    environment="production",
-                )
-            ]
+        # Production mapping, but only a lone .env.staging for a *different* env.
+        dummy_backend, mock_client, mock_keys_instance, _ = _setup_push_all_single_mapping(
+            tmp_path,
+            (mock_loader, mock_resolve_backend, mock_keys_file),
+            environment="production",
+            env_filename=".env.staging",
         )
-        mock_loader.return_value = (mock_sync_config, mock_client, "azure", None, None, None)
-
-        dummy_backend = DummyEncryptionBackend()
-        mock_resolve_backend.return_value = (
-            dummy_backend,
-            EncryptionProvider.DOTENVX,
-            None,
-        )
-
-        service_dir = tmp_path / "service1"
-        service_dir.mkdir()
-        # Only a .env.staging for a *different* environment than the mapping.
-        (service_dir / ".env.staging").write_text("PLAIN=text")
-        (service_dir / ".env.keys").write_text("DOTENV_PRIVATE_KEY_STAGING=secret123")
-
-        mock_keys_instance = MagicMock()
-        mock_keys_instance.read_key.return_value = "secret123"
-        mock_keys_file.return_value = mock_keys_instance
-
-        mock_client.get_secret.side_effect = SecretNotFoundError("missing")
 
         result = runner.invoke(app, ["vault-push", "--all"])
 

--- a/tests/unit/test_cli_vault_push.py
+++ b/tests/unit/test_cli_vault_push.py
@@ -374,14 +374,14 @@ class TestVaultPushAll:
         mock_resolve_backend,
         tmp_path,
     ):
-        """vault-push --all should auto-detect env files and update environment."""
+        """vault-push --all should auto-detect a lone env file matching the env."""
         mock_client = MagicMock()
         mock_sync_config = SyncConfig(
             mappings=[
                 ServiceMapping(
                     secret_name="my-secret",
                     folder_path=tmp_path / "service1",
-                    environment="production",
+                    environment="staging",
                 )
             ]
         )
@@ -414,6 +414,61 @@ class TestVaultPushAll:
         mock_client.set_secret.assert_called_with(
             "my-secret", "DOTENV_PRIVATE_KEY_STAGING=secret123"
         )
+
+    @patch("envdrift.cli_commands.encryption_helpers.resolve_encryption_backend")
+    @patch("envdrift.cli_commands.sync.load_sync_config_and_client")
+    @patch("envdrift.sync.operations.EnvKeysFile")
+    def test_push_all_skips_lone_other_environment_file(
+        self,
+        mock_keys_file,
+        mock_loader,
+        mock_resolve_backend,
+        tmp_path,
+    ):
+        """Regression for #395.
+
+        A production mapping with no .env.production but a lone .env.staging must
+        NOT be auto-detected and pushed under DOTENV_PRIVATE_KEY_STAGING. The push
+        must skip: nothing is encrypted and no secret is written to the vault.
+        """
+        mock_client = MagicMock()
+        mock_sync_config = SyncConfig(
+            mappings=[
+                ServiceMapping(
+                    secret_name="my-secret",
+                    folder_path=tmp_path / "service1",
+                    environment="production",
+                )
+            ]
+        )
+        mock_loader.return_value = (mock_sync_config, mock_client, "azure", None, None, None)
+
+        dummy_backend = DummyEncryptionBackend()
+        mock_resolve_backend.return_value = (
+            dummy_backend,
+            EncryptionProvider.DOTENVX,
+            None,
+        )
+
+        service_dir = tmp_path / "service1"
+        service_dir.mkdir()
+        # Only a .env.staging for a *different* environment than the mapping.
+        (service_dir / ".env.staging").write_text("PLAIN=text")
+        (service_dir / ".env.keys").write_text("DOTENV_PRIVATE_KEY_STAGING=secret123")
+
+        mock_keys_instance = MagicMock()
+        mock_keys_instance.read_key.return_value = "secret123"
+        mock_keys_file.return_value = mock_keys_instance
+
+        mock_client.get_secret.side_effect = SecretNotFoundError("missing")
+
+        result = runner.invoke(app, ["vault-push", "--all"])
+
+        assert result.exit_code == 0
+        # The staging file is never encrypted nor pushed under the staging key.
+        assert dummy_backend.encrypt_calls == []
+        mock_keys_instance.read_key.assert_not_called()
+        mock_client.set_secret.assert_not_called()
 
     @patch("envdrift.cli_commands.encryption_helpers.resolve_encryption_backend")
     @patch("envdrift.cli_commands.sync.load_sync_config_and_client")

--- a/tests/unit/test_env_files.py
+++ b/tests/unit/test_env_files.py
@@ -106,10 +106,40 @@ def test_resolve_mapping_env_file_preserves_legacy_exact_environment(
 def test_resolve_mapping_env_file_preserves_legacy_single_env_detection(
     tmp_path: Path,
 ) -> None:
+    """A lone ``.env.<env>`` is adopted only when it matches the mapping's env."""
     service_dir = tmp_path / "service"
     service_dir.mkdir()
     env_file = service_dir / ".env.sqa"
     env_file.write_text("SECRET=value\n")
+
+    mapping = ServiceMapping(
+        secret_name="dotenv-key",
+        folder_path=service_dir,
+        environment="sqa",
+    )
+
+    detection = resolve_mapping_env_file(mapping)
+
+    assert detection.status == "found"
+    assert detection.path == env_file
+    assert detection.environment == "sqa"
+
+
+def test_resolve_mapping_env_file_skips_lone_other_environment_file(
+    tmp_path: Path,
+) -> None:
+    """Regression for #395.
+
+    A mapping for ``production`` with no ``.env.production`` (and no custom
+    match) but exactly one ``.env.staging`` must NOT fall through to legacy
+    detection and claim staging. Doing so would sync ``.env.staging`` under
+    ``DOTENV_PRIVATE_KEY_STAGING`` for a production mapping. The resolver must
+    report "not_found" so ``_sync_service`` SKIPS instead.
+    """
+    service_dir = tmp_path / "service"
+    service_dir.mkdir()
+    staging = service_dir / ".env.staging"
+    staging.write_text("SECRET=value\n")
 
     mapping = ServiceMapping(
         secret_name="dotenv-key",
@@ -119,9 +149,10 @@ def test_resolve_mapping_env_file_preserves_legacy_single_env_detection(
 
     detection = resolve_mapping_env_file(mapping)
 
-    assert detection.status == "found"
-    assert detection.path == env_file
-    assert detection.environment == "sqa"
+    assert detection.status == "not_found"
+    assert detection.path is None
+    # Crucially, the staging suffix is never adopted as the environment of record.
+    assert detection.environment != "staging"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #395: a mapping configured for env X with no `.env.X` but exactly one other `.env.Y` fell through to `detect_env_file`, which adopted Y's suffix → synced `.env.Y` under `DOTENV_PRIVATE_KEY_Y`. Fix: only adopt a lone `.env.<suffix>` when the suffix matches the requested environment; otherwise return not_found so sync/vault-push SKIPS. Load-bearing regression test added.

Closes #395

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes issue #395 where a sync mapping configured for environment X (e.g. `production`) with no `.env.X` but a single `.env.Y` (e.g. `.env.staging`) would fall through to `detect_env_file`, which adopted Y's suffix and synced the staging file under `DOTENV_PRIVATE_KEY_STAGING` for a production mapping. The fix adds a suffix-match guard (`_resolve_lone_env_file`) so a lone `.env.*` is only adopted when its suffix equals the requested environment; otherwise `"not_found"` is returned and the mapping is skipped.

- **`env_files.py`**: Introduces `_resolve_lone_env_file`, `_candidate_env_files`, `_one_or_ambiguous`, and `_resolve_explicit_env_file` as private helpers; refactors `detect_env_file` and `resolve_mapping_env_file` to use them, eliminating the duplicate exclusion-filter logic and the unsafe lone-file adoption.
- **Test suite**: The test previously validating the buggy behavior (`environment=\"production\"` + `.env.staging`) is corrected to use `environment=\"staging\"`, and a new load-bearing regression test is added across three test files (`test_env_files.py`, `test_cov_sync_engine.py`, `test_cli_vault_push.py`).

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change narrows a single detection fallback path, all affected callers are covered by existing and new tests, and no pre-existing correct behavior is altered.

The fix is surgical and well-contained: only the lone-file adoption branch in detect_env_file changes, and every other resolution path (exact match, custom-named files, explicit env_file, plain .env) is untouched. Regression tests were added at the unit, integration, and end-to-end CLI levels, and the previously incorrect test that was validating the buggy behavior has been corrected. The refactoring helpers are straightforward extractions with no logic change.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/envdrift/env_files.py | Core fix: adds _resolve_lone_env_file with a suffix-equality guard, extracts _candidate_env_files/_one_or_ambiguous/_resolve_explicit_env_file as clean helpers. Logic is correct and behavior-equivalent for all pre-existing valid cases. |
| tests/unit/coverage/test_cov_sync_engine.py | Class docstring and inline comment updated per prior review thread; new test_lone_other_env_file_is_skipped_not_synced is the key end-to-end regression test for #395. |
| tests/unit/test_cli_vault_push.py | Extracts _setup_push_all_single_mapping helper; refactors the old buggy-behavior test to use environment='staging'; adds test_push_all_skips_lone_other_environment_file regression for #395. |
| tests/unit/test_env_files.py | Fixes test_resolve_mapping_env_file_preserves_legacy_single_env_detection (environment now 'sqa' to match the file); adds test_resolve_mapping_env_file_skips_lone_other_environment_file regression. |
| tests/unit/test_cli.py | Adds two direct unit tests for detect_env_file: mismatched-env returns not_found; matching-env returns found. Good coverage of the new guard in isolation. |
| docs/guides/env-file-sync.md | Documentation updated to accurately describe the new restriction: only a .env.<env> whose suffix matches the mapping's environment is auto-adopted. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[resolve_mapping_env_file] --> B{env_file configured?}
    B -- yes --> C[_resolve_explicit_env_file\nfolder_not_found / found / not_found]
    B -- no --> D{.env.effective_env\nexists?}
    D -- yes --> E[Return found\nexact match]
    D -- no --> F[_match_env_files_for_environment\ncustom-named files]
    F --> G{matches?}
    G -- 1 file --> H[Return found]
    G -- >1 files --> I[Return multiple_found]
    G -- none --> J[detect_env_file\nlegacy fallback]
    J --> K{plain .env\nexists?}
    K -- yes --> L[Return found\ndefault env]
    K -- no --> M{lone .env.* file?}
    M -- yes --> N{suffix ==\nrequested env?}
    N -- yes --> O[Return found]
    N -- no --> P[Return not_found\n⚠️ FIX for #395: skip]
    M -- ">1" --> Q[Return multiple_found]
    M -- none --> R[Return not_found]
```

<sub>Reviews (6): Last reviewed commit: ["test(vault-push): share --all scaffold t..."](https://github.com/jainal09/envdrift/commit/4087a383a87a86df7fadb91f66e170fd9cd10f53) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36051861)</sub>

<!-- /greptile_comment -->