### PR TITLE
fix(vault): wrap transport errors and coerce non-string HashiCorp values

### DIFF
--- a/src/envdrift/vault/aws.py
+++ b/src/envdrift/vault/aws.py
@@ -53,33 +53,34 @@ _ACCESS_DENIED_CODES = ("AccessDeniedException", "UnauthorizedException")
 def _map_aws_error(
     e: Exception,
     *,
-    transport_msg: str,
+    error_msg: str,
     not_found: tuple[str, str] | None = None,
     access_denied: tuple[tuple[str, ...], str] | None = None,
-    generic_msg: str,
 ) -> Exception:
     """Translate a botocore/boto3 exception into a domain VaultError.
 
     Centralizes the catch-ladder shared by every AWS operation so each method
-    delegates instead of repeating the `BotoCoreError`-then-error-code branches:
+    delegates instead of repeating the `BotoCoreError`-then-error-code branches.
+    `error_msg` is the generic prefix used for both transport failures and
+    unclassified error codes (always the same text per call site):
 
     - `BotoCoreError` (transport/connectivity, no `.response`) -> ``VaultError``.
     - An error code matching `not_found` (code, message) -> ``SecretNotFoundError``.
     - An error code in `access_denied` (codes, message) -> ``AuthenticationError``.
-    - Any other code -> ``VaultError(generic_msg)``.
+    - Any other error code -> ``VaultError(error_msg)``.
 
     Returns the exception to raise, or re-raises ``e`` unchanged when it carries
     no recognizable error code (so the caller's ``raise`` semantics are preserved).
     """
     if isinstance(e, BotoCoreError):
-        return VaultError(f"{transport_msg}: {e}")
+        return VaultError(f"{error_msg}: {e}")
     error_code = _get_error_code(e)
     if not_found is not None and error_code == not_found[0]:
         return SecretNotFoundError(not_found[1])
     if access_denied is not None and error_code in access_denied[0]:
         return AuthenticationError(access_denied[1])
     if error_code:
-        return VaultError(f"{generic_msg}: {e}")
+        return VaultError(f"{error_msg}: {e}")
     raise e
 
 
@@ -128,12 +129,11 @@ class AWSSecretsManagerClient(VaultClient):
             # error codes both map to the domain hierarchy via the shared helper.
             raise _map_aws_error(
                 e,
-                transport_msg="AWS Secrets Manager error",
+                error_msg="AWS Secrets Manager error",
                 access_denied=(
                     ("AccessDenied", "InvalidClientTokenId"),
                     f"AWS authentication failed: {e}",
                 ),
-                generic_msg="AWS Secrets Manager error",
             ) from e
 
     def is_authenticated(self) -> bool:
@@ -222,10 +222,9 @@ class AWSSecretsManagerClient(VaultClient):
         except Exception as e:
             raise _map_aws_error(
                 e,
-                transport_msg=f"Failed to get secret {name}",
+                error_msg=f"Failed to get secret {name}",
                 not_found=("ResourceNotFoundException", f"Secret not found: {name}"),
                 access_denied=(_ACCESS_DENIED_CODES, f"Access denied for secret: {name}"),
-                generic_msg=f"Failed to get secret {name}",
             ) from e
 
     def list_secrets(self, prefix: str = "") -> list[str]:
@@ -259,9 +258,8 @@ class AWSSecretsManagerClient(VaultClient):
         except Exception as e:
             raise _map_aws_error(
                 e,
-                transport_msg="Failed to list secrets",
+                error_msg="Failed to list secrets",
                 access_denied=(_ACCESS_DENIED_CODES, "Access denied when listing secrets"),
-                generic_msg="Failed to list secrets",
             ) from e
 
     def _put_secret_value(self, name: str, value: str) -> SecretValue:
@@ -283,9 +281,8 @@ class AWSSecretsManagerClient(VaultClient):
         except Exception as e:
             raise _map_aws_error(
                 e,
-                transport_msg=f"Failed to set secret {name}",
+                error_msg=f"Failed to set secret {name}",
                 access_denied=(_ACCESS_DENIED_CODES, f"Access denied for secret: {name}"),
-                generic_msg=f"Failed to set secret {name}",
             ) from e
 
     def set_secret(self, name: str, value: str) -> SecretValue:
@@ -326,9 +323,8 @@ class AWSSecretsManagerClient(VaultClient):
                 return self._put_secret_value(name, value)
             raise _map_aws_error(
                 e,
-                transport_msg=f"Failed to set secret {name}",
+                error_msg=f"Failed to set secret {name}",
                 access_denied=(_ACCESS_DENIED_CODES, f"Access denied for secret: {name}"),
-                generic_msg=f"Failed to set secret {name}",
             ) from e
 
     def set_secret_dict(self, name: str, value: dict[str, Any]) -> SecretValue:

--- a/src/envdrift/vault/aws.py
+++ b/src/envdrift/vault/aws.py
@@ -46,6 +46,43 @@ def _get_error_code(e: Exception) -> str:
     return str(error.get("Code", ""))
 
 
+# Error codes that mean "authenticated but not authorized" across operations.
+_ACCESS_DENIED_CODES = ("AccessDeniedException", "UnauthorizedException")
+
+
+def _map_aws_error(
+    e: Exception,
+    *,
+    transport_msg: str,
+    not_found: tuple[str, str] | None = None,
+    access_denied: tuple[tuple[str, ...], str] | None = None,
+    generic_msg: str,
+) -> Exception:
+    """Translate a botocore/boto3 exception into a domain VaultError.
+
+    Centralizes the catch-ladder shared by every AWS operation so each method
+    delegates instead of repeating the `BotoCoreError`-then-error-code branches:
+
+    - `BotoCoreError` (transport/connectivity, no `.response`) -> ``VaultError``.
+    - An error code matching `not_found` (code, message) -> ``SecretNotFoundError``.
+    - An error code in `access_denied` (codes, message) -> ``AuthenticationError``.
+    - Any other code -> ``VaultError(generic_msg)``.
+
+    Returns the exception to raise, or re-raises ``e`` unchanged when it carries
+    no recognizable error code (so the caller's ``raise`` semantics are preserved).
+    """
+    if isinstance(e, BotoCoreError):
+        return VaultError(f"{transport_msg}: {e}")
+    error_code = _get_error_code(e)
+    if not_found is not None and error_code == not_found[0]:
+        return SecretNotFoundError(not_found[1])
+    if access_denied is not None and error_code in access_denied[0]:
+        return AuthenticationError(access_denied[1])
+    if error_code:
+        return VaultError(f"{generic_msg}: {e}")
+    raise e
+
+
 class AWSSecretsManagerClient(VaultClient):
     """AWS Secrets Manager implementation.
 
@@ -86,20 +123,18 @@ class AWSSecretsManagerClient(VaultClient):
             sts.get_caller_identity()
         except (NoCredentialsError, PartialCredentialsError) as e:
             raise AuthenticationError(f"AWS authentication failed: {e}") from e
-        except BotoCoreError as e:
-            # Transport/connectivity failures (EndpointConnectionError,
-            # ConnectTimeoutError, ReadTimeoutError, ...) subclass BotoCoreError
-            # and carry no `.response`, so they never reach the error-code branches
-            # below. Wrap them in the domain hierarchy instead of letting a raw
-            # botocore exception escape to the CLI as an uncaught traceback.
-            raise VaultError(f"AWS Secrets Manager error: {e}") from e
         except Exception as e:
-            error_code = _get_error_code(e)
-            if error_code in ("AccessDenied", "InvalidClientTokenId"):
-                raise AuthenticationError(f"AWS authentication failed: {e}") from e
-            if error_code:
-                raise VaultError(f"AWS Secrets Manager error: {e}") from e
-            raise
+            # Transport failures (BotoCoreError, no `.response`) and credential
+            # error codes both map to the domain hierarchy via the shared helper.
+            raise _map_aws_error(
+                e,
+                transport_msg="AWS Secrets Manager error",
+                access_denied=(
+                    ("AccessDenied", "InvalidClientTokenId"),
+                    f"AWS authentication failed: {e}",
+                ),
+                generic_msg="AWS Secrets Manager error",
+            ) from e
 
     def is_authenticated(self) -> bool:
         """
@@ -184,21 +219,14 @@ class AWSSecretsManagerClient(VaultClient):
             # Already a domain error (e.g. malformed-response above); do not
             # re-wrap or misclassify it via the AWS error-code branches below.
             raise
-        except BotoCoreError as e:
-            # Transport/connectivity failures carry no `.response` (error_code == "")
-            # and would otherwise escape via the bare `raise` below. Surface them as
-            # a domain VaultError instead of a raw botocore exception.
-            raise VaultError(f"Failed to get secret {name}: {e}") from e
         except Exception as e:
