### PR TITLE
ci: add codecov.yml to stop project status false-reds

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,53 @@
+# Codecov configuration for envdrift.
+#
+# Why this file exists (see #411):
+#   The global `codecov/project` status is a coverage ratchet over the *whole*
+#   project. Run-to-run coverage variance — flaky/skipped integration tests
+#   slightly shifting the merged total, or PRs that change no Python at all
+#   (e.g. a CI-only or docs-only change) — made it false-red on #405/#406/#407/
+#   #408/#412 even when the PR's own changed lines were fully covered. That
+#   chronic red is noise and undermines "all green = actually green".
+#
+# The fix:
+#   - `project` gets a small absolute `threshold` (0.5%) so sub-noise dips no
+#     longer fail the status, while a genuine, meaningful drop still flags.
+#   - `patch` stays the *real* gate: changed lines must stay covered (target
+#     80%, matching our "touched files ≥ 80%" convention in CLAUDE.md).
+#
+# YAML is validated in CI / locally with PyYAML.
+
+coverage:
+  # Round to two decimals and treat coverage as a percentage.
+  precision: 2
+  round: down
+  range: "80...100"
+
+  status:
+    # Whole-project coverage. Informational-ish: a tiny threshold absorbs the
+    # run-to-run variance that caused the false-reds, so only a real regression
+    # turns it red.
+    project:
+      default:
+        target: auto
+        # Allow the total to dip by up to 0.5% vs. the base without failing.
+        threshold: 0.5%
+        # A PR that touches no measured code shouldn't fail the project status.
+        if_ci_failed: error
+        only_pulls: false
+
+    # Changed-lines coverage — THE real gate. New/modified lines must stay
+    # covered; this is what enforces our "touched files ≥ 80%" rule.
+    patch:
+      default:
+        target: 80%
+        threshold: 0%
+
+# Don't fail the whole CI run on a Codecov upload hiccup; the status checks
+# above are what matter.
+codecov:
+  require_ci_to_pass: false
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: false

--- a/codecov.yml
+++ b/codecov.yml
@@ -30,8 +30,11 @@ coverage:
       default:
         target: auto
         # Allow the total to dip by up to 0.5% vs. the base without failing.
+        # (No-Python-change PRs are absorbed by this threshold, not by
+        # `if_ci_failed`.)
         threshold: 0.5%
-        # A PR that touches no measured code shouldn't fail the project status.
+        # If CI crashes before coverage is generated, surface an error rather
+        # than silently passing the status.
         if_ci_failed: error
         only_pulls: false
 
@@ -50,4 +53,6 @@ codecov:
 comment:
   layout: "reach, diff, flags, files"
   behavior: default
-  require_changes: false
+  # Don't post a coverage comment when the PR has no coverage delta (e.g.
+  # CI-only/docs-only changes) — keeps the noise-reduction goal consistent.
+  require_changes: true


### PR DESCRIPTION
## What

Adds a repo-root `codecov.yml` so the global `codecov/project` status stops
false-red'ing on sub-noise / no-Python-change PRs, while keeping `codecov/patch`
as the real coverage gate on changed lines.

Closes #411. (Context: part of the reliability audit umbrella #413, Cluster F — codecov signal.)

## Why

`codecov/project` is a whole-project coverage ratchet. Run-to-run variance —
flaky/skipped integration tests slightly shifting the merged total, or PRs that
change **no Python at all** — made it report **FAILURE** on #405, #406, #407,
#408, and #412 even when the PR's own changed lines were fully covered
(`codecov/patch` green). That chronic red is noise and undermines
"all green = actually green".

## Findings fixed

- **CI: `codecov/project` produces false-red on PRs (global ratchet noise)** —
  issue #411 (no `codecov.yml` existed at repo root, `main` @ 2bf7075).

## How

`codecov.yml`:
- `coverage.status.project.default.threshold: 0.5%` — absorbs run-to-run
  coverage variance so only a genuine regression turns the status red.
- `coverage.status.patch.default.target: 80%` (threshold `0%`) — **the real
  gate**; new/modified lines must stay covered, matching our "touched files
  ≥ 80%" convention.
- The choice (small threshold vs `informational`) is documented in a comment at
  the top of the file.

## Validation

- Parses with PyYAML.
- Accepted by Codecov's own validation API (`https://codecov.io/validate` →
  `Valid!`), which confirms `project.threshold == 0.5` and `patch.target == 80.0`.

## Tests

Config-only change (CI behavior, no Python touched), so there is no unit/regression
test to add. Validated the YAML parses and is schema-valid as above.

## Acceptance criteria (#411)

- [x] `codecov/project` no longer reports FAILURE for sub-threshold /
  no-Python-change PRs (0.5% threshold).
- [x] `codecov/patch` still enforces coverage on changed lines (target 80%).
- [x] Documented choice (threshold vs informational) in `codecov.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added code coverage configuration to establish coverage requirements and thresholds for quality assurance, including CI integration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `codecov.yml` at the repo root to stop `codecov/project` from false-red'ing on PRs that touch no Python or cause sub-noise coverage variance. The patch status remains the real gate at 80% target for changed lines.

- Adds `coverage.status.project.default.threshold: 0.5%` to absorb run-to-run variance, and `target: auto` so the ratchet tracks the base commit rather than a fixed number.
- Adds `coverage.status.patch.default.target: 80%` with `threshold: 0%` as the strict gate on changed lines.
- Sets `comment.require_changes: true` to suppress PR comments on no-coverage-delta changes, consistent with the noise-reduction goal.

<h3>Confidence Score: 5/5</h3>

Config-only change; no application code touched and the YAML is schema-valid per Codecov's own validation API.

The new codecov.yml is a well-scoped CI configuration change. The project threshold (0.5%) absorbs run-to-run variance without hiding real regressions, the patch gate (80%, 0% tolerance) is correctly strict on changed lines, and require_changes: true keeps the noise-reduction goal consistent for no-Python-change PRs. No Python source code is affected.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| codecov.yml | New Codecov config file; project/patch thresholds are correct, comments are accurate, and the require_changes/if_ci_failed settings are well-chosen. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PR opened / push to branch] --> B{Coverage data uploaded?}
    B -- No / CI crash --> C[if_ci_failed: error\nproject status → ERROR]
    B -- Yes --> D{Any Python lines changed?}
    D -- No --> E[require_changes: true\nNo PR comment posted]
    D -- Yes --> F[Evaluate patch status\ntarget 80%, threshold 0%]
    F -- changed lines ≥ 80% --> G[patch ✅ GREEN]
    F -- changed lines < 80% --> H[patch ❌ RED — blocks merge]
    B -- Yes --> I[Evaluate project status\ntarget: auto, threshold 0.5%]
    I -- total drop ≤ 0.5% --> J[project ✅ GREEN]
    I -- total drop > 0.5% --> K[project ❌ RED]
```

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/codecov-pro..."](https://github.com/jainal09/envdrift/commit/86812108f4720590c9170fbcebc3eb606c28408d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36083066)</sub>

<!-- /greptile_comment -->