### PR TITLE
ci: add a required-able repo-wide Lint gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ permissions:
   contents: read
 
 jobs:
-  tests:
-    name: Tests & Coverage
+  lint:
+    name: Lint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -32,6 +32,30 @@ jobs:
       - name: Lint with ruff
         run: uv run ruff check src tests
 
+      - name: Check formatting with ruff
+        run: uv run ruff format --check .
+
+      - name: Lint markdown docs
+        run: make lint-docs
+
+  tests:
+    name: Tests & Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.2.0
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
       - name: Type check with pyrefly
         run: uv run pyrefly check
 
@@ -43,9 +67,6 @@ jobs:
 
       - name: Run integration tests
         run: uv run pytest -m integration --cov-append
-
-      - name: Lint markdown docs
-        run: make lint-docs
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v7


### PR DESCRIPTION
## What

Splits ruff + markdownlint out of the `Tests & Coverage` job into a dedicated, always-running **`Lint`** job, and adds `ruff format --check .` (previously a local-only pre-commit gate that CI never enforced).

## Why

We want lint failures to **block merges**. The existing standalone `Lint` checks are component-scoped — agent (`golangci-lint`) in `agent-ci.yml` and vscode (ESLint) in `vscode-ci.yml` — and **path-filtered** to their components, so they don't run on src-only PRs. Marking `Lint` required while it's component-scoped would permanently block every src-only PR (the check never reports → "Expected — Lint").

This `Lint` job lives in `ci.yml`, which runs on **every** PR (no path filter), so the `Lint` context always reports and can be safely added to the required status checks on `main`.

## Notes

- `Tests & Coverage` keeps pyrefly + bandit + unit/integration tests + coverage (type/security/tests).
- `ruff format --check .` is **new in CI** — verified it passes on current `main` (179 files already formatted), so it won't retroactively fail.
- Follow-up (separate): after this merges I'll add `Lint` to the required status checks, and pin `golangci-lint` (agent CI currently uses `version: latest`, which 429s fetching its remote config).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR splits the single `CI` job into two parallel jobs — `Lint` and `Tests & Coverage` — so that lint failures can be enforced as a required status check on `main` without blocking PRs that only touch non-Python components. It also promotes `ruff format --check .` from a local pre-commit hook into a CI-enforced gate.

- **New `Lint` job**: runs `ruff check`, `ruff format --check .` (new CI step), and `markdownlint` on every PR with no path filter, making it safe to mark as a required check.
- **`Tests & Coverage` job**: retains pyrefly, bandit, unit/integration tests, and Codecov upload; setup boilerplate is duplicated between jobs as expected for parallel execution.
- Both jobs use `uv sync --all-extras`; the `lint` job could use a lighter `uv sync` since it only needs `ruff`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a straightforward CI restructuring with no impact on production code.

The only change is splitting one workflow job into two parallel jobs and adding a formatting check. The lint-docs step was already present in the old job and is simply relocated; no new tools or permissions are introduced. The new ruff format --check step was verified against main before this PR. The sole observation is that the lint job uses --all-extras when a plain uv sync would suffice, which is a minor inefficiency with no correctness impact.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Splits a monolithic CI job into parallel Lint and Tests & Coverage jobs; adds ruff format --check as a new CI gate; both jobs correctly duplicate the setup boilerplate as expected for parallel execution. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    PR[Pull Request / Push to main]
    PR --> L[lint job]
    PR --> T[tests job]

    subgraph L[Lint job]
        L1[Checkout] --> L2[Setup Python 3.14]
        L2 --> L3[Install uv + uv sync --all-extras]
        L3 --> L4[ruff check src tests]
        L4 --> L5[ruff format --check . NEW]
        L5 --> L6[make lint-docs / markdownlint]
    end

    subgraph T[Tests & Coverage job]
        T1[Checkout] --> T2[Setup Python 3.14]
        T2 --> T3[Install uv + uv sync --all-extras]
        T3 --> T4[pyrefly type check]
        T4 --> T5[bandit security check]
        T5 --> T6[pytest unit tests]
        T6 --> T7[pytest integration tests --cov-append]
        T7 --> T8[Upload coverage to Codecov]
    end

    L --> GATE{Required status check on main}
    T --> GATE
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.github/workflows/ci.yml`, line 29-32 ([link](https://github.com/jainal09/envdrift/blob/b3416920106168b51721ec76ca8ece4b8bbe4e23/.github/workflows/ci.yml#L29-L32)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The `lint` job installs all optional Python extras via `--all-extras` but only needs `ruff` to run the two lint steps. Dropping `--all-extras` here speeds up the job and avoids pulling in heavy optional packages that are only relevant for tests. (This is the same call that's in the `tests` job, where all extras are legitimately needed for integration tests.)

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["ci: split lint into a dedicated always-r..."](https://github.com/jainal09/envdrift/commit/b3416920106168b51721ec76ca8ece4b8bbe4e23) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36056945)</sub>

<!-- /greptile_comment -->