-            error_code = _get_error_code(e)
-            if error_code == "ResourceNotFoundException":
-                raise SecretNotFoundError(f"Secret not found: {name}") from e
-            if error_code in ("AccessDeniedException", "UnauthorizedException"):
-                raise AuthenticationError(f"Access denied for secret: {name}") from e
-            # Check if it's a ClientError (with safe isinstance check)
-            if error_code:
-                raise VaultError(f"Failed to get secret {name}: {e}") from e
-            raise
+            raise _map_aws_error(
+                e,
+                transport_msg=f"Failed to get secret {name}",
+                not_found=("ResourceNotFoundException", f"Secret not found: {name}"),
+                access_denied=(_ACCESS_DENIED_CODES, f"Access denied for secret: {name}"),
+                generic_msg=f"Failed to get secret {name}",
+            ) from e
 
     def list_secrets(self, prefix: str = "") -> list[str]:
         """
@@ -228,17 +256,13 @@ class AWSSecretsManagerClient(VaultClient):
                         secret_names.append(name)
 
             return sorted(secret_names)
-        except BotoCoreError as e:
-            # Transport/connectivity failures escape the error-code branches; wrap
-            # them in the domain hierarchy rather than leaking a raw botocore error.
-            raise VaultError(f"Failed to list secrets: {e}") from e
         except Exception as e:
-            error_code = _get_error_code(e)
-            if error_code in ("AccessDeniedException", "UnauthorizedException"):
-                raise AuthenticationError("Access denied when listing secrets") from e
-            if error_code:
-                raise VaultError(f"Failed to list secrets: {e}") from e
-            raise
+            raise _map_aws_error(
+                e,
+                transport_msg="Failed to list secrets",
+                access_denied=(_ACCESS_DENIED_CODES, "Access denied when listing secrets"),
+                generic_msg="Failed to list secrets",
+            ) from e
 
     def _put_secret_value(self, name: str, value: str) -> SecretValue:
         """Update an existing secret value."""
@@ -256,17 +280,13 @@ class AWSSecretsManagerClient(VaultClient):
                 version=response.get("VersionId"),
                 metadata={"arn": response.get("ARN")},
             )
-        except BotoCoreError as e:
-            # Transport/connectivity failures escape the error-code branches; wrap
-            # them in the domain hierarchy rather than leaking a raw botocore error.
-            raise VaultError(f"Failed to set secret {name}: {e}") from e
         except Exception as e:
-            error_code = _get_error_code(e)
-            if error_code in ("AccessDeniedException", "UnauthorizedException"):
-                raise AuthenticationError(f"Access denied for secret: {name}") from e
-            if error_code:
-                raise VaultError(f"Failed to set secret {name}: {e}") from e
-            raise
+            raise _map_aws_error(
+                e,
+                transport_msg=f"Failed to set secret {name}",
+                access_denied=(_ACCESS_DENIED_CODES, f"Access denied for secret: {name}"),
+                generic_msg=f"Failed to set secret {name}",
+            ) from e
 
     def set_secret(self, name: str, value: str) -> SecretValue:
         """
@@ -298,22 +318,18 @@ class AWSSecretsManagerClient(VaultClient):
                 version=response.get("VersionId"),
                 metadata={"arn": response.get("ARN")},
             )
-        except BotoCoreError as e:
-            # Transport/connectivity failures escape the error-code branches; wrap
-            # them in the domain hierarchy rather than leaking a raw botocore error.
-            raise VaultError(f"Failed to set secret {name}: {e}") from e
         except Exception as e:
-            error_code = _get_error_code(e)
-            # Secret already exists: fall back to updating its value.
-            if error_code == "ResourceExistsException":
+            # Secret already exists: fall back to updating its value. A genuine
+            # create-permission denial must still surface (consistent with the
+            # other entry points), so only ResourceExistsException short-circuits.
+            if not isinstance(e, BotoCoreError) and _get_error_code(e) == "ResourceExistsException":
                 return self._put_secret_value(name, value)
-            # A genuine create-permission denial must surface, not be masked
-            # as an update attempt (consistent with the other entry points).
-            if error_code in ("AccessDeniedException", "UnauthorizedException"):
-                raise AuthenticationError(f"Access denied for secret: {name}") from e
-            if error_code:
-                raise VaultError(f"Failed to set secret {name}: {e}") from e
-            raise
+            raise _map_aws_error(
+                e,
+                transport_msg=f"Failed to set secret {name}",
+                access_denied=(_ACCESS_DENIED_CODES, f"Access denied for secret: {name}"),
+                generic_msg=f"Failed to set secret {name}",
+            ) from e
 
     def set_secret_dict(self, name: str, value: dict[str, Any]) -> SecretValue:
         """

--- a/src/envdrift/vault/aws.py
+++ b/src/envdrift/vault/aws.py
@@ -15,7 +15,11 @@ from envdrift.vault.base import (
 
 try:
     import boto3 as _boto3
-    from botocore.exceptions import NoCredentialsError, PartialCredentialsError
+    from botocore.exceptions import (
+        BotoCoreError,
+        NoCredentialsError,
+        PartialCredentialsError,
+    )
 
     AWS_AVAILABLE = True
 except ImportError:
@@ -23,6 +27,7 @@ except ImportError:
     _boto3 = None
     NoCredentialsError = Exception  # type: ignore[misc, assignment]
     PartialCredentialsError = Exception  # type: ignore[misc, assignment]
+    BotoCoreError = Exception  # type: ignore[misc, assignment]
 
 
 def _get_boto3() -> Any:
@@ -81,6 +86,13 @@ class AWSSecretsManagerClient(VaultClient):
             sts.get_caller_identity()
         except (NoCredentialsError, PartialCredentialsError) as e:
             raise AuthenticationError(f"AWS authentication failed: {e}") from e
+        except BotoCoreError as e:
+            # Transport/connectivity failures (EndpointConnectionError,
+            # ConnectTimeoutError, ReadTimeoutError, ...) subclass BotoCoreError
+            # and carry no `.response`, so they never reach the error-code branches
+            # below. Wrap them in the domain hierarchy instead of letting a raw
+            # botocore exception escape to the CLI as an uncaught traceback.
+            raise VaultError(f"AWS Secrets Manager error: {e}") from e
         except Exception as e:
             error_code = _get_error_code(e)
             if error_code in ("AccessDenied", "InvalidClientTokenId"):
@@ -172,6 +184,11 @@ class AWSSecretsManagerClient(VaultClient):
             # Already a domain error (e.g. malformed-response above); do not
             # re-wrap or misclassify it via the AWS error-code branches below.
             raise
+        except BotoCoreError as e:
+            # Transport/connectivity failures carry no `.response` (error_code == "")
+            # and would otherwise escape via the bare `raise` below. Surface them as
+            # a domain VaultError instead of a raw botocore exception.
+            raise VaultError(f"Failed to get secret {name}: {e}") from e
         except Exception as e:
             error_code = _get_error_code(e)
             if error_code == "ResourceNotFoundException":
@@ -211,6 +228,10 @@ class AWSSecretsManagerClient(VaultClient):
                         secret_names.append(name)
 
             return sorted(secret_names)
+        except BotoCoreError as e:
+            # Transport/connectivity failures escape the error-code branches; wrap
+            # them in the domain hierarchy rather than leaking a raw botocore error.
+            raise VaultError(f"Failed to list secrets: {e}") from e
         except Exception as e:
             error_code = _get_error_code(e)
             if error_code in ("AccessDeniedException", "UnauthorizedException"):
@@ -235,6 +256,10 @@ class AWSSecretsManagerClient(VaultClient):
                 version=response.get("VersionId"),
                 metadata={"arn": response.get("ARN")},
             )
+        except BotoCoreError as e:
+            # Transport/connectivity failures escape the error-code branches; wrap
+            # them in the domain hierarchy rather than leaking a raw botocore error.
+            raise VaultError(f"Failed to set secret {name}: {e}") from e
         except Exception as e:
             error_code = _get_error_code(e)
             if error_code in ("AccessDeniedException", "UnauthorizedException"):
@@ -273,6 +298,10 @@ class AWSSecretsManagerClient(VaultClient):
                 version=response.get("VersionId"),
                 metadata={"arn": response.get("ARN")},
             )
+        except BotoCoreError as e:
+            # Transport/connectivity failures escape the error-code branches; wrap
+            # them in the domain hierarchy rather than leaking a raw botocore error.
+            raise VaultError(f"Failed to set secret {name}: {e}") from e
         except Exception as e:
             error_code = _get_error_code(e)
             # Secret already exists: fall back to updating its value.

--- a/src/envdrift/vault/azure.py
+++ b/src/envdrift/vault/azure.py
@@ -14,6 +14,7 @@ from envdrift.vault.base import (
 
 try:
     from azure.core.exceptions import (
+        AzureError,
         ClientAuthenticationError,
         HttpResponseError,
         ResourceNotFoundError,
@@ -29,6 +30,7 @@ except ImportError:
     ResourceNotFoundError = Exception  # type: ignore[misc, assignment]
     ClientAuthenticationError = Exception  # type: ignore[misc, assignment]
     HttpResponseError = Exception  # type: ignore[misc, assignment]
+    AzureError = Exception  # type: ignore[misc, assignment]
 
 
 def _get_azure_classes() -> tuple[Any, Any]:
@@ -154,7 +156,17 @@ class AzureKeyVaultClient(VaultClient):
             )
         except ResourceNotFoundError as e:
             raise SecretNotFoundError(f"Secret '{name}' not found in vault") from e
+        except ClientAuthenticationError as e:
+            # A token that expires/is revoked mid-session (401) is an auth failure.
+            # ClientAuthenticationError subclasses HttpResponseError, so this clause
+            # MUST precede the HttpResponseError handler below (ordering matters).
+            raise AuthenticationError(f"Access denied to secret '{name}': {e}") from e
         except HttpResponseError as e:
+            raise VaultError(f"Azure Key Vault error: {e}") from e
+        except AzureError as e:
+            # Transport/connectivity failures (ServiceRequestError: DNS/TLS/network)
+            # are AzureError but NOT HttpResponseError, so they would otherwise escape
+            # as a raw SDK exception. Wrap them in the domain hierarchy.
             raise VaultError(f"Azure Key Vault error: {e}") from e
 
     def list_secrets(self, prefix: str = "") -> list[str]:
@@ -176,7 +188,14 @@ class AzureKeyVaultClient(VaultClient):
                 if name and (not prefix or name.startswith(prefix)):
                     secrets.append(name)
             return sorted(secrets)
+        except ClientAuthenticationError as e:
+            # Mid-session credential expiry (401) is an auth failure; this clause must
+            # precede HttpResponseError since ClientAuthenticationError subclasses it.
+            raise AuthenticationError(f"Access denied to list secrets: {e}") from e
         except HttpResponseError as e:
+            raise VaultError(f"Azure Key Vault error: {e}") from e
+        except AzureError as e:
+            # Transport/connectivity failures (ServiceRequestError) — wrap, don't leak.
             raise VaultError(f"Azure Key Vault error: {e}") from e
 
     def set_secret(self, name: str, value: str) -> SecretValue:
@@ -198,5 +217,12 @@ class AzureKeyVaultClient(VaultClient):
                     "enabled": secret.properties.enabled,
                 },
             )
+        except ClientAuthenticationError as e:
+            # Mid-session credential expiry (401) is an auth failure; this clause must
+            # precede HttpResponseError since ClientAuthenticationError subclasses it.
+            raise AuthenticationError(f"Access denied to write secret '{name}': {e}") from e
         except HttpResponseError as e:
+            raise VaultError(f"Azure Key Vault error: {e}") from e
+        except AzureError as e:
+            # Transport/connectivity failures (ServiceRequestError) — wrap, don't leak.
             raise VaultError(f"Azure Key Vault error: {e}") from e

--- a/src/envdrift/vault/azure.py
+++ b/src/envdrift/vault/azure.py
@@ -129,6 +129,16 @@ class AzureKeyVaultClient(VaultClient):
             self._client = None
             self._credential = None
             raise VaultError(f"Azure Key Vault error: {e}") from e
+        except AzureError as e:
+            # Transport-layer failure that is not an HttpResponseError -- e.g.
+            # ServiceRequestError (DNS/TLS/connectivity). This is a genuine
+            # failure, not a least-privilege List denial, so discard the
+            # half-initialized client and surface it as a VaultError (matching
+            # how get_secret/list_secrets/set_secret map transport errors), rather
+            # than letting the raw SDK exception escape the domain hierarchy.
+            self._client = None
+            self._credential = None
+            raise VaultError(f"Azure Key Vault error: {e}") from e
 
     def is_authenticated(self) -> bool:
         """

