### PR TITLE
fix(sync): gitignore decrypted merge artifact and guard non-UTF-8 env reads

### DIFF
--- a/docs/cli/pull.md
+++ b/docs/cli/pull.md
@@ -106,8 +106,14 @@ When this flag is used with partial encryption enabled, the command will:
 
 1. Decrypt `.env.{env}.secret` files
 2. Merge `.env.{env}.clear` + decrypted `.env.{env}.secret` → `.env.{env}`
+3. Add the combined file to `.gitignore` (it contains decrypted secrets)
 
 This creates a single usable `.env` file for local development.
+
+> **Note:** The merged `.env.{env}` file contains decrypted secrets, so it is
+> added to `.gitignore` (just like `envdrift push`) to keep a routine
+> `git add .` from staging plaintext secrets. Commit only the `.clear` and
+> `.secret` files, never the combined file.
 
 ```bash
 # Decrypt and merge partial encryption files

--- a/src/envdrift/cli_commands/sync.py
+++ b/src/envdrift/cli_commands/sync.py
@@ -337,6 +337,31 @@ def _run_tasks(tasks: list[Any], worker, max_workers: int | None):
         return list(executor.map(worker, tasks))
 
 
+def _write_merged_combined_file(clear_file: Path, secret_file: Path, combined_file: Path) -> None:
+    """Write ``combined_file`` from the clear file plus the decrypted secret file.
+
+    The dotenvx header comments (``#/---`` banner and ``DOTENV_PUBLIC_KEY``) are
+    stripped from the secret content so the merged file is a clean .env. The
+    resulting file holds DECRYPTED secrets and must already be gitignored by the
+    caller (see ``_ensure_combined_gitignore``).
+    """
+    combined_lines: list[str] = []
+
+    if clear_file.exists():
+        combined_lines.extend(clear_file.read_text(encoding="utf-8").splitlines())
+        combined_lines.append("")
+
+    if secret_file.exists():
+        combined_lines.extend(
+            line
+            for line in secret_file.read_text(encoding="utf-8").splitlines()
+            if not line.strip().startswith("#/---")
+            and not line.strip().startswith("DOTENV_PUBLIC_KEY")
+        )
+
+    combined_file.write_text("\n".join(combined_lines) + "\n", encoding="utf-8")
+
+
 def sync(
     config_file: Annotated[
         Path | None,
@@ -974,29 +999,9 @@ def pull(
                 # Merge if requested
                 if merge:
                     combined_file = Path(env_config.combined_file)
-                    clear_file = Path(env_config.clear_file)
-
-                    # Build combined content (decrypted version)
-                    combined_lines = []
-
-                    # Add clear file content
-                    if clear_file.exists():
-                        combined_lines.extend(clear_file.read_text().splitlines())
-                        combined_lines.append("")
-
-                    # Add decrypted secret file content
-                    if secret_file.exists():
-                        secret_content = secret_file.read_text().splitlines()
-                        # Skip dotenvx header comments
-                        secret_content = [
-                            line
-                            for line in secret_content
-                            if not line.strip().startswith("#/---")
-                            and not line.strip().startswith("DOTENV_PUBLIC_KEY")
-                        ]
-                        combined_lines.extend(secret_content)
-
-                    combined_file.write_text("\n".join(combined_lines) + "\n")
+                    _write_merged_combined_file(
+                        Path(env_config.clear_file), secret_file, combined_file
+                    )
                     console.print(
                         f"  [cyan]→[/cyan] {combined_file} [dim]- merged (decrypted)[/dim]"
                     )

--- a/src/envdrift/cli_commands/sync.py
+++ b/src/envdrift/cli_commands/sync.py
@@ -999,9 +999,16 @@ def pull(
                 # Merge if requested
                 if merge:
                     combined_file = Path(env_config.combined_file)
-                    _write_merged_combined_file(
-                        Path(env_config.clear_file), secret_file, combined_file
-                    )
+                    try:
+                        _write_merged_combined_file(
+                            Path(env_config.clear_file), secret_file, combined_file
+                        )
+                    except (OSError, UnicodeDecodeError) as e:
+                        console.print(
+                            f"  [red]![/red] {combined_file} [red]- merge failed: {e}[/red]"
+                        )
+                        partial_errors.append(f"{env_config.name}: {e}")
+                        continue
                     console.print(
                         f"  [cyan]→[/cyan] {combined_file} [dim]- merged (decrypted)[/dim]"
                     )

--- a/src/envdrift/cli_commands/sync.py
+++ b/src/envdrift/cli_commands/sync.py
@@ -460,7 +460,7 @@ def sync(
     # Run sync
     try:
         result = engine.sync_all()
-    except (VaultError, SyncConfigError, SecretNotFoundError) as e:
+    except (VaultError, SyncConfigError, SecretNotFoundError, OSError, UnicodeDecodeError) as e:
         print_error(f"Sync failed: {e}")
         raise typer.Exit(code=1) from None
 
@@ -918,6 +918,15 @@ def pull(
             pull_partial_encryption,
             pull_secrets_only,
         )
+
+        # When --merge writes combined files with DECRYPTED secrets, they must be
+        # gitignored just like `push` does — otherwise a routine `git add .` stages
+        # plaintext secrets. Mirror push's _ensure_combined_gitignore (which also
+        # protects the dotenvx .env.keys file) before writing anything (see #413).
+        if merge:
+            from envdrift.cli_commands.partial import _ensure_combined_gitignore
+
+            _ensure_combined_gitignore(partial_config.partial_encryption.environments)
 
         for env_config in partial_config.partial_encryption.environments:
             if env_config.secrets_only:

--- a/src/envdrift/sync/engine.py
+++ b/src/envdrift/sync/engine.py
@@ -352,8 +352,17 @@ class SyncEngine:
             return DecryptionTestResult.SKIPPED
         target_file = detection.path
 
+        # Reading the env file can raise for a non-UTF-8 file
+        # (UnicodeDecodeError) or an unreadable one (OSError). Neither must escape
+        # as a traceback: a file we cannot even decode/open is not a key we can
+        # verify, so treat it as a FAILED decryption test rather than crashing the
+        # whole sync run (see #413).
+        try:
+            content = target_file.read_text()
+        except (OSError, UnicodeDecodeError):
+            return DecryptionTestResult.FAILED
+
         # Check if file is encrypted (contains dotenvx markers)
-        content = target_file.read_text()
         if "encrypted:" not in content.lower():
             return DecryptionTestResult.SKIPPED
 

--- a/src/envdrift/sync/engine.py
+++ b/src/envdrift/sync/engine.py
@@ -358,7 +358,7 @@ class SyncEngine:
         # verify, so treat it as a FAILED decryption test rather than crashing the
         # whole sync run (see #413).
         try:
-            content = target_file.read_text()
+            content = target_file.read_text(encoding="utf-8")
         except (OSError, UnicodeDecodeError):
             return DecryptionTestResult.FAILED
 
@@ -382,14 +382,44 @@ class SyncEngine:
         except Exception:
             return DecryptionTestResult.FAILED
 
-        # The backup may only be deleted when the on-disk target file is in its
-        # original (encrypted) state: it was never modified, OR the happy-path
-        # re-encrypt restored it, OR every attempted restore succeeded. If the
-        # file has been decrypted on disk and a restore is attempted and *fails*,
-        # the target is left as plaintext secret on disk and the backup is the
-        # only recovery copy — so it must be preserved (see cubic P1 on #317).
-        backup_safe_to_delete = True
+        result, backup_safe_to_delete = self._dotenvx_roundtrip(
+            dotenvx_path, target_file, backup_path, mapping
+        )
 
+        # Only delete the backup when the file is in a known-good state. If a
+        # restore was attempted and failed, KEEP the backup as the recovery copy
+        # and warn the user that the file may be left decrypted.
+        if backup_safe_to_delete:
+            backup_path.unlink(missing_ok=True)
+        else:
+            logger.warning(
+                "Failed to restore %s after a decryption-test failure; the file "
+                "may be left decrypted. The backup has been preserved at %s — "
+                "restore it manually to recover the original encrypted file.",
+                target_file,
+                backup_path,
+            )
+
+        return result
+
+    def _dotenvx_roundtrip(
+        self,
+        dotenvx_path: str,
+        target_file: Path,
+        backup_path: Path,
+        mapping: ServiceMapping,
+    ) -> tuple[DecryptionTestResult, bool]:
+        """
+        Decrypt then re-encrypt ``target_file`` with dotenvx to verify the key.
+
+        A backup already exists at ``backup_path``; this helper never deletes it.
+
+        Returns:
+            ``(result, backup_safe_to_delete)``. ``backup_safe_to_delete`` is
+            ``False`` only when the on-disk file was decrypted and a subsequent
+            restore failed — the backup is then the only encrypted copy and the
+            caller must preserve it (see cubic P1 on #317).
+        """
         # Tracks whether the live target file has been rewritten to plaintext on
         # disk by `dotenvx decrypt`. Once True, any subsequent failure (a missing
         # dotenvx binary at the encrypt stage, a timeout, a vanished cwd, …) must
@@ -414,14 +444,14 @@ class SyncEngine:
                 )
             except FileNotFoundError:
                 # dotenvx not installed; the decrypt never ran and the file was
-                # never modified, so the backup is safe to delete (finally).
-                return DecryptionTestResult.SKIPPED
+                # never modified, so the backup is safe to delete.
+                return DecryptionTestResult.SKIPPED, True
 
             if result.returncode != 0:
                 # Decrypt failed: dotenvx may or may not have modified the file,
                 # so restore from backup to be conservative.
-                backup_safe_to_delete = self._safe_restore(backup_path, target_file)
-                return DecryptionTestResult.FAILED
+                safe = self._safe_restore(backup_path, target_file)
+                return DecryptionTestResult.FAILED, safe
 
             # Decrypt returned 0: the live file is now plaintext on disk. From
             # this point on the backup is the ONLY encrypted copy, so no failure
@@ -438,11 +468,11 @@ class SyncEngine:
             )
 
             if encrypt_result.returncode != 0:
-                backup_safe_to_delete = self._safe_restore(backup_path, target_file)
-                return DecryptionTestResult.FAILED
+                safe = self._safe_restore(backup_path, target_file)
+                return DecryptionTestResult.FAILED, safe
 
             # Happy path: the file is correctly re-encrypted, backup is disposable.
-            return DecryptionTestResult.PASSED
+            return DecryptionTestResult.PASSED, True
 
         except FileNotFoundError:
             # dotenvx vanished mid-run (e.g. at the encrypt stage). If the file
@@ -452,31 +482,17 @@ class SyncEngine:
             # preserve it if the restore fails so the plaintext file can be
             # recovered (never delete the only encrypted copy).
             if not file_modified:
-                return DecryptionTestResult.SKIPPED
-            backup_safe_to_delete = self._safe_restore(backup_path, target_file)
-            return DecryptionTestResult.FAILED
+                return DecryptionTestResult.SKIPPED, True
+            safe = self._safe_restore(backup_path, target_file)
+            return DecryptionTestResult.FAILED, safe
         except subprocess.TimeoutExpired:
-            backup_safe_to_delete = self._safe_restore(backup_path, target_file)
-            return DecryptionTestResult.FAILED
+            safe = self._safe_restore(backup_path, target_file)
+            return DecryptionTestResult.FAILED, safe
         except Exception:
             # Any other failure is a failed decryption test; restore only when a
             # backup actually exists so the restore cannot itself raise.
-            backup_safe_to_delete = self._safe_restore(backup_path, target_file)
-            return DecryptionTestResult.FAILED
-        finally:
-            # Only delete the backup when the file is in a known-good state. If a
-            # restore was attempted and failed, KEEP the backup as the recovery
-            # copy and warn the user that the file may be left decrypted.
-            if backup_safe_to_delete:
-                backup_path.unlink(missing_ok=True)
-            else:
-                logger.warning(
-                    "Failed to restore %s after a decryption-test failure; the file "
-                    "may be left decrypted. The backup has been preserved at %s — "
-                    "restore it manually to recover the original encrypted file.",
-                    target_file,
-                    backup_path,
-                )
+            safe = self._safe_restore(backup_path, target_file)
+            return DecryptionTestResult.FAILED, safe
 
     def _validate_schema(self, mapping: ServiceMapping) -> bool:
         """Run schema validation for the service."""

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -3072,30 +3072,19 @@ class TestPullCommand:
         assert "API_KEY=decrypted_key" in content
         assert "DB_PASS=decrypted_pass" in content
 
-    def test_pull_merge_gitignores_combined_file(
-        self,
-        monkeypatch,
-        tmp_path: Path,
-    ):
-        """Pull --merge must gitignore the decrypted combined file (#413).
+    @staticmethod
+    def _setup_merge_pull_env(monkeypatch, tmp_path: Path) -> dict[str, Path]:
+        """Build a real git repo + config for the ``pull --merge`` regression test.
 
-        Regression for #413: the ``--merge`` branch wrote a combined file
-        containing merged clear + DECRYPTED secret values but never added it to
-        ``.gitignore`` (unlike ``push``, which calls ``_ensure_combined_gitignore``
-        first). A routine ``git add .`` then staged plaintext secrets. This test
-        runs the real ``pull --merge`` path against a real git repo and asserts the
-        combined file lands in ``.gitignore``.
+        Returns the clear/secret/combined paths and the config file. Only the
+        vault/backend/hook seams are stubbed; the gitignore + combined-file
+        writing under test runs for real.
         """
         import subprocess
 
         # A real git repo so ensure_gitignore_entries can resolve the git root and
         # write a real .gitignore (no mock of the behavior under test).
-        subprocess.run(
-            ["git", "init"],
-            cwd=str(tmp_path),
-            capture_output=True,
-            check=True,
-        )
+        subprocess.run(["git", "init"], cwd=str(tmp_path), capture_output=True, check=True)
 
         service_dir = tmp_path / "service"
         service_dir.mkdir()
@@ -3153,11 +3142,7 @@ class TestPullCommand:
 
         sync_config = SyncConfig(
             mappings=[
-                ServiceMapping(
-                    secret_name="key",
-                    folder_path=service_dir,
-                    environment="prod",
-                )
+                ServiceMapping(secret_name="key", folder_path=service_dir, environment="prod")
             ],
         )
         monkeypatch.setattr(
@@ -3168,6 +3153,33 @@ class TestPullCommand:
             "envdrift.integrations.hook_check.ensure_git_hook_setup",
             lambda **_kwargs: [],
         )
+
+        return {
+            "clear_file": clear_file,
+            "secret_file": secret_file,
+            "combined_file": combined_file,
+            "config_file": config_file,
+        }
+
+    def test_pull_merge_gitignores_combined_file(
+        self,
+        monkeypatch,
+        tmp_path: Path,
+    ):
+        """Pull --merge must gitignore the decrypted combined file (#413).
+
+        Regression for #413: the ``--merge`` branch wrote a combined file
+        containing merged clear + DECRYPTED secret values but never added it to
+        ``.gitignore`` (unlike ``push``, which calls ``_ensure_combined_gitignore``
+        first). A routine ``git add .`` then staged plaintext secrets. This test
+        runs the real ``pull --merge`` path against a real git repo and asserts the
+        combined file lands in ``.gitignore``.
+        """
+        import subprocess
+
+        env = self._setup_merge_pull_env(monkeypatch, tmp_path)
+        combined_file = env["combined_file"]
+        config_file = env["config_file"]
 
         result = runner.invoke(app, ["pull", "-c", str(config_file), "--skip-sync", "--merge"])
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1935,6 +1935,61 @@ class TestSyncCommand:
         assert captured["kwargs"]["project_id"] == "my-gcp-project"
         assert captured["config"].default_vault_name == "gcp"
 
+    def test_sync_unicode_decode_error_exits_cleanly(self, monkeypatch, tmp_path: Path):
+        """A non-UTF-8 env file during sync exits 1, not a traceback (#413).
+
+        Regression for #413: ``sync --check-decryption`` read env files outside any
+        guard, so a non-UTF-8 file raised ``UnicodeDecodeError`` that escaped the
+        CLI's narrow ``except (VaultError, SyncConfigError, SecretNotFoundError)``.
+        The catch is now broadened to ``OSError``/``UnicodeDecodeError`` so the user
+        gets a clean error and exit code 1 instead of a crash.
+        """
+        config_file = tmp_path / "envdrift.toml"
+        config_file.write_text(
+            dedent(
+                """
+                [vault]
+                provider = "gcp"
+
+                [vault.gcp]
+                project_id = "my-gcp-project"
+
+                [vault.sync]
+                default_vault_name = "gcp"
+
+                [[vault.sync.mappings]]
+                secret_name = "dotenv-key"
+                folder_path = "services/api"
+                """
+            )
+        )
+        monkeypatch.chdir(tmp_path)
+
+        monkeypatch.setattr(
+            "envdrift.vault.get_vault_client",
+            lambda *_a, **_k: SimpleNamespace(ensure_authenticated=lambda: None),
+        )
+        monkeypatch.setattr("envdrift.output.rich.print_service_sync_status", lambda *_, **__: None)
+        monkeypatch.setattr("envdrift.output.rich.print_sync_result", lambda *_, **__: None)
+
+        class DummyEngine:
+            def __init__(self, config, vault_client, mode, prompt_callback, progress_callback):
+                pass
+
+            def sync_all(self):
+                # Simulate the real engine hitting a non-UTF-8 env file.
+                b"\xff\xfe".decode("utf-8")
+                raise AssertionError("decode above should have raised")
+
+        monkeypatch.setattr("envdrift.sync.engine.SyncEngine", DummyEngine)
+
+        result = runner.invoke(app, ["sync", "--check-decryption"])
+
+        assert result.exit_code == 1
+        assert "sync failed" in result.output.lower()
+        # No raw traceback leaked to the user.
+        assert "Traceback" not in result.output
+
     def test_sync_invalid_toml_config_errors(self, monkeypatch, tmp_path: Path):
         """Invalid TOML sync config should raise a SyncConfigError."""
 
@@ -3016,6 +3071,129 @@ class TestPullCommand:
         assert "DEBUG=true" in content
         assert "API_KEY=decrypted_key" in content
         assert "DB_PASS=decrypted_pass" in content
+
+    def test_pull_merge_gitignores_combined_file(
+        self,
+        monkeypatch,
+        tmp_path: Path,
+    ):
+        """Pull --merge must gitignore the decrypted combined file (#413).
+
+        Regression for #413: the ``--merge`` branch wrote a combined file
+        containing merged clear + DECRYPTED secret values but never added it to
+        ``.gitignore`` (unlike ``push``, which calls ``_ensure_combined_gitignore``
+        first). A routine ``git add .`` then staged plaintext secrets. This test
+        runs the real ``pull --merge`` path against a real git repo and asserts the
+        combined file lands in ``.gitignore``.
+        """
+        import subprocess
+
+        # A real git repo so ensure_gitignore_entries can resolve the git root and
+        # write a real .gitignore (no mock of the behavior under test).
+        subprocess.run(
+            ["git", "init"],
+            cwd=str(tmp_path),
+            capture_output=True,
+            check=True,
+        )
+
+        service_dir = tmp_path / "service"
+        service_dir.mkdir()
+
+        clear_file = service_dir / ".env.prod.clear"
+        secret_file = service_dir / ".env.prod.secret"
+        combined_file = service_dir / ".env.prod"
+
+        clear_file.write_text("APP_NAME=myapp\n")
+        secret_file.write_text("API_KEY=decrypted_key\n")
+
+        config_file = tmp_path / "envdrift.toml"
+        config_file.write_text(
+            dedent(
+                f"""
+                [vault]
+                provider = "aws"
+
+                [vault.sync]
+                [[vault.sync.mappings]]
+                secret_name = "key"
+                folder_path = "{service_dir.as_posix()}"
+                environment = "prod"
+
+                [partial_encryption]
+                enabled = true
+
+                [[partial_encryption.environments]]
+                name = "prod"
+                clear_file = "{clear_file.as_posix()}"
+                secret_file = "{secret_file.as_posix()}"
+                combined_file = "{combined_file.as_posix()}"
+                """
+            ).lstrip()
+        )
+
+        monkeypatch.setattr(
+            "envdrift.cli_commands.encryption_helpers.resolve_encryption_backend",
+            lambda *_args, **_kwargs: (
+                DummyEncryptionBackend(
+                    name="dotenvx",
+                    installed=True,
+                    has_encrypted_header=lambda _: False,
+                ),
+                EncryptionProvider.DOTENVX,
+                None,
+            ),
+        )
+        monkeypatch.setattr(
+            "envdrift.core.partial_encryption.pull_partial_encryption",
+            lambda _: (False, True),  # (was_decrypted, protected)
+        )
+
+        from envdrift.sync.config import ServiceMapping, SyncConfig
+
+        sync_config = SyncConfig(
+            mappings=[
+                ServiceMapping(
+                    secret_name="key",
+                    folder_path=service_dir,
+                    environment="prod",
+                )
+            ],
+        )
+        monkeypatch.setattr(
+            "envdrift.cli_commands.sync.load_sync_config_and_client",
+            lambda *_args, **_kwargs: (sync_config, SimpleNamespace(), "aws", None, None, None),
+        )
+        monkeypatch.setattr(
+            "envdrift.integrations.hook_check.ensure_git_hook_setup",
+            lambda **_kwargs: [],
+        )
+
+        result = runner.invoke(app, ["pull", "-c", str(config_file), "--skip-sync", "--merge"])
+
+        assert result.exit_code == 0, result.output
+        assert combined_file.exists()
+
+        # The decrypted combined artifact must be gitignored, matching `push`.
+        gitignore = tmp_path / ".gitignore"
+        assert gitignore.exists(), ".gitignore was not created for the decrypted combined file"
+        ignored = {line.strip() for line in gitignore.read_text().splitlines() if line.strip()}
+        combined_rel = combined_file.resolve().relative_to(tmp_path.resolve()).as_posix()
+        assert combined_rel in ignored, (
+            f"{combined_rel} not gitignored; .gitignore has: {sorted(ignored)}"
+        )
+
+        # `git status` must NOT see the combined file as untracked-and-stageable.
+        status = subprocess.run(
+            ["git", "status", "--porcelain", "--", combined_rel],
+            cwd=str(tmp_path),
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        assert status.stdout.strip() == "", (
+            f"combined file is still visible to git: {status.stdout!r}"
+        )
 
 
 class TestLockCommand:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -3073,30 +3073,8 @@ class TestPullCommand:
         assert "DB_PASS=decrypted_pass" in content
 
     @staticmethod
-    def _setup_merge_pull_env(monkeypatch, tmp_path: Path) -> dict[str, Path]:
-        """Build a real git repo + config for the ``pull --merge`` regression test.
-
-        Returns the clear/secret/combined paths and the config file. Only the
-        vault/backend/hook seams are stubbed; the gitignore + combined-file
-        writing under test runs for real.
-        """
-        import subprocess
-
-        # A real git repo so ensure_gitignore_entries can resolve the git root and
-        # write a real .gitignore (no mock of the behavior under test).
-        subprocess.run(["git", "init"], cwd=str(tmp_path), capture_output=True, check=True)
-
-        service_dir = tmp_path / "service"
-        service_dir.mkdir()
-
-        clear_file = service_dir / ".env.prod.clear"
-        secret_file = service_dir / ".env.prod.secret"
-        combined_file = service_dir / ".env.prod"
-
-        clear_file.write_text("APP_NAME=myapp\n")
-        secret_file.write_text("API_KEY=decrypted_key\n")
-
-        config_file = tmp_path / "envdrift.toml"
+    def _write_partial_config(config_file: Path, service_dir: Path, paths: dict[str, Path]) -> None:
+        """Write a sync TOML with one ``prod`` partial-encryption environment."""
         config_file.write_text(
             dedent(
                 f"""
@@ -3114,12 +3092,20 @@ class TestPullCommand:
 
                 [[partial_encryption.environments]]
                 name = "prod"
-                clear_file = "{clear_file.as_posix()}"
-                secret_file = "{secret_file.as_posix()}"
-                combined_file = "{combined_file.as_posix()}"
+                clear_file = "{paths["clear_file"].as_posix()}"
+                secret_file = "{paths["secret_file"].as_posix()}"
+                combined_file = "{paths["combined_file"].as_posix()}"
                 """
             ).lstrip()
         )
+
+    @staticmethod
+    def _stub_merge_pull_seams(monkeypatch, service_dir: Path) -> None:
+        """Stub only the vault/backend/hook seams for ``pull --merge`` tests.
+
+        The gitignore + combined-file writing under test still runs for real.
+        """
+        from envdrift.sync.config import ServiceMapping, SyncConfig
 
         monkeypatch.setattr(
             "envdrift.cli_commands.encryption_helpers.resolve_encryption_backend",
@@ -3137,9 +3123,6 @@ class TestPullCommand:
             "envdrift.core.partial_encryption.pull_partial_encryption",
             lambda _: (False, True),  # (was_decrypted, protected)
         )
-
-        from envdrift.sync.config import ServiceMapping, SyncConfig
-
         sync_config = SyncConfig(
             mappings=[
                 ServiceMapping(secret_name="key", folder_path=service_dir, environment="prod")
@@ -3154,12 +3137,35 @@ class TestPullCommand:
             lambda **_kwargs: [],
         )
 
-        return {
-            "clear_file": clear_file,
-            "secret_file": secret_file,
-            "combined_file": combined_file,
-            "config_file": config_file,
+    @classmethod
+    def _setup_merge_pull_env(cls, monkeypatch, tmp_path: Path) -> dict[str, Path]:
+        """Build a real git repo + config for the ``pull --merge`` regression test.
+
+        Returns the clear/secret/combined paths and the config file. Only the
+        vault/backend/hook seams are stubbed; the gitignore + combined-file
+        writing under test runs for real.
+        """
+        import subprocess
+
+        # A real git repo so ensure_gitignore_entries can resolve the git root and
+        # write a real .gitignore (no mock of the behavior under test).
+        subprocess.run(["git", "init"], cwd=str(tmp_path), capture_output=True, check=True)
+
+        service_dir = tmp_path / "service"
+        service_dir.mkdir()
+
+        paths = {
+            "clear_file": service_dir / ".env.prod.clear",
+            "secret_file": service_dir / ".env.prod.secret",
+            "combined_file": service_dir / ".env.prod",
+            "config_file": tmp_path / "envdrift.toml",
         }
+        paths["clear_file"].write_text("APP_NAME=myapp\n")
+        paths["secret_file"].write_text("API_KEY=decrypted_key\n")
+
+        cls._write_partial_config(paths["config_file"], service_dir, paths)
+        cls._stub_merge_pull_seams(monkeypatch, service_dir)
+        return paths
 
     def test_pull_merge_gitignores_combined_file(
         self,
@@ -3206,6 +3212,32 @@ class TestPullCommand:
         assert status.stdout.strip() == "", (
             f"combined file is still visible to git: {status.stdout!r}"
         )
+
+    def test_pull_merge_reports_error_on_non_utf8_secret(
+        self,
+        monkeypatch,
+        tmp_path: Path,
+    ):
+        """A non-UTF-8 secret file must surface a partial error, not crash.
+
+        The merge writer reads files as UTF-8; a decrypted secret with invalid
+        bytes raises ``UnicodeDecodeError``. ``pull --merge`` must catch it,
+        record a partial error, and exit 1 cleanly rather than propagating an
+        unhandled exception out of the command.
+        """
+        env = self._setup_merge_pull_env(monkeypatch, tmp_path)
+        # Overwrite the secret file with bytes that are not valid UTF-8 so the
+        # real merge writer (read_text(encoding="utf-8")) raises.
+        env["secret_file"].write_bytes(b"API_KEY=\xff\xfe_not_utf8\n")
+        config_file = env["config_file"]
+
+        result = runner.invoke(app, ["pull", "-c", str(config_file), "--skip-sync", "--merge"])
+
+        assert result.exit_code == 1, result.output
+        assert "merge failed" in result.output.lower()
+        assert "partial encryption" in result.output.lower()
+        # The decrypted combined artifact must not be left half-written.
+        assert not env["combined_file"].exists()
 
 
 class TestLockCommand:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -3239,6 +3239,47 @@ class TestPullCommand:
         # The decrypted combined artifact must not be left half-written.
         assert not env["combined_file"].exists()
 
+    @staticmethod
+    def test_write_merged_combined_file_handles_missing_inputs(tmp_path: Path):
+        """The merge writer tolerates a missing clear and/or secret file.
+
+        Exercises every existence branch of ``_write_merged_combined_file``:
+        both present, only clear, only secret, and neither. The header lines
+        from the secret file (``#/---`` banner, ``DOTENV_PUBLIC_KEY``) are
+        always stripped.
+        """
+        from envdrift.cli_commands.sync import _write_merged_combined_file
+
+        clear = tmp_path / ".env.clear"
+        secret = tmp_path / ".env.secret"
+        combined = tmp_path / ".env"
+
+        # Both present: clear lines, a blank separator, then stripped secret lines.
+        clear.write_text("APP=web\n")
+        secret.write_text("#/--- banner\nDOTENV_PUBLIC_KEY=abc\nAPI_KEY=k\n")
+        _write_merged_combined_file(clear, secret, combined)
+        body = combined.read_text()
+        assert "APP=web" in body
+        assert "API_KEY=k" in body
+        assert "banner" not in body
+        assert "DOTENV_PUBLIC_KEY" not in body
+
+        # Only the secret file present (clear missing): no separator needed.
+        clear.unlink()
+        _write_merged_combined_file(clear, secret, combined)
+        assert combined.read_text().strip() == "API_KEY=k"
+
+        # Only the clear file present (secret missing).
+        clear.write_text("APP=web\n")
+        secret.unlink()
+        _write_merged_combined_file(clear, secret, combined)
+        assert combined.read_text() == "APP=web\n\n"
+
+        # Neither input present: an empty (single trailing newline) combined file.
+        clear.unlink()
+        _write_merged_combined_file(clear, secret, combined)
+        assert combined.read_text() == "\n"
+
 
 class TestLockCommand:
     """Tests for the lock CLI command."""

--- a/tests/unit/test_sync_engine.py
+++ b/tests/unit/test_sync_engine.py
@@ -808,6 +808,73 @@ class TestSyncEngineDecryptionTest:
             for record in caplog.records
         )
 
+    def test_decryption_test_non_utf8_file_returns_failed(
+        self, mock_vault_client: MagicMock, tmp_path: Path
+    ) -> None:
+        """A non-UTF-8 env file yields FAILED, never an uncaught traceback (#413).
+
+        Regression for #413: the ``resolve_mapping_env_file()`` /
+        ``target_file.read_text()`` preamble ran *outside* the method's try/except.
+        A genuinely non-UTF-8 env file (e.g. one with stray ``0xff 0xfe`` bytes)
+        made ``read_text()`` raise ``UnicodeDecodeError``, which escaped
+        ``_test_decryption`` and crashed the whole ``sync --check-decryption`` run
+        with a traceback. The read is now guarded and returns FAILED.
+        """
+        mapping = ServiceMapping(
+            secret_name="test-key", folder_path=tmp_path, environment="production"
+        )
+        env_file = tmp_path / ".env.production"
+        # Real undecodable bytes: a plausible "encrypted" value with raw 0xff 0xfe
+        # that is not valid UTF-8 — write_bytes so no encoding step sanitizes it.
+        env_file.write_bytes(b"FOO=encrypted:abc\xff\xfe\n")
+
+        engine = SyncEngine(
+            config=SyncConfig(mappings=[mapping]),
+            vault_client=mock_vault_client,
+            mode=SyncMode(check_decryption=True),
+        )
+
+        # Must NOT raise UnicodeDecodeError; must return FAILED.
+        result = engine._test_decryption(mapping)
+
+        assert result == DecryptionTestResult.FAILED
+
+    def test_sync_all_non_utf8_file_does_not_crash(
+        self, mock_vault_client: MagicMock, tmp_path: Path
+    ) -> None:
+        """sync_all with check_decryption survives a non-UTF-8 env file (#413).
+
+        End-to-end guard: the full ``sync_all`` path (the real call site at
+        engine.py invoking ``_test_decryption``) must record FAILED for the
+        service rather than propagating ``UnicodeDecodeError``.
+        """
+        mock_vault_client.get_secret.return_value = SecretValue(name="test-key", value="secret123")
+
+        service_dir = tmp_path / "service1"
+        service_dir.mkdir()
+        (service_dir / ".env.production").write_bytes(b"FOO=encrypted:abc\xff\xfe\n")
+
+        config = SyncConfig(
+            mappings=[
+                ServiceMapping(
+                    secret_name="test-key",
+                    folder_path=service_dir,
+                    environment="production",
+                ),
+            ],
+        )
+
+        engine = SyncEngine(
+            config=config,
+            vault_client=mock_vault_client,
+            mode=SyncMode(check_decryption=True),
+        )
+
+        # Must complete without raising.
+        result = engine.sync_all()
+
+        assert result.services[0].decryption_result == DecryptionTestResult.FAILED
+
 
 class TestSyncEngineFetchVaultSecret:
     """Tests for vault secret fetching."""


### PR DESCRIPTION
Fixes two HIGH reliability findings from the #413 audit — **cluster B (sync data-loss / crash)**.

## Findings fixed

### 1. `pull --merge` writes a decrypted combined `.env` without adding it to `.gitignore` (HIGH)
`src/envdrift/cli_commands/sync.py` (~965-994)

The `--merge` branch of `pull` wrote a combined file containing merged clear + **DECRYPTED** secret values (`write_text`) but never protected it via `.gitignore`, unlike partial-encryption `push` which calls `_ensure_combined_gitignore` first. Because `pull --merge` skipped this, the plaintext combined file was left untracked-and-unignored, so a routine `git add .` would stage decrypted secrets.

**Fix:** the `--merge` branch now calls the same `_ensure_combined_gitignore` helper (which also protects the dotenvx `.env.keys` file) before writing any combined file, matching `push`.

### 2. `sync --check-decryption` crashes with uncaught `UnicodeDecodeError`/`OSError` on an unreadable or non-UTF-8 env file (HIGH)
`src/envdrift/sync/engine.py:356` (read_text was OUTSIDE the try); CLI catch at `src/envdrift/cli_commands/sync.py:463`

The `resolve_mapping_env_file()` / `read_text()` preamble in `_test_decryption` ran outside the method's try/except, so a non-UTF-8 env file (e.g. `b"FOO=encrypted:abc\xff\xfe\n"`) raised `UnicodeDecodeError` that escaped the method and crashed the whole `sync --check-decryption` run with a traceback.

**Fix:** the `read_text()` is now guarded, returning `DecryptionTestResult.FAILED` on `OSError`/`UnicodeDecodeError`. The CLI catch in `sync()` is also broadened to `OSError`/`UnicodeDecodeError` as defense in depth.

## Regression tests
Each verified to **fail on unfixed code** and **pass with the fix**:

- `tests/unit/test_cli.py::TestPullCommand::test_pull_merge_gitignores_combined_file` — drives the real `pull --merge` path against a real `git init` repo; asserts the combined file lands in `.gitignore` and `git status --porcelain` no longer sees it.
- `tests/unit/test_sync_engine.py::TestSyncEngineDecryptionTest::test_decryption_test_non_utf8_file_returns_failed` and `::test_sync_all_non_utf8_file_does_not_crash` — a real non-UTF-8 env file yields `FAILED`, not a traceback (both `_test_decryption` and the full `sync_all` path).
- `tests/unit/test_cli.py::TestSyncCommand::test_sync_unicode_decode_error_exits_cleanly` — the broadened CLI catch exits 1 with "Sync failed" and no leaked traceback.

## Docs
Updated `docs/cli/pull.md` to document that `pull --merge` now gitignores the decrypted combined file (consistent with `push`).

## Gates
`ruff check` + `ruff format --check` + `pyrefly check` + `bandit` + targeted `pytest` (183 passed) all green. Touched source files stay ≥80% line coverage; the changed lines are covered by the new tests.

Refs #413. Does not merge or enable auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR addresses two reliability issues from audit #413: `pull --merge` now calls `_ensure_combined_gitignore` before writing combined files containing decrypted secrets, and `_test_decryption` now guards `read_text` in a `try/except` that returns `FAILED` instead of crashing on non-UTF-8 or unreadable env files. As a side effect, `_test_decryption` is refactored to extract a `_dotenvx_roundtrip` helper, moving the backup-cleanup logic from a `finally` block to inline handling after the helper returns.

- **Gitignore guard for `pull --merge`**: `_ensure_combined_gitignore` is now called once before the environment loop, mirroring the `push` path. The merge-write logic is also extracted into `_write_merged_combined_file` with explicit `encoding=\"utf-8\"` and an `(OSError, UnicodeDecodeError)` catch that records a partial error and continues rather than crashing.
- **Non-UTF-8 guard in `_test_decryption`**: `target_file.read_text(encoding=\"utf-8\")` is now inside a `try/except (OSError, UnicodeDecodeError)` that returns `DecryptionTestResult.FAILED`, and the CLI's `sync()` catch is broadened to include the same exceptions as defence-in-depth.
- **New regression tests** cover all four patched paths (gitignore creation, non-UTF-8 engine crash, non-UTF-8 pull-merge error, and clean CLI exit), with each confirmed to fail on unfixed code.

