### PR TITLE
docs(changelog): strip stray "cluster J" shorthand from release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Bug Fixes
 
-* **agent:** harden watcher, lockcheck, registry, and stop reliability ([#413](https://github.com/jainal09/envdrift/issues/413) cluster J) ([#424](https://github.com/jainal09/envdrift/issues/424)) ([b9f9993](https://github.com/jainal09/envdrift/commit/b9f99939680b61274e60582c49b26caaa1e17297))
+* **agent:** harden watcher, lockcheck, registry, and stop reliability ([#413](https://github.com/jainal09/envdrift/issues/413)) ([#424](https://github.com/jainal09/envdrift/issues/424)) ([b9f9993](https://github.com/jainal09/envdrift/commit/b9f99939680b61274e60582c49b26caaa1e17297))
 * **cli:** keep guard/diff machine output clean and unescape TOML in error messages ([#418](https://github.com/jainal09/envdrift/issues/418)) ([cbd2f56](https://github.com/jainal09/envdrift/commit/cbd2f566d14019068657214b52ab246b8902fb0a))
 * **config:** defer guardian/partial validation; harden schema metadata isolation ([#425](https://github.com/jainal09/envdrift/issues/425)) ([f9ccd49](https://github.com/jainal09/envdrift/commit/f9ccd494dbf585eccf31c47d85eb85c5a625820b))
 * **init:** generate safe, importable Python for keyword and non-identifier vars ([#423](https://github.com/jainal09/envdrift/issues/423)) ([e17a103](https://github.com/jainal09/envdrift/commit/e17a1037f6b8132e6f0ba0039e8eb2dea83dbfcc))

--- a/envdrift-agent/CHANGELOG.md
+++ b/envdrift-agent/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
-* **agent:** harden watcher, lockcheck, registry, and stop reliability ([#413](https://github.com/jainal09/envdrift/issues/413) cluster J) ([#424](https://github.com/jainal09/envdrift/issues/424)) ([b9f9993](https://github.com/jainal09/envdrift/commit/b9f99939680b61274e60582c49b26caaa1e17297))
+* **agent:** harden watcher, lockcheck, registry, and stop reliability ([#413](https://github.com/jainal09/envdrift/issues/413)) ([#424](https://github.com/jainal09/envdrift/issues/424)) ([b9f9993](https://github.com/jainal09/envdrift/commit/b9f99939680b61274e60582c49b26caaa1e17297))
 
 ## [1.1.1](https://github.com/jainal09/envdrift/compare/agent-v1.1.0...agent-v1.1.1) (2026-06-07)
 


### PR DESCRIPTION
## What

Removes the stray internal shorthand `cluster J` from the `v10.13.8` and
`agent-v1.1.2` entries in both changelog files.

## Why

The squash-commit subject for #424 on `main` was:

> `fix(agent): harden watcher, lockcheck, registry, and stop reliability (#413 cluster J) (#424)`

`cluster J` was an internal cluster label that leaked into the commit
title. release-please copies commit subjects verbatim into the generated
changelogs, so both `CHANGELOG.md` (10.13.8) and
`envdrift-agent/CHANGELOG.md` (agent-1.1.2) ended up with the fragment in
a user-facing line. CodeRabbit flagged it on the agent release PR (#427).

These sections are already released, so release-please won't regenerate
them — this manual edit is the way to clean them on `main`.

## Scope

- `CHANGELOG.md` — drop ` cluster J` from the 10.13.8 agent line
- `envdrift-agent/CHANGELOG.md` — drop ` cluster J` from the 1.1.2 line
- Issue links (#413, #424) and commit hash (`b9f9993`) unchanged

The matching **GitHub release notes** for `v10.13.8` and `agent-v1.1.2`
were already corrected directly via the releases API.

## Follow-up

Keep internal cluster labels out of Conventional Commit subject lines —
release-please surfaces them verbatim in published notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes the internal label `cluster J` from two changelog entries that were generated verbatim by release-please from a squash-commit subject. Both `CHANGELOG.md` (v10.13.8) and `envdrift-agent/CHANGELOG.md` (agent-v1.1.2) receive the same single-line fix.

- `CHANGELOG.md`: strips ` cluster J` from the `#413` issue link in the 10.13.8 bug-fix entry, leaving the issue number, PR link, and commit hash intact.
- `envdrift-agent/CHANGELOG.md`: identical strip in the agent 1.1.2 entry.

<h3>Confidence Score: 5/5</h3>

Documentation-only change with no risk to runtime behaviour.

Both edits are purely mechanical text removals in already-released changelog sections. Issue links, PR references, and commit hashes are all preserved, and no code paths are touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| CHANGELOG.md | Removes ` cluster J` from the v10.13.8 agent bug-fix entry; all links and commit hash are preserved correctly. |
| envdrift-agent/CHANGELOG.md | Removes ` cluster J` from the agent-v1.1.2 bug-fix entry; all links and commit hash are preserved correctly. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Squash-commit subject\n'fix(agent): harden watcher… (#413 cluster J) (#424)'"] --> B["release-please copies subject verbatim"]
    B --> C["CHANGELOG.md v10.13.8\n❌ '(#413 cluster J)'"]
    B --> D["envdrift-agent/CHANGELOG.md v1.1.2\n❌ '(#413 cluster J)'"]
    C --> E["This PR: strip 'cluster J'\n✅ '(#413)'"]
    D --> F["This PR: strip 'cluster J'\n✅ '(#413)'"]
    E --> G["GitHub release notes already\ncorrected via releases API"]
    F --> G
```

<sub>Reviews (1): Last reviewed commit: ["docs(changelog): strip stray &quot;cluster J&quot;..."](https://github.com/jainal09/envdrift/commit/5b5d2efc707ea769e22446ff7fc36160f3f0fbfa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36270664)</sub>

<!-- /greptile_comment -->