--- a/src/envdrift/vault/azure.py
+++ b/src/envdrift/vault/azure.py
@@ -40,6 +40,23 @@ def _get_azure_classes() -> tuple[Any, Any]:
     return _DefaultAzureCredential, _SecretClient
 
 
+def _map_azure_error(e: Exception, *, denied_msg: str) -> Exception:
+    """Translate an Azure SDK exception into a domain error.
+
+    Shared by get/list/set so each delegates instead of repeating the
+    auth-then-HTTP-then-transport catch ladder:
+
+    - ``ClientAuthenticationError`` (mid-session 401, a subclass of
+      ``HttpResponseError``, so it must be checked first) -> ``AuthenticationError``.
+    - ``HttpResponseError`` / any other ``AzureError`` (incl. transport failures
+      like ``ServiceRequestError`` that are *not* ``HttpResponseError``)
+      -> ``VaultError``.
+    """
+    if isinstance(e, ClientAuthenticationError):
+        return AuthenticationError(denied_msg)
+    return VaultError(f"Azure Key Vault error: {e}")
+
+
 class AzureKeyVaultClient(VaultClient):
     """Azure Key Vault implementation.
 
@@ -156,18 +173,8 @@ class AzureKeyVaultClient(VaultClient):
             )
         except ResourceNotFoundError as e:
             raise SecretNotFoundError(f"Secret '{name}' not found in vault") from e
-        except ClientAuthenticationError as e:
-            # A token that expires/is revoked mid-session (401) is an auth failure.
-            # ClientAuthenticationError subclasses HttpResponseError, so this clause
-            # MUST precede the HttpResponseError handler below (ordering matters).
-            raise AuthenticationError(f"Access denied to secret '{name}': {e}") from e
-        except HttpResponseError as e:
-            raise VaultError(f"Azure Key Vault error: {e}") from e
         except AzureError as e:
-            # Transport/connectivity failures (ServiceRequestError: DNS/TLS/network)
-            # are AzureError but NOT HttpResponseError, so they would otherwise escape
-            # as a raw SDK exception. Wrap them in the domain hierarchy.
-            raise VaultError(f"Azure Key Vault error: {e}") from e
+            raise _map_azure_error(e, denied_msg=f"Access denied to secret '{name}': {e}") from e
 
     def list_secrets(self, prefix: str = "") -> list[str]:
         """
@@ -188,15 +195,8 @@ class AzureKeyVaultClient(VaultClient):
                 if name and (not prefix or name.startswith(prefix)):
                     secrets.append(name)
             return sorted(secrets)
-        except ClientAuthenticationError as e:
-            # Mid-session credential expiry (401) is an auth failure; this clause must
-            # precede HttpResponseError since ClientAuthenticationError subclasses it.
-            raise AuthenticationError(f"Access denied to list secrets: {e}") from e
-        except HttpResponseError as e:
-            raise VaultError(f"Azure Key Vault error: {e}") from e
         except AzureError as e:
-            # Transport/connectivity failures (ServiceRequestError) — wrap, don't leak.
-            raise VaultError(f"Azure Key Vault error: {e}") from e
+            raise _map_azure_error(e, denied_msg=f"Access denied to list secrets: {e}") from e
 
     def set_secret(self, name: str, value: str) -> SecretValue:
         """
@@ -217,12 +217,7 @@ class AzureKeyVaultClient(VaultClient):
                     "enabled": secret.properties.enabled,
                 },
             )
-        except ClientAuthenticationError as e:
-            # Mid-session credential expiry (401) is an auth failure; this clause must
-            # precede HttpResponseError since ClientAuthenticationError subclasses it.
-            raise AuthenticationError(f"Access denied to write secret '{name}': {e}") from e
-        except HttpResponseError as e:
-            raise VaultError(f"Azure Key Vault error: {e}") from e
         except AzureError as e:
-            # Transport/connectivity failures (ServiceRequestError) — wrap, don't leak.
-            raise VaultError(f"Azure Key Vault error: {e}") from e
+            raise _map_azure_error(
+                e, denied_msg=f"Access denied to write secret '{name}': {e}"
+            ) from e

--- a/src/envdrift/vault/gcp.py
+++ b/src/envdrift/vault/gcp.py
@@ -43,6 +43,35 @@ def _get_gcp_modules() -> tuple[Any, Any]:
     return _secretmanager, _google_exceptions
 
 
+def _map_gcp_error(
+    e: Exception,
+    google_exceptions: Any,
+    *,
+    denied_msg: str,
+    not_found_msg: str | None = None,
+) -> Exception:
+    """Translate a GCP SDK exception into a domain error.
+
+    Shared by get/list/set so each delegates instead of repeating the
+    not-found/permission/API/auth catch ladder:
+
+    - ``NotFound`` -> ``SecretNotFoundError`` (only when ``not_found_msg`` given).
+    - ``PermissionDenied`` / ``Unauthenticated`` (authz/expired-token) and
+      ``RefreshError`` (mid-session refresh failure) -> ``AuthenticationError``.
+    - ``GoogleAPICallError`` and any other ``GoogleAuthError`` (e.g. transport
+      ``TransportError``) -> ``VaultError``.
+
+    ``RefreshError`` is a ``GoogleAuthError`` subclass, so it is checked first.
+    """
+    if not_found_msg is not None and isinstance(e, google_exceptions.NotFound):
+        return SecretNotFoundError(not_found_msg)
+    if isinstance(
+        e, (google_exceptions.PermissionDenied, google_exceptions.Unauthenticated, RefreshError)
+    ):
+        return AuthenticationError(denied_msg)
+    return VaultError(f"GCP Secret Manager error: {e}")
+
+
 # Canonical GCP Secret Manager resource name: projects/<P>/secrets/<S> optionally
 # followed by /versions/<V>. Each segment is non-empty and slash-free. A bare
 # secret name (no `projects/` prefix) is handled separately and resolves under the
@@ -135,11 +164,6 @@ class GCPSecretManagerClient(VaultClient):
                 request={"parent": self._project_path(), "page_size": 1}
             )
             next(iter(secrets_iter), None)
-        except DefaultCredentialsError as e:
-            # No usable credentials at all (no ADC, bad GOOGLE_APPLICATION_CREDENTIALS,
-            # etc.) — a genuine authentication failure.
-            self._client = None
-            raise AuthenticationError(f"GCP authentication failed: {e}") from e
         except google_exceptions.PermissionDenied:
             # The credential authenticated successfully but lacks
             # `secretmanager.secrets.list`. A least-privilege service account that
@@ -148,26 +172,20 @@ class GCPSecretManagerClient(VaultClient):
             # authenticated-but-cannot-list: keep the client. If a specific secret
             # genuinely can't be read, get_secret() surfaces a clear error later.
             pass
-        except google_exceptions.Unauthenticated as e:
-            # The credential itself is invalid/expired — a genuine auth failure,
-            # distinct from PermissionDenied (authenticated, missing list permission).
+        except (
+            DefaultCredentialsError,
+            google_exceptions.GoogleAPICallError,
+            GoogleAuthError,
+        ) as e:
+            # Any other failure invalidates the half-initialized client. Map it
+            # via the shared helper: DefaultCredentialsError (no usable ADC) is a
+            # genuine auth failure, so treat it like the access-denied family.
             self._client = None
-            raise AuthenticationError(f"GCP authentication failed: {e}") from e
-        except google_exceptions.GoogleAPICallError as e:
-            self._client = None
-            raise VaultError(f"GCP Secret Manager error: {e}") from e
-        except RefreshError as e:
-            # Token refresh failure (e.g. invalid_grant on a service-account key) is
-            # an authentication problem, not a transport one. It is a GoogleAuthError
-            # (not a GoogleAPICallError), so it would otherwise escape uncaught.
-            self._client = None
-            raise AuthenticationError(f"GCP authentication failed: {e}") from e
-        except GoogleAuthError as e:
-            # Other auth-layer failures (e.g. TransportError: DNS/TLS/connectivity)
-            # also escape the GoogleAPICallError handler above; map them into the
-            # domain hierarchy instead of leaking a raw SDK exception to the CLI.
-            self._client = None
-            raise VaultError(f"GCP Secret Manager error: {e}") from e
+            if isinstance(e, DefaultCredentialsError):
+                raise AuthenticationError(f"GCP authentication failed: {e}") from e
+            raise _map_gcp_error(
+                e, google_exceptions, denied_msg=f"GCP authentication failed: {e}"
+            ) from e
 
     def is_authenticated(self) -> bool:
         return self._client is not None
@@ -202,21 +220,13 @@ class GCPSecretManagerClient(VaultClient):
                 version=version,
                 metadata={"name": response.name},
             )
-        except google_exceptions.NotFound as e:
-            raise SecretNotFoundError(f"Secret '{name}' not found") from e
-        except (
-            google_exceptions.PermissionDenied,
-            google_exceptions.Unauthenticated,
-        ) as e:
-            raise AuthenticationError(f"Access denied to secret '{name}': {e}") from e
-        except google_exceptions.GoogleAPICallError as e:
-            raise VaultError(f"GCP Secret Manager error: {e}") from e
-        except RefreshError as e:
-            # Mid-session token refresh failure — an auth problem, surfaced as such.
-            raise AuthenticationError(f"Access denied to secret '{name}': {e}") from e
-        except GoogleAuthError as e:
-            # Transport/auth-layer failure (e.g. TransportError) — wrap rather than leak.
-            raise VaultError(f"GCP Secret Manager error: {e}") from e
+        except (google_exceptions.GoogleAPICallError, GoogleAuthError) as e:
+            raise _map_gcp_error(
+                e,
+                google_exceptions,
+                denied_msg=f"Access denied to secret '{name}': {e}",
+                not_found_msg=f"Secret '{name}' not found",
+            ) from e
 
     def list_secrets(self, prefix: str = "") -> list[str]:
         """
