### PR TITLE
ci: dedup Lint check names and pin golangci-lint

### DIFF
--- a/.github/workflows/agent-ci.yml
+++ b/.github/workflows/agent-ci.yml
@@ -192,7 +192,9 @@ jobs:
         run: ..\bin\envdrift-agent-windows-amd64.exe --help
 
   lint:
-    name: Lint
+    # Named "Agent Lint" (not "Lint") so it does not collide with the required
+    # repo-wide "Lint" status check from ci.yml on PRs that touch envdrift-agent/**.
+    name: Agent Lint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -207,5 +209,9 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: latest
+          # Pinned (not "latest"): "latest" makes the action fetch its
+          # version-mapping config from raw.githubusercontent.com on every run,
+          # which 429s under rate limiting (see #410). Bumped by Renovate.
+          # renovate: datasource=github-releases depName=golangci/golangci-lint
+          version: v2.12.2
           working-directory: envdrift-agent

--- a/.github/workflows/vscode-ci.yml
+++ b/.github/workflows/vscode-ci.yml
@@ -22,7 +22,9 @@ defaults:
 
 jobs:
   lint:
-    name: Lint
+    # Named "VS Code Lint" (not "Lint") so it does not collide with the required
+    # repo-wide "Lint" status check from ci.yml on PRs that touch envdrift-vscode/**.
+    name: VS Code Lint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/renovate.json
+++ b/renovate.json
@@ -80,6 +80,13 @@
       "matchStrings": ["\"detect_secrets_version\":\\s*\"(?<currentValue>\\d+\\.\\d+\\.\\d+)\""],
       "depNameTemplate": "detect-secrets",
       "datasourceTemplate": "pypi"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^\\.github/workflows/agent-ci\\.yml$/"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s+version:\\s*(?<currentValue>v\\d+\\.\\d+\\.\\d+)"
+      ]
     }
   ],
   "packageRules": [

--- a/renovate.json
+++ b/renovate.json
@@ -83,7 +83,7 @@
     },
     {
       "customType": "regex",
-      "managerFilePatterns": ["/^\\.github/workflows/agent-ci\\.yml$/"],
+      "managerFilePatterns": ["/^\\.github/workflows/.*\\.ya?ml$/"],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s+version:\\s*(?<currentValue>v\\d+\\.\\d+\\.\\d+)"
       ]


### PR DESCRIPTION
Closes #409, closes #410.

## What

Two CI-reliability fixes for the `Lint` gate added in #408:

1. **Dedup `Lint` check names (#409).** `ci.yml` (required, repo-wide Python lint), `agent-ci.yml`, and `vscode-ci.yml` all named their job `Lint`. On a PR touching `envdrift-agent/**` or `envdrift-vscode/**`, GitHub saw multiple check-runs named `Lint`, making the required-check resolution ambiguous (could let a failing component lint through, or block unpredictably). Renamed:
   - agent-ci `Lint` → **`Agent Lint`**
   - vscode-ci `Lint` → **`VS Code Lint`**
   - The required `Lint` context is now unambiguously the `ci.yml` Python lint.

2. **Pin golangci-lint (#410).** `version: latest` makes `golangci-lint-action` fetch its version-mapping config from `raw.githubusercontent.com` every run — which **429'd on #401**. Pinned to `v2.12.2` (skips that fetch) + added a Renovate custom manager (inline `# renovate:` annotation) so it's bumped automatically.

## Verification

- This PR touches both `agent-ci.yml` and `vscode-ci.yml`, so it exercises **`Agent Lint`** (with the pinned golangci-lint) and **`VS Code Lint`** directly — they should report under the new names, and the required `Lint` still reports from `ci.yml`.
- YAML + `renovate.json` validated locally.

> Note: this only renames jobs and pins a version — no behavior change to the lints themselves. Whether to *require* `Agent Lint` / `VS Code Lint` (so component lint blocks their PRs) is a separate decision, noted in #409.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two CI reliability issues introduced in #408: duplicate `Lint` check names across workflows and a rate-limiting problem caused by using `version: latest` for golangci-lint.

- **Job renames**: `agent-ci.yml` and `vscode-ci.yml` lint jobs are renamed to `Agent Lint` and `VS Code Lint` respectively, so the required `Lint` status check from `ci.yml` is no longer ambiguous when a PR touches multiple components.
- **golangci-lint pinned to `v2.12.2`**: Avoids the `raw.githubusercontent.com` version-mapping fetch that was causing HTTP 429s; a new Renovate regex custom manager targeting all `/.github/workflows/*.ya?ml` files ensures the pinned version is bumped automatically via PR.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are limited to CI job name labels and a version pin with no behavioral effect on the lints themselves.

The job renames are cosmetic label changes that resolve genuine GitHub check-name ambiguity. Pinning golangci-lint to an explicit version is strictly more deterministic than `latest` and the Renovate custom manager ensures it stays current. The `managerFilePatterns` regex now correctly covers all workflow YAML files (widened from the previous `agent-ci.yml`-only scope noted in a prior review comment). No application logic is touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/agent-ci.yml | Lint job renamed from "Lint" to "Agent Lint" and golangci-lint pinned from `latest` to `v2.12.2` with a Renovate annotation for auto-bumping. |
| .github/workflows/vscode-ci.yml | Lint job renamed from "Lint" to "VS Code Lint" to prevent collision with the repo-wide required "Lint" status check from ci.yml. |
| renovate.json | New regex custom manager added to track `# renovate:` annotations across all `.github/workflows/*.yml` and `*.yaml` files, enabling automatic version bump PRs for pinned tool versions. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    PR[Pull Request]
    PR --> pathAgent{touches\nenvdrift-agent/**?}
    PR --> pathVSCode{touches\nenvdrift-vscode/**?}
    PR --> pathMain{touches\nmain Python?}

    pathAgent -- yes --> agentCI[agent-ci.yml]
    pathVSCode -- yes --> vscodeCI[vscode-ci.yml]
    pathMain -- yes --> ci[ci.yml]

    agentCI --> agentLint["✅ Agent Lint\n(was: Lint)"]
    vscodeCI --> vscodeLint["✅ VS Code Lint\n(was: Lint)"]
    ci --> lint["🔒 Lint (required)\nci.yml Python lint"]

    agentLint --> golangci["golangci-lint v2.12.2\n(pinned, no 429s)"]
    golangci --> renovate["Renovate monitors\n.github/workflows/*.yml\nfor # renovate: annotations"]
```

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into ci/lint-reliabi..."](https://github.com/jainal09/envdrift/commit/42425fef17fcdcac60b076feb7d147f1f7c6a156) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36081973)</sub>

<!-- /greptile_comment -->