<h3>Confidence Score: 5/5</h3>

Safe to merge — both fixes are correctly scoped, the refactored backup-handling path in `_dotenvx_roundtrip` preserves the original `finally` semantics, and regression tests for all four patched paths are included.

The gitignore guard is placed before the environment loop so it runs once for all combined files before any write occurs. The `read_text` guard in `_test_decryption` is correctly inside the `try/except` that maps to `FAILED`. The `_dotenvx_roundtrip` extraction moves backup cleanup from a `finally` block to inline post-call logic — the helper is exhaustively exception-safe (`except Exception` at its outermost layer), so the inline handler always runs. New tests drive the actual file-system paths rather than mocking the code under test.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/envdrift/cli_commands/sync.py | Adds `_write_merged_combined_file` helper with UTF-8 enforcement and error handling; guards pull --merge with `_ensure_combined_gitignore` before the environment loop; broadens CLI `sync()` catch to `OSError`/`UnicodeDecodeError`. |
| src/envdrift/sync/engine.py | Guards `read_text` in `_test_decryption` with `(OSError, UnicodeDecodeError)` returning FAILED; extracts `_dotenvx_roundtrip` helper, replacing the `finally`-based backup cleanup with inline tuple-return handling — semantics are preserved. |
| tests/unit/test_cli.py | Adds four regression tests covering gitignore creation, non-UTF-8 merge error, missing-input merge writer branches, and clean CLI exit on UnicodeDecodeError from sync engine. |
| tests/unit/test_sync_engine.py | Adds two regression tests: `_test_decryption` returns FAILED (not traceback) for a non-UTF-8 env file, and `sync_all` completes without raising when a non-UTF-8 file is encountered. |
| docs/cli/pull.md | Documents that `pull --merge` now adds the combined file to `.gitignore`, consistent with `push` behaviour. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["pull --merge invoked"] --> B["_ensure_combined_gitignore(environments)"]
    B --> C["For each env_config"]
    C --> D{"secrets_only?"}
    D -- Yes --> E["pull_secrets_only()"] --> C
    D -- No --> F{"secret_file exists?"}
    F -- No --> G["skip, continue"] --> C
    F -- Yes --> H["pull_partial_encryption(env_config)"]
    H --> I{"merge flag?"}
    I -- No --> C
    I -- Yes --> J["_write_merged_combined_file(clear, secret, combined)"]
    J --> K{"read_text UTF-8 raises?"}
    K -- "OSError / UnicodeDecodeError" --> L["partial_errors.append()\ncontinue"] --> C
    K -- Success --> M["combined_file.write_text(encoding=utf-8)"] --> C

    subgraph engine ["SyncEngine._test_decryption"]
        N["resolve_mapping_env_file()"] --> O{"file found?"}
        O -- No --> P["SKIPPED"]
        O -- Yes --> Q["target_file.read_text(encoding=utf-8)"]
        Q --> R{"OSError / UnicodeDecodeError?"}
        R -- Yes --> S["return FAILED"]
        R -- No --> T{"contains 'encrypted:'?"}
        T -- No --> U["SKIPPED"]
        T -- Yes --> V["_dotenvx_roundtrip()"]
        V --> W{"backup_safe_to_delete?"}
        W -- Yes --> X["backup.unlink()"]
        W -- No --> Y["logger.warning()\nkeep backup"]
    end
```

<sub>Reviews (4): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/sync-datalo..."](https://github.com/jainal09/envdrift/commit/cbdc2ae63213f180c28eea1cb905084597568736) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36083374)</sub>

<!-- /greptile_comment -->