@@ -235,19 +245,10 @@ class GCPSecretManagerClient(VaultClient):
                 if secret_id and (not prefix or secret_id.startswith(prefix)):
                     secrets.append(secret_id)
             return sorted(secrets)
-        except (
-            google_exceptions.PermissionDenied,
-            google_exceptions.Unauthenticated,
-        ) as e:
-            raise AuthenticationError(f"Access denied to list secrets: {e}") from e
-        except google_exceptions.GoogleAPICallError as e:
-            raise VaultError(f"GCP Secret Manager error: {e}") from e
-        except RefreshError as e:
-            # Mid-session token refresh failure — an auth problem, surfaced as such.
-            raise AuthenticationError(f"Access denied to list secrets: {e}") from e
-        except GoogleAuthError as e:
-            # Transport/auth-layer failure (e.g. TransportError) — wrap rather than leak.
-            raise VaultError(f"GCP Secret Manager error: {e}") from e
+        except (google_exceptions.GoogleAPICallError, GoogleAuthError) as e:
+            raise _map_gcp_error(
+                e, google_exceptions, denied_msg=f"Access denied to list secrets: {e}"
+            ) from e
 
     def set_secret(self, name: str, value: str) -> SecretValue:
         """
@@ -285,16 +286,7 @@ class GCPSecretManagerClient(VaultClient):
                 version=version_id,
                 metadata={"name": version.name},
             )
-        except (
-            google_exceptions.PermissionDenied,
-            google_exceptions.Unauthenticated,
-        ) as e:
-            raise AuthenticationError(f"Access denied to write secret '{name}': {e}") from e
-        except google_exceptions.GoogleAPICallError as e:
-            raise VaultError(f"GCP Secret Manager error: {e}") from e
-        except RefreshError as e:
-            # Mid-session token refresh failure — an auth problem, surfaced as such.
-            raise AuthenticationError(f"Access denied to write secret '{name}': {e}") from e
-        except GoogleAuthError as e:
-            # Transport/auth-layer failure (e.g. TransportError) — wrap rather than leak.
-            raise VaultError(f"GCP Secret Manager error: {e}") from e
+        except (google_exceptions.GoogleAPICallError, GoogleAuthError) as e:
+            raise _map_gcp_error(
+                e, google_exceptions, denied_msg=f"Access denied to write secret '{name}': {e}"
+            ) from e

--- a/src/envdrift/vault/gcp.py
+++ b/src/envdrift/vault/gcp.py
@@ -16,7 +16,11 @@ from envdrift.vault.base import (
 
 try:
     from google.api_core import exceptions as _google_exceptions
-    from google.auth.exceptions import DefaultCredentialsError
+    from google.auth.exceptions import (
+        DefaultCredentialsError,
+        GoogleAuthError,
+        RefreshError,
+    )
     from google.cloud import secretmanager as _secretmanager
 
     GCP_AVAILABLE = True
@@ -25,6 +29,8 @@ except ImportError:
     _secretmanager = None
     _google_exceptions = None
     DefaultCredentialsError = Exception  # type: ignore[misc, assignment]
+    GoogleAuthError = Exception  # type: ignore[misc, assignment]
+    RefreshError = Exception  # type: ignore[misc, assignment]
 
 
 def _get_gcp_modules() -> tuple[Any, Any]:
@@ -150,6 +156,18 @@ class GCPSecretManagerClient(VaultClient):
         except google_exceptions.GoogleAPICallError as e:
             self._client = None
             raise VaultError(f"GCP Secret Manager error: {e}") from e
+        except RefreshError as e:
+            # Token refresh failure (e.g. invalid_grant on a service-account key) is
+            # an authentication problem, not a transport one. It is a GoogleAuthError
+            # (not a GoogleAPICallError), so it would otherwise escape uncaught.
+            self._client = None
+            raise AuthenticationError(f"GCP authentication failed: {e}") from e
+        except GoogleAuthError as e:
+            # Other auth-layer failures (e.g. TransportError: DNS/TLS/connectivity)
+            # also escape the GoogleAPICallError handler above; map them into the
+            # domain hierarchy instead of leaking a raw SDK exception to the CLI.
+            self._client = None
+            raise VaultError(f"GCP Secret Manager error: {e}") from e
 
     def is_authenticated(self) -> bool:
         return self._client is not None
@@ -193,6 +211,12 @@ class GCPSecretManagerClient(VaultClient):
             raise AuthenticationError(f"Access denied to secret '{name}': {e}") from e
         except google_exceptions.GoogleAPICallError as e:
             raise VaultError(f"GCP Secret Manager error: {e}") from e
+        except RefreshError as e:
+            # Mid-session token refresh failure — an auth problem, surfaced as such.
+            raise AuthenticationError(f"Access denied to secret '{name}': {e}") from e
+        except GoogleAuthError as e:
+            # Transport/auth-layer failure (e.g. TransportError) — wrap rather than leak.
+            raise VaultError(f"GCP Secret Manager error: {e}") from e
 
     def list_secrets(self, prefix: str = "") -> list[str]:
         """
@@ -217,6 +241,12 @@ class GCPSecretManagerClient(VaultClient):
         ) as e:
             raise AuthenticationError(f"Access denied to list secrets: {e}") from e
         except google_exceptions.GoogleAPICallError as e:
+            raise VaultError(f"GCP Secret Manager error: {e}") from e
+        except RefreshError as e:
+            # Mid-session token refresh failure — an auth problem, surfaced as such.
+            raise AuthenticationError(f"Access denied to list secrets: {e}") from e
+        except GoogleAuthError as e:
+            # Transport/auth-layer failure (e.g. TransportError) — wrap rather than leak.
             raise VaultError(f"GCP Secret Manager error: {e}") from e
 
     def set_secret(self, name: str, value: str) -> SecretValue:
@@ -261,4 +291,10 @@ class GCPSecretManagerClient(VaultClient):
         ) as e:
             raise AuthenticationError(f"Access denied to write secret '{name}': {e}") from e
         except google_exceptions.GoogleAPICallError as e:
+            raise VaultError(f"GCP Secret Manager error: {e}") from e
+        except RefreshError as e:
+            # Mid-session token refresh failure — an auth problem, surfaced as such.
+            raise AuthenticationError(f"Access denied to write secret '{name}': {e}") from e
+        except GoogleAuthError as e:
+            # Transport/auth-layer failure (e.g. TransportError) — wrap rather than leak.
             raise VaultError(f"GCP Secret Manager error: {e}") from e

--- a/src/envdrift/vault/hashicorp.py
+++ b/src/envdrift/vault/hashicorp.py
@@ -149,11 +149,17 @@ class HashiCorpVaultClient(VaultClient):
 
             # If there's a single "value" key, return that
             # Otherwise return the JSON string of all data
+            import json
+
             if "value" in secret_data and len(secret_data) == 1:
                 value = secret_data["value"]
+                # KV stores arbitrary JSON, so a single "value" can be a non-string
+                # (int/bool/list/dict). SecretValue.value must always be a str, or the
+                # sync engine and vault-pull crash downstream; coerce non-strings to JSON
+                # (mirroring the multi-key path's json.dumps()).
+                if not isinstance(value, str):
+                    value = json.dumps(value)
             else:
-                import json
-
                 value = json.dumps(secret_data)
 
             return SecretValue(

--- a/src/envdrift/vault/hashicorp.py
+++ b/src/envdrift/vault/hashicorp.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 from typing import Any
 
@@ -24,6 +25,20 @@ except ImportError:
     InvalidPath = Exception  # type: ignore[misc, assignment]
     Forbidden = Exception  # type: ignore[misc, assignment]
     Unauthorized = Exception  # type: ignore[misc, assignment]
+
+
+def _coerce_secret_value(secret_data: dict[str, Any]) -> str:
+    """Render KV-v2 secret data as the single string ``SecretValue.value`` requires.
+
+    A lone ``value`` key is returned as-is when already a string; KV stores
+    arbitrary JSON, so a non-string single ``value`` (int/bool/list/dict) — or any
+    multi-key payload — is JSON-encoded. ``SecretValue.value`` must always be a
+    str, or the sync engine and vault-pull crash downstream.
+    """
+    if "value" in secret_data and len(secret_data) == 1:
+        value = secret_data["value"]
+        return value if isinstance(value, str) else json.dumps(value)
+    return json.dumps(secret_data)
 
 
 def _get_hvac() -> Any:
@@ -147,20 +162,9 @@ class HashiCorpVaultClient(VaultClient):
             secret_data = data.get("data", {})
             metadata = data.get("metadata", {})
 
-            # If there's a single "value" key, return that
-            # Otherwise return the JSON string of all data
-            import json
-
-            if "value" in secret_data and len(secret_data) == 1:
-                value = secret_data["value"]
-                # KV stores arbitrary JSON, so a single "value" can be a non-string
-                # (int/bool/list/dict). SecretValue.value must always be a str, or the
-                # sync engine and vault-pull crash downstream; coerce non-strings to JSON
-                # (mirroring the multi-key path's json.dumps()).
-                if not isinstance(value, str):
-                    value = json.dumps(value)
-            else:
-                value = json.dumps(secret_data)
+            # A single "value" key returns that value; otherwise the whole dict is
+            # JSON-encoded. Coercion lives in a helper to keep this method simple.
+            value = _coerce_secret_value(secret_data)
 
             return SecretValue(
                 name=name,
@@ -233,10 +237,9 @@ class HashiCorpVaultClient(VaultClient):
 
             metadata = response.get("data", {})
 
-            # Use same value extraction logic as get_secret for consistency
-            import json
-
-            value = data["value"] if ("value" in data and len(data) == 1) else json.dumps(data)
+            # Same string-coercion as get_secret so the returned SecretValue.value
+            # is always a str even when the caller stored a non-string single value.
+            value = _coerce_secret_value(data)
 
             return SecretValue(
                 name=name,

--- a/tests/unit/test_vault_aws.py
+++ b/tests/unit/test_vault_aws.py
@@ -16,6 +16,22 @@ from envdrift.vault.base import (
 )
 
 
+class FakeBotoCoreError(Exception):
+    """Stand-in for ``botocore.exceptions.BotoCoreError``.
+
+    In the real SDK every transport/connectivity error
+    (``EndpointConnectionError``, ``ConnectTimeoutError``, ``ReadTimeoutError``,
+    ``ConnectionClosedError``, ...) subclasses ``BotoCoreError``, while the
+    API-response ``ClientError`` (which carries ``.response``/an error code) does
+    NOT. Modeling that distinction here lets the tests prove a transport failure
+    is wrapped as a domain ``VaultError`` rather than escaping raw.
+    """
+
+
+class FakeTransportError(FakeBotoCoreError):
+    """Fake transport failure (e.g. EndpointConnectionError) — no ``.response``."""
+
+
 @pytest.fixture
 def mock_client_factory():
     """Create reusable mocked AWS clients for testing."""
@@ -64,6 +80,14 @@ class TestAWSSecretsManagerClient:
             import envdrift.vault.aws as aws_module
 
             importlib.reload(aws_module)
+            # ``botocore.exceptions`` is a MagicMock here, so the reloaded module
+            # captured ``BotoCoreError`` as a MagicMock — not a usable ``except``
+            # type. Swap in a real sentinel exception class (the common base of the
+            # botocore transport errors) so the production ``except BotoCoreError``
+            # clause is a valid, narrowly-scoped catch in these tests. It does NOT
+            # match the plain-``Exception`` fakes used below (FakeClientError /
+            # WeirdError), preserving their distinct error-code / propagate paths.
+            aws_module.BotoCoreError = FakeBotoCoreError
             yield aws_module
 
     def test_init_without_boto3_raises(self):
@@ -752,6 +776,85 @@ class TestAWSSecretsManagerClient:
 
         with pytest.raises(WeirdError):
             client.set_secret("name", "value")
+
+    def test_authenticate_transport_error_wraps_as_vault_error(self, mock_boto3):
+        """Regression #413: a botocore transport/connectivity error during
+        authenticate() (no ``.response``, e.g. EndpointConnectionError) must surface
+        as a domain VaultError, not escape raw to the CLI as an uncaught traceback.
+        """
+
+        class FakeCredentialsError(Exception):
+            pass
+
+        mock_boto3.NoCredentialsError = FakeCredentialsError
+        mock_boto3.PartialCredentialsError = FakeCredentialsError
+
+        with patch("boto3.client") as mock_client:
+            mock_client.side_effect = FakeTransportError("Could not connect to the endpoint URL")
+
+            client = mock_boto3.AWSSecretsManagerClient()
+            with pytest.raises(VaultError) as exc_info:
+                client.authenticate()
+
+        # Mapped into the domain hierarchy, not leaked as the raw botocore type.
+        assert not isinstance(exc_info.value, FakeTransportError)
+
+    def test_get_secret_transport_error_wraps_as_vault_error(
+        self, mock_boto3, patched_boto_clients
+    ):
+        """Regression #413: a transport error during get_secret() (no error code)
+        is wrapped as VaultError instead of leaking the raw botocore exception."""
+        mock_sm_client, _ = patched_boto_clients
+        mock_sm_client.get_secret_value.side_effect = FakeTransportError("connection reset")
+
+        client = mock_boto3.AWSSecretsManagerClient()
+        client.authenticate()
+
+        with pytest.raises(VaultError) as exc_info:
+            client.get_secret("secret")
+        assert not isinstance(exc_info.value, FakeTransportError)
+
+    def test_list_secrets_transport_error_wraps_as_vault_error(
+        self, mock_boto3, patched_boto_clients
+    ):
+        """Regression #413: a transport error during list_secrets() is wrapped."""
+        mock_sm_client, _ = patched_boto_clients
+        mock_sm_client.get_paginator.side_effect = FakeTransportError("read timeout")
+
+        client = mock_boto3.AWSSecretsManagerClient()
+        client.authenticate()
+
+        with pytest.raises(VaultError) as exc_info:
+            client.list_secrets()
+        assert not isinstance(exc_info.value, FakeTransportError)
+
+    def test_put_secret_value_transport_error_wraps_as_vault_error(
+        self, mock_boto3, patched_boto_clients
+    ):
+        """Regression #413: a transport error during _put_secret_value() is wrapped."""
+        mock_sm_client, _ = patched_boto_clients
+        mock_sm_client.put_secret_value.side_effect = FakeTransportError("connect timeout")
+
+        client = mock_boto3.AWSSecretsManagerClient()
+        client.authenticate()
+
+        with pytest.raises(VaultError) as exc_info:
+            client._put_secret_value("name", "value")
+        assert not isinstance(exc_info.value, FakeTransportError)
+
+    def test_set_secret_transport_error_wraps_as_vault_error(
+        self, mock_boto3, patched_boto_clients
+    ):
+        """Regression #413: a transport error during set_secret() is wrapped."""
+        mock_sm_client, _ = patched_boto_clients
+        mock_sm_client.create_secret.side_effect = FakeTransportError("endpoint unreachable")
+
+        client = mock_boto3.AWSSecretsManagerClient()
+        client.authenticate()
+
+        with pytest.raises(VaultError) as exc_info:
+            client.set_secret("name", "value")
+        assert not isinstance(exc_info.value, FakeTransportError)
 
     def test_set_secret_dict(self, mock_boto3, patched_boto_clients):
         """Test set_secret_dict creates secret with JSON-encoded dict."""

--- a/tests/unit/test_vault_azure.py
+++ b/tests/unit/test_vault_azure.py
@@ -390,6 +390,31 @@ class TestAzureKeyVaultClient:
             assert client._client is None
             assert client._credential is None
 
+    def test_authenticate_transport_error_maps_to_vault_error(self, mock_azure):
+        """Regression #413: a transport ServiceRequestError during authenticate()
+        (an AzureError that is NOT an HttpResponseError, e.g. DNS/TLS failure) must
+        be wrapped as a domain VaultError, not escape as the raw SDK exception, and
+        the half-initialized client/credential must be discarded.
+        """
+        mock_credential = MagicMock()
+        mock_secret_client = MagicMock()
+        mock_secret_client.list_properties_of_secrets.side_effect = FakeServiceRequestError(
+            "DNS failure"
+        )
+
+        with self._patched_client(
+            mock_azure,
+            mock_secret_client,
+            credential=mock_credential,
+            faithful_exceptions=True,
+        ) as client:
+            with pytest.raises(VaultError):
+                client.authenticate()
+
+            assert client.is_authenticated() is False
+            assert client._client is None
+            assert client._credential is None
+
     def test_is_authenticated_false_after_failed_auth_error(self, mock_azure):
         """After authenticate() fails on the probe, is_authenticated() must be False.
 

--- a/tests/unit/test_vault_azure.py
+++ b/tests/unit/test_vault_azure.py
@@ -12,16 +12,38 @@ import pytest
 from envdrift.vault.base import AuthenticationError, SecretNotFoundError, VaultError
 
 
-class FakeHttpResponseError(Exception):
+class FakeAzureError(Exception):
+    """Stand-in for ``azure.core.exceptions.AzureError`` (the SDK error base).
+
+    The real MRO is ``HttpResponseError -> AzureError`` and
+    ``ServiceRequestError -> AzureError`` (the latter is a transport failure and is
+    NOT a ``HttpResponseError``). Modeling that here lets the tests prove a
+    transport ``ServiceRequestError`` is wrapped as a domain ``VaultError`` while
+    still reaching the dedicated ``AzureError`` catch-all clause.
+    """
+
+
+class FakeHttpResponseError(FakeAzureError):
     """Stand-in for ``azure.core.exceptions.HttpResponseError``.
 
     Carries a ``status_code`` like the real SDK exception so the production
-    ``status_code == 403`` accept branch can be exercised.
+    ``status_code == 403`` accept branch can be exercised. Subclasses
+    ``FakeAzureError`` to mirror the real ``HttpResponseError -> AzureError`` MRO.
     """
 
     def __init__(self, message: str = "", status_code: int | None = None):
         super().__init__(message)
         self.status_code = status_code
+
+
+class FakeServiceRequestError(FakeAzureError):
+    """Stand-in for ``azure.core.exceptions.ServiceRequestError`` (transport).
+
+    Critically it subclasses ``FakeAzureError`` but NOT ``FakeHttpResponseError``,
+    mirroring the real SDK: a DNS/TLS/connectivity failure that the production
+    ``except HttpResponseError`` clause does NOT catch, so it must fall through to
+    the dedicated ``except AzureError`` catch-all and be wrapped as a VaultError.
+    """
 
 
 class FakeClientAuthenticationError(FakeHttpResponseError):
@@ -94,6 +116,7 @@ class TestAzureKeyVaultClient:
             patch.object(mock_azure, "_SecretClient", return_value=secret_client),
         ):
             if faithful_exceptions:
+                mock_azure.AzureError = FakeAzureError
                 mock_azure.HttpResponseError = FakeHttpResponseError
                 mock_azure.ClientAuthenticationError = FakeClientAuthenticationError
                 mock_azure.ResourceNotFoundError = FakeResourceNotFoundError
@@ -462,3 +485,114 @@ class TestAzureKeyVaultClient:
 
             with pytest.raises(VaultError):
                 client.set_secret("some-secret", "value")
+
+    def test_get_secret_client_auth_error_maps_to_authentication_error(self, mock_azure):
+        """Regression #413 (low): a mid-session credential expiry (401) during
+        get_secret() must map to AuthenticationError, not a generic VaultError.
+
+        ClientAuthenticationError subclasses HttpResponseError, so the dedicated
+        ``except ClientAuthenticationError`` clause must precede ``except
+        HttpResponseError`` (ordering matters). Callers special-casing
+        AuthenticationError (e.g. to prompt re-login) rely on this distinction.
+        """
+        mock_secret_client = MagicMock()
+        mock_secret_client.list_properties_of_secrets.return_value = iter([])
+        mock_secret_client.get_secret.side_effect = FakeClientAuthenticationError(
+            "token expired", status_code=401
+        )
+
+        with self._patched_client(
+            mock_azure, mock_secret_client, faithful_exceptions=True
+        ) as client:
+            client.authenticate()
+
+            with pytest.raises(AuthenticationError):
+                client.get_secret("some-secret")
+
+    def test_list_secrets_client_auth_error_maps_to_authentication_error(self, mock_azure):
+        """Regression #413 (low): mid-session 401 during list_secrets() maps to
+        AuthenticationError (ClientAuthenticationError before HttpResponseError)."""
+        mock_secret_client = MagicMock()
+        mock_secret_client.list_properties_of_secrets.return_value = iter([])
+
+        with self._patched_client(
+            mock_azure, mock_secret_client, faithful_exceptions=True
+        ) as client:
+            client.authenticate()
+
+            mock_secret_client.list_properties_of_secrets.side_effect = (
+                FakeClientAuthenticationError("token expired", status_code=401)
+            )
+
+            with pytest.raises(AuthenticationError):
+                client.list_secrets()
+
+    def test_set_secret_client_auth_error_maps_to_authentication_error(self, mock_azure):
+        """Regression #413 (low): mid-session 401 during set_secret() maps to
+        AuthenticationError (ClientAuthenticationError before HttpResponseError)."""
+        mock_secret_client = MagicMock()
+        mock_secret_client.list_properties_of_secrets.return_value = iter([])
+        mock_secret_client.set_secret.side_effect = FakeClientAuthenticationError(
+            "token expired", status_code=401
+        )
+
+        with self._patched_client(
+            mock_azure, mock_secret_client, faithful_exceptions=True
+        ) as client:
+            client.authenticate()
+
+            with pytest.raises(AuthenticationError):
+                client.set_secret("some-secret", "value")
+
+    def test_get_secret_transport_error_maps_to_vault_error(self, mock_azure):
+        """Regression #413 (high): a transport ServiceRequestError (AzureError but
+        NOT HttpResponseError: DNS/TLS/connectivity) during get_secret() must be
+        wrapped as a domain VaultError, not escape raw to the CLI."""
+        mock_secret_client = MagicMock()
+        mock_secret_client.list_properties_of_secrets.return_value = iter([])
+        mock_secret_client.get_secret.side_effect = FakeServiceRequestError("DNS failure")
+
+        with self._patched_client(
+            mock_azure, mock_secret_client, faithful_exceptions=True
+        ) as client:
+            client.authenticate()
+
+            with pytest.raises(VaultError) as exc_info:
+                client.get_secret("some-secret")
+        # Wrapped, not leaked as the raw transport exception.
+        assert not isinstance(exc_info.value, FakeServiceRequestError)
+
+    def test_list_secrets_transport_error_maps_to_vault_error(self, mock_azure):
+        """Regression #413 (high): a transport ServiceRequestError during
+        list_secrets() is wrapped as a domain VaultError."""
+        mock_secret_client = MagicMock()
+        mock_secret_client.list_properties_of_secrets.return_value = iter([])
+
+        with self._patched_client(
+            mock_azure, mock_secret_client, faithful_exceptions=True
+        ) as client:
+            client.authenticate()
+
+            mock_secret_client.list_properties_of_secrets.side_effect = FakeServiceRequestError(
+                "connection reset"
+            )
+
+            with pytest.raises(VaultError) as exc_info:
+                client.list_secrets()
+        assert not isinstance(exc_info.value, FakeServiceRequestError)
+
+    def test_set_secret_transport_error_maps_to_vault_error(self, mock_azure):
+        """Regression #413 (high): a transport ServiceRequestError during
+        set_secret() is wrapped as a domain VaultError."""
+        mock_secret_client = MagicMock()
+        mock_secret_client.list_properties_of_secrets.return_value = iter([])
+        mock_secret_client.set_secret.side_effect = FakeServiceRequestError("TLS handshake failed")
+
+        with self._patched_client(
+            mock_azure, mock_secret_client, faithful_exceptions=True
+        ) as client:
+            client.authenticate()
+
+            with pytest.raises(VaultError) as exc_info:
+                client.set_secret("some-secret", "value")
+        assert not isinstance(exc_info.value, FakeServiceRequestError)

--- a/tests/unit/test_vault_gcp.py
+++ b/tests/unit/test_vault_gcp.py
@@ -47,8 +47,27 @@ class DummyAlreadyExistsError(DummyGoogleAPICallError):
     """Fake AlreadyExists (a GoogleAPICallError subclass, as in the real SDK)."""
 
 
-class DummyDefaultCredentialsError(Exception):
-    """Fake DefaultCredentialsError."""
+class DummyGoogleAuthError(Exception):
+    """Fake ``google.auth.exceptions.GoogleAuthError`` (the auth-layer base).
+
+    The real SDK makes ``DefaultCredentialsError``, ``RefreshError`` and
+    ``TransportError`` all subclass ``GoogleAuthError`` (and crucially NONE of them
+    subclass ``GoogleAPICallError``). Mirroring that here is load-bearing: it lets
+    the tests exercise the production split where ``RefreshError`` -> auth failure
+    and other ``GoogleAuthError`` (e.g. ``TransportError``) -> ``VaultError``.
+    """
+
+
+class DummyDefaultCredentialsError(DummyGoogleAuthError):
+    """Fake DefaultCredentialsError (a GoogleAuthError subclass, as in the real SDK)."""
+
+
+class DummyRefreshError(DummyGoogleAuthError):
+    """Fake RefreshError (a GoogleAuthError subclass; e.g. invalid_grant)."""
+
+
+class DummyTransportError(DummyGoogleAuthError):
+    """Fake TransportError (a GoogleAuthError subclass; DNS/TLS/connectivity)."""
 
 
 @pytest.fixture
@@ -64,7 +83,10 @@ def mock_gcp():
     api_core_mod = SimpleNamespace(exceptions=exceptions_mod)
 
     auth_exceptions_mod = SimpleNamespace(
+        GoogleAuthError=DummyGoogleAuthError,
         DefaultCredentialsError=DummyDefaultCredentialsError,
+        RefreshError=DummyRefreshError,
+        TransportError=DummyTransportError,
     )
     auth_mod = SimpleNamespace(exceptions=auth_exceptions_mod)
 
@@ -307,6 +329,98 @@ class TestGCPSecretManagerClient:
         with pytest.raises(AuthenticationError):
             client_2.authenticate()
         assert client_2.is_authenticated() is False
+
+    def test_authenticate_refresh_error_maps_to_authentication_error(self, mock_gcp):
+        """Regression #413: a token-refresh failure (RefreshError, e.g. invalid_grant)
+        during authenticate() is an *auth* problem and must map to AuthenticationError.
+
+        RefreshError is a GoogleAuthError (NOT a GoogleAPICallError), so it previously
+        escaped every except clause and propagated as a raw SDK exception.
+        """
+        mock_client = MagicMock()
+        mock_client.list_secrets.side_effect = mock_gcp.RefreshError("invalid_grant")
+        mock_gcp._secretmanager.SecretManagerServiceClient.return_value = mock_client
+
+        client = mock_gcp.GCPSecretManagerClient(project_id="my-project")
+        with pytest.raises(AuthenticationError):
+            client.authenticate()
+
+        assert client.is_authenticated() is False
+
+    def test_authenticate_transport_error_maps_to_vault_error(self, mock_gcp):
+        """Regression #413: a transport-layer GoogleAuthError (TransportError:
+        DNS/TLS/connectivity) during authenticate() is wrapped as VaultError, not
+        leaked raw. It is a GoogleAuthError but NOT a GoogleAPICallError, so it
+        previously escaped all handlers.
+        """
+        mock_client = MagicMock()
+        mock_client.list_secrets.side_effect = mock_gcp.GoogleAuthError("network unreachable")
+        mock_gcp._secretmanager.SecretManagerServiceClient.return_value = mock_client
+
+        client = mock_gcp.GCPSecretManagerClient(project_id="my-project")
+        with pytest.raises(VaultError) as exc_info:
+            client.authenticate()
+
+        # Must be a domain VaultError, not the raw auth-layer exception.
+        assert not isinstance(exc_info.value, mock_gcp.GoogleAuthError)
+        assert client.is_authenticated() is False
+
+    def test_get_secret_refresh_error_maps_to_authentication_error(self, mock_gcp):
+        """Regression #413: a RefreshError during get_secret() maps to AuthenticationError."""
+        mock_client = MagicMock()
+        mock_client.list_secrets.return_value = iter([])
+        mock_client.access_secret_version.side_effect = mock_gcp.RefreshError("invalid_grant")
+        mock_gcp._secretmanager.SecretManagerServiceClient.return_value = mock_client
+
+        client = mock_gcp.GCPSecretManagerClient(project_id="my-project")
+        client.authenticate()
+
+        with pytest.raises(AuthenticationError):
+            client.get_secret("secret-name")
+
+    def test_get_secret_transport_error_maps_to_vault_error(self, mock_gcp):
+        """Regression #413: a transport GoogleAuthError during get_secret() is wrapped."""
+        mock_client = MagicMock()
+        mock_client.list_secrets.return_value = iter([])
+        mock_client.access_secret_version.side_effect = mock_gcp.GoogleAuthError("network down")
+        mock_gcp._secretmanager.SecretManagerServiceClient.return_value = mock_client
+
+        client = mock_gcp.GCPSecretManagerClient(project_id="my-project")
+        client.authenticate()
+
+        with pytest.raises(VaultError) as exc_info:
+            client.get_secret("secret-name")
+        assert not isinstance(exc_info.value, mock_gcp.GoogleAuthError)
+
+    def test_list_secrets_transport_error_maps_to_vault_error(self, mock_gcp):
+        """Regression #413: a transport GoogleAuthError during list_secrets() is wrapped."""
+        mock_client = MagicMock()
+        mock_client.list_secrets.side_effect = [
+            iter([]),
+            mock_gcp.GoogleAuthError("network down"),
+        ]
+        mock_gcp._secretmanager.SecretManagerServiceClient.return_value = mock_client
+
+        client = mock_gcp.GCPSecretManagerClient(project_id="my-project")
+        client.authenticate()
+
+        with pytest.raises(VaultError) as exc_info:
+            client.list_secrets()
+        assert not isinstance(exc_info.value, mock_gcp.GoogleAuthError)
+
+    def test_set_secret_transport_error_maps_to_vault_error(self, mock_gcp):
+        """Regression #413: a transport GoogleAuthError during set_secret() is wrapped."""
+        mock_client = MagicMock()
+        mock_client.list_secrets.return_value = iter([])
+        mock_client.add_secret_version.side_effect = mock_gcp.GoogleAuthError("network down")
+        mock_gcp._secretmanager.SecretManagerServiceClient.return_value = mock_client
+
+        client = mock_gcp.GCPSecretManagerClient(project_id="my-project")
+        client.authenticate()
+
+        with pytest.raises(VaultError) as exc_info:
+            client.set_secret("write-error", "value")
+        assert not isinstance(exc_info.value, mock_gcp.GoogleAuthError)
 
     def test_get_secret_binary_payload(self, mock_gcp):
         """Binary payload should be base64-encoded."""

--- a/tests/unit/test_vault_gcp.py
+++ b/tests/unit/test_vault_gcp.py
@@ -365,61 +365,52 @@ class TestGCPSecretManagerClient:
         assert not isinstance(exc_info.value, mock_gcp.GoogleAuthError)
         assert client.is_authenticated() is False
 
-    def test_get_secret_refresh_error_maps_to_authentication_error(self, mock_gcp):
-        """Regression #413: a RefreshError during get_secret() maps to AuthenticationError."""
-        mock_client = MagicMock()
-        mock_client.list_secrets.return_value = iter([])
-        mock_client.access_secret_version.side_effect = mock_gcp.RefreshError("invalid_grant")
-        mock_gcp._secretmanager.SecretManagerServiceClient.return_value = mock_client
+    @staticmethod
+    def _authenticated_client_with_op_error(mock_gcp, *, op: str, error: Exception):
+        """Build an authenticated client whose post-auth ``op`` call raises ``error``.
 
+        Authentication consumes the first ``list_secrets`` (an empty iterator); the
+        injected error is wired onto the operation under test so the four
+        auth-layer-failure regressions (#413) share one setup instead of copying
+        the build/authenticate boilerplate.
+        """
+        mock_client = MagicMock()
+        if op == "list_secrets":
+            # list_secrets is called twice: once by authenticate(), once under test.
+            mock_client.list_secrets.side_effect = [iter([]), error]
+        else:
+            mock_client.list_secrets.return_value = iter([])
+            getattr(mock_client, op).side_effect = error
+        mock_gcp._secretmanager.SecretManagerServiceClient.return_value = mock_client
         client = mock_gcp.GCPSecretManagerClient(project_id="my-project")
         client.authenticate()
+        return client
 
+    def test_get_secret_refresh_error_maps_to_authentication_error(self, mock_gcp):
+        """Regression #413: a RefreshError during get_secret() maps to AuthenticationError."""
+        client = self._authenticated_client_with_op_error(
+            mock_gcp, op="access_secret_version", error=mock_gcp.RefreshError("invalid_grant")
+        )
         with pytest.raises(AuthenticationError):
             client.get_secret("secret-name")
 
-    def test_get_secret_transport_error_maps_to_vault_error(self, mock_gcp):
-        """Regression #413: a transport GoogleAuthError during get_secret() is wrapped."""
-        mock_client = MagicMock()
-        mock_client.list_secrets.return_value = iter([])
-        mock_client.access_secret_version.side_effect = mock_gcp.GoogleAuthError("network down")
-        mock_gcp._secretmanager.SecretManagerServiceClient.return_value = mock_client
-
-        client = mock_gcp.GCPSecretManagerClient(project_id="my-project")
-        client.authenticate()
-
+    @pytest.mark.parametrize(
+        ("op", "call"),
+        [
+            ("access_secret_version", lambda c: c.get_secret("secret-name")),
+            ("list_secrets", lambda c: c.list_secrets()),
+            ("add_secret_version", lambda c: c.set_secret("write-error", "value")),
+        ],
+    )
+    def test_transport_error_maps_to_vault_error(self, mock_gcp, op, call):
+        """Regression #413: a transport GoogleAuthError during any operation is wrapped
+        as a domain VaultError rather than leaked as a raw auth-layer SDK exception.
+        """
+        client = self._authenticated_client_with_op_error(
+            mock_gcp, op=op, error=mock_gcp.GoogleAuthError("network down")
+        )
         with pytest.raises(VaultError) as exc_info:
-            client.get_secret("secret-name")
-        assert not isinstance(exc_info.value, mock_gcp.GoogleAuthError)
-
-    def test_list_secrets_transport_error_maps_to_vault_error(self, mock_gcp):
-        """Regression #413: a transport GoogleAuthError during list_secrets() is wrapped."""
-        mock_client = MagicMock()
-        mock_client.list_secrets.side_effect = [
-            iter([]),
-            mock_gcp.GoogleAuthError("network down"),
-        ]
-        mock_gcp._secretmanager.SecretManagerServiceClient.return_value = mock_client
-
-        client = mock_gcp.GCPSecretManagerClient(project_id="my-project")
-        client.authenticate()
-
-        with pytest.raises(VaultError) as exc_info:
-            client.list_secrets()
-        assert not isinstance(exc_info.value, mock_gcp.GoogleAuthError)
-
-    def test_set_secret_transport_error_maps_to_vault_error(self, mock_gcp):
-        """Regression #413: a transport GoogleAuthError during set_secret() is wrapped."""
-        mock_client = MagicMock()
-        mock_client.list_secrets.return_value = iter([])
-        mock_client.add_secret_version.side_effect = mock_gcp.GoogleAuthError("network down")
-        mock_gcp._secretmanager.SecretManagerServiceClient.return_value = mock_client
-
-        client = mock_gcp.GCPSecretManagerClient(project_id="my-project")
-        client.authenticate()
-
-        with pytest.raises(VaultError) as exc_info:
-            client.set_secret("write-error", "value")
+            call(client)
         assert not isinstance(exc_info.value, mock_gcp.GoogleAuthError)
 
     def test_get_secret_binary_payload(self, mock_gcp):

--- a/tests/unit/test_vault_hashicorp.py
+++ b/tests/unit/test_vault_hashicorp.py
@@ -353,6 +353,46 @@ class TestHashiCorpVaultClientWithMock:
         assert secret.value == "my-secret-value"
 
     @patch("envdrift.vault.hashicorp._hvac")
+    @pytest.mark.parametrize(
+        ("stored_value", "expected"),
+        [
+            (42, "42"),
+            (True, "true"),
+            (3.5, "3.5"),
+            ({"nested": "dict"}, '{"nested": "dict"}'),
+            ([1, 2, 3], "[1, 2, 3]"),
+        ],
+    )
+    def test_get_secret_single_non_string_value_is_coerced_to_str(
+        self, mock_hvac_module, stored_value, expected
+    ):
+        """Regression #413: a KV entry whose single ``value`` is a non-string
+        (int/bool/float/dict/list) must still yield a ``str`` SecretValue.value.
+
+        Vault KV stores arbitrary JSON, so ``secret_data["value"]`` can be a
+        non-string. The single-``value`` fast path previously assigned it verbatim
+        (no ``json.dumps``), so SecretValue.value was a non-str. The sync engine and
+        vault-pull then crash downstream when they treat the value as text. The
+        multi-key path already JSON-encodes; the single-value path must too.
+        """
+        mock_client = MagicMock()
+        mock_client.is_authenticated.return_value = True
+        mock_client.secrets.kv.v2.read_secret_version.return_value = {
+            "data": {"data": {"value": stored_value}, "metadata": {"version": 1}}
+        }
+        mock_hvac_module.Client.return_value = mock_client
+
+        from envdrift.vault.hashicorp import HashiCorpVaultClient
+
+        client = HashiCorpVaultClient(url="http://localhost:8200", token="valid-token")
+        client.authenticate()
+
+        secret = client.get_secret("my-secret")
+
+        assert isinstance(secret.value, str)
+        assert secret.value == expected
+
+    @patch("envdrift.vault.hashicorp._hvac")
     def test_get_secret_with_multiple_values(self, mock_hvac_module):
         """Test get_secret returns JSON for multiple values."""
         mock_client = MagicMock()

--- a/tests/unit/test_vault_hashicorp.py
+++ b/tests/unit/test_vault_hashicorp.py
@@ -564,6 +564,34 @@ class TestHashiCorpVaultClientWithMock:
         assert call_args[1]["secret"] == {"key": "value"}
 
     @patch("envdrift.vault.hashicorp._hvac")
+    def test_create_or_update_secret_single_non_string_value_returns_str(self, mock_hvac_module):
+        """Regression #413: writing a non-string single ``value`` returns a ``str``.
+
+        ``SecretValue.value`` must always be a str (the sync engine/vault-pull treat
+        it as text), so the write path coerces a non-string single value to JSON,
+        mirroring the read path. The secret stored in Vault keeps its raw type.
+        """
+        mock_client = MagicMock()
+        mock_client.is_authenticated.return_value = True
+        mock_client.secrets.kv.v2.create_or_update_secret.return_value = {
+            "data": {"version": 1, "created_time": "now"}
+        }
+        mock_hvac_module.Client.return_value = mock_client
+
+        from envdrift.vault.hashicorp import HashiCorpVaultClient
+
+        client = HashiCorpVaultClient(url="http://localhost:8200", token="valid-token")
+        client.authenticate()
+
+        result = client.create_or_update_secret("num-secret", {"value": 123})
+
+        # Returned value is a JSON-coerced str; the payload written to Vault is raw.
+        assert isinstance(result.value, str)
+        assert result.value == "123"
+        call_args = mock_client.secrets.kv.v2.create_or_update_secret.call_args
+        assert call_args[1]["secret"] == {"value": 123}
+
+    @patch("envdrift.vault.hashicorp._hvac")
     def test_set_secret_delegates_to_create_or_update(self, mock_hvac_module):
         """Test set_secret is an alias."""
         mock_client = MagicMock()


### PR DESCRIPTION
## Summary

Cluster D of #413 — vault backend error handling. The non-HashiCorp backends only
caught their SDK's *response/API-call* error types, so a transport/network failure
(DNS, TLS, timeout, unreachable endpoint, bad service-account key) escaped as a
**raw SDK exception that is not a `VaultError`**, producing an uncaught CLI
traceback with the wrong exit code. HashiCorp's single-`value` fast path also
leaked a non-string value, crashing the sync engine and vault-pull downstream.
HashiCorp's `except Exception -> VaultError` catch-all is the correct model; this
PR brings the other three backends in line and fixes the HashiCorp coercion gap.

## Findings fixed (from #413)

- **[HIGH] HashiCorp `get_secret` leaks a non-string value, crashing the sync
  engine and vault-pull** — `src/envdrift/vault/hashicorp.py:152-153`. The single-
  `value` fast path assigned `secret_data["value"]` with no `str` coercion (the
  multi-key path already `json.dumps()`es). Fix: coerce a non-string single value
  (int/bool/float/dict/list) to JSON so `SecretValue.value` is always a `str`.
- **[HIGH] Transport/network errors escape AWS/GCP/Azure backends as raw
  exceptions** — `src/envdrift/vault/aws.py:84-90,214-220`;
  `gcp.py:150-152,194-195`; `azure.py:102-112,157-158`.
  - AWS: added `except BotoCoreError -> VaultError` to `authenticate`/`get_secret`/
    `list_secrets`/`_put_secret_value`/`set_secret`. botocore transport errors
    (`EndpointConnectionError`/`ConnectTimeoutError`/`ReadTimeoutError`/...)
    subclass `BotoCoreError` and carry no `.response`, so they used to hit the bare
    `raise`. `ClientError` (error-code path) and genuinely-unknown errors are
    unaffected — the existing `*_unknown_error_propagates` tests still pass.
  - GCP: catch `google.auth.exceptions.GoogleAuthError` (`RefreshError` ->
    `AuthenticationError`, other e.g. `TransportError` -> `VaultError`). These are
    not `GoogleAPICallError`, so they previously escaped.
  - Azure: added `except AzureError -> VaultError` to wrap `ServiceRequestError`
    (an `AzureError` but **not** a `HttpResponseError`).
- **[LOW] Azure maps mid-session credential expiry to generic `VaultError`** —
  `src/envdrift/vault/azure.py:157-158,179-180,201-202`. Added
  `except ClientAuthenticationError -> AuthenticationError` **before** the
  `HttpResponseError` clause in `get_secret`/`list_secrets`/`set_secret` (it is a
  subclass, so ordering matters), so a 401 mid-session expiry is reported as
  `AuthenticationError` like the other three backends.

## Regression tests (22 added)

Every fix ships a real regression test, each verified to **fail on the unfixed
source** and **pass with the fix** (temporarily reverting only the source hunk):

- HashiCorp: parametrized `int/bool/float/dict/list` single-value -> `str` (5).
- AWS: transport-error -> `VaultError` for authenticate/get/list/put/set (5).
- GCP: `RefreshError` -> `AuthenticationError` and `TransportError`/`GoogleAuthError`
  -> `VaultError` across authenticate/get/list/set (6).
- Azure: `ClientAuthenticationError` -> `AuthenticationError` and
  `ServiceRequestError` -> `VaultError` across get/list/set (6).

The test SDK-exception fakes were extended to mirror the **real MROs**
(`BotoCoreError` base; `GoogleAuthError`/`RefreshError`/`TransportError` tree;
`AzureError`/`ServiceRequestError` split) so the production except-clause ordering
is genuinely exercised, not bypassed.

## Gates

`ruff check` + `ruff format --check` + `pyrefly check` (src and touched tests) +
`bandit` all green. Touched-file coverage: aws 99%, azure 92%, gcp 92%, hashicorp
100%. Full unit suite (`-m "not integration"`) green (1630 passed). No `--format
json` / machine-readable output touched. No docs change needed (the new behavior
matches the docstrings' already-documented `VaultError`/`AuthenticationError`
contracts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Unified and improved error handling across AWS, Azure, GCP and HashiCorp backends so authentication failures, access-denied, not-found, and transport/network errors are classified and reported consistently.
  * Fixed HashiCorp Vault secret handling to always return secret values as strings (JSON-encoded when needed).
  * Adjusted create/update fallback behavior to preserve correct error semantics.

* **Tests**
  * Added regression tests covering error mapping and transport/auth failure scenarios for all providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes transport/network error escaping across all vault backends and a non-string value coercion bug in the HashiCorp backend. A previous review found that `AzureError` transport wrapping was missing from `authenticate()` — that gap is now closed in this version.

- **HashiCorp**: `_coerce_secret_value` helper ensures `SecretValue.value` is always a `str`, JSON-encoding non-string single values (int/bool/float/dict/list) instead of assigning them verbatim.
- **AWS/GCP/Azure**: New `_map_aws_error`/`_map_gcp_error`/`_map_azure_error` helpers centralise exception mapping so transport failures (`BotoCoreError`, `GoogleAuthError`, `ServiceRequestError`) are wrapped into domain `VaultError`s instead of escaping raw; Azure also gains `ClientAuthenticationError -> AuthenticationError` mid-session mapping across all three post-auth operations.
- **Tests**: 22 regression tests added (parametrized for all backends/operations), each exercising fake exception hierarchies that mirror real SDK MROs.

<h3>Confidence Score: 5/5</h3>

Safe to merge. All four backends now wrap transport and network failures into domain errors, and the previous gap in Azure's authenticate() has been closed.

Every fixed path ships a matching regression test that was verified to fail on the unfixed source. The exception-hierarchy fakes mirror real SDK MROs so the production catch-ordering is genuinely exercised. No previously-handled error code was dropped or reclassified, and the existing unknown-error propagation tests still pass.

No files require special attention. The prior concern about Azure's authenticate() transport gap is resolved in this version.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/envdrift/vault/aws.py | Adds `_map_aws_error` helper that centralises BotoCoreError/error-code mapping for all five operations; `set_secret` explicitly guards the ResourceExistsException short-circuit against BotoCoreError to avoid bypassing the new transport-error path. |
| src/envdrift/vault/azure.py | Adds `_map_azure_error` helper and widens the exception catches from `HttpResponseError` to `AzureError` in get/list/set; `authenticate()` now has its own `except AzureError` block (the gap flagged in the previous review), resetting `_client`/`_credential` and raising `VaultError` for transport failures. |
| src/envdrift/vault/gcp.py | Adds `_map_gcp_error` helper; `authenticate()` consolidates DefaultCredentialsError/GoogleAPICallError/GoogleAuthError into one handler; get/list/set now catch both GoogleAPICallError and GoogleAuthError to cover RefreshError/TransportError that previously escaped. |
| src/envdrift/vault/hashicorp.py | Extracts `_coerce_secret_value` helper; `get_secret` and `create_or_update_secret` both use it, ensuring `SecretValue.value` is always a `str` even when the KV entry stores a non-string single value. |
| tests/unit/test_vault_aws.py | Adds FakeBotoCoreError/FakeTransportError hierarchy and 5 regression tests (authenticate/get/list/put/set) verifying transport errors are wrapped as VaultError; BotoCoreError is patched onto the reloaded module so production isinstance checks work correctly. |
| tests/unit/test_vault_azure.py | Refactors FakeHttpResponseError to subclass FakeAzureError; adds FakeServiceRequestError (AzureError, not HttpResponseError) and 6 regression tests covering ClientAuthenticationError->AuthenticationError and ServiceRequestError->VaultError for get/list/set/authenticate. |
| tests/unit/test_vault_gcp.py | Restructures fake exception hierarchy (DummyGoogleAuthError base, DummyRefreshError/DummyTransportError subclasses); adds 6 regression tests for RefreshError->AuthenticationError and TransportError/GoogleAuthError->VaultError across authenticate/get/list/set. |
| tests/unit/test_vault_hashicorp.py | Adds parametrized regression test covering int/bool/float/dict/list single-value coercion, and a separate test for create_or_update_secret non-string write path; all assert SecretValue.value is str with correct JSON representation. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/envdrift/vault/azure.py`, line 69-114 ([link](https://github.com/jainal09/envdrift/blob/86b3e4be3120989160e2fdd62baccb0cdb42906b/src/envdrift/vault/azure.py#L69-L114)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Transport errors still escape from `authenticate()`**

   The `AzureError` catch-all added to `get_secret`, `list_secrets`, and `set_secret` was not applied to `authenticate()`. A `ServiceRequestError` (DNS/TLS/connectivity failure) raised during the auth probe `next(iter(secrets_iter), None)` is an `AzureError` but not an `HttpResponseError`, so it falls through both existing `except` clauses and surfaces as an uncaught raw SDK exception — the exact bug this PR fixes for the other three methods. An `except AzureError` block (resetting `_client`/`_credential` like the other failure paths) should be added as the final handler in `authenticate()`.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (4): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/vault-error..."](https://github.com/jainal09/envdrift/commit/b7c6d056cdbb2f7ac2c20be8c780789966357144) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36083499)</sub>

<!-- /greptile_comment -->