### PR TITLE
feat(validate): honor [validation] config; drop dead secret_patterns

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -75,30 +75,22 @@ environments = ["development", "staging", "production"]
 
 ### [validation] — Validation Settings
 
-Settings parsed under the `[validation]` section.
+Settings under the `[validation]` section, consumed by `envdrift validate`.
 
-> **Note:** `envdrift validate` does not currently read these keys. The command
-> always loads its options from CLI flags (for example
-> `--check-encryption/--no-check-encryption`, default on) and always treats
-> extra variables as errors. `strict_extra` and `secret_patterns` are parsed
-> into the config object but are not yet consumed by any command, so setting
-> them has no effect on validation behavior today.
+> **Note:** `check_encryption` seeds the default for the
+> `--check-encryption/--no-check-encryption` flag — passing the flag explicitly
+> overrides the config value. `strict_extra` controls whether `validate` checks
+> for variables absent from the schema at all.
 
 | Option | Type | Default | Description |
 |:-------|:-----|:--------|:------------|
-| `check_encryption` | `bool` | `true` | Parsed but not consumed; the same-named `--check-encryption/--no-check-encryption` CLI flag (default on) controls this instead |
-| `strict_extra` | `bool` | `true` | Parsed but not consumed; extra variables are always treated as errors |
-| `secret_patterns` | `list[string]` | `[]` | Parsed but not consumed; no command reads these patterns |
+| `check_encryption` | `bool` | `true` | Default for the encryption check; the `--check-encryption/--no-check-encryption` CLI flag overrides it when passed |
+| `strict_extra` | `bool` | `true` | When `true`, variables not in the schema are checked (and rejected if the schema sets `extra="forbid"`); `false` skips the extra-variable check entirely |
 
 ```toml
 [validation]
 check_encryption = true
 strict_extra = true
-secret_patterns = [
-    "^STRIPE_",
-    "^TWILIO_",
-    "^SENDGRID_",
-]
 ```
 
 ### [guard] — Secret Scanning Settings
@@ -501,7 +493,6 @@ environments = ["development", "staging", "production"]
 [validation]
 check_encryption = true
 strict_extra = true
-secret_patterns = ["^STRIPE_", "^TWILIO_"]
 
 [guard]
 scanners = ["native", "gitleaks"]

--- a/src/envdrift/cli_commands/validate.py
+++ b/src/envdrift/cli_commands/validate.py
@@ -8,11 +8,37 @@ from typing import Annotated
 
 import typer
 
-from envdrift.config import ValidationConfig, find_config, load_config
+from envdrift.config import ConfigNotFoundError, ValidationConfig, find_config, load_config
 from envdrift.core.parser import EnvParser
 from envdrift.core.schema import SchemaLoader, SchemaLoadError
 from envdrift.core.validator import Validator
 from envdrift.output.rich import console, print_error, print_validation_result
+
+
+def _resolve_validation_settings(check_encryption_flag: bool | None) -> tuple[bool, bool]:
+    """Resolve effective ``(check_encryption, check_extra)`` from the CLI flag
+    and ``[validation]`` config.
+
+    ``--check-encryption/--no-check-encryption`` overrides config when passed
+    explicitly; otherwise ``[validation].check_encryption`` is the default.
+    ``check_extra`` comes from ``[validation].strict_extra``. A config that
+    cannot be loaded raises ``typer.Exit(1)`` with a clean error.
+    """
+    validation_cfg = ValidationConfig()
+    config_path = find_config()
+    if config_path is not None:
+        try:
+            validation_cfg = load_config(config_path).validation
+        except (OSError, ValueError, tomllib.TOMLDecodeError, ConfigNotFoundError) as exc:
+            print_error(f"Failed to load envdrift config ({config_path}): {exc}")
+            raise typer.Exit(code=1) from None
+
+    effective_check_encryption = (
+        check_encryption_flag
+        if check_encryption_flag is not None
+        else validation_cfg.check_encryption
+    )
+    return effective_check_encryption, validation_cfg.strict_extra
 
 
 def validate(
@@ -94,30 +120,16 @@ def validate(
         print_error(str(e))
         raise typer.Exit(code=1) from None
 
-    # Resolve [validation] settings from envdrift.toml (if present). These seed
-    # the encryption-check default and control extra-variable checking.
-    validation_cfg = ValidationConfig()
-    config_path = find_config()
-    if config_path is not None:
-        try:
-            validation_cfg = load_config(config_path).validation
-        except (OSError, ValueError, tomllib.TOMLDecodeError) as exc:
-            print_error(f"Failed to load envdrift config ({config_path}): {exc}")
-            raise typer.Exit(code=1) from None
+    # Resolve [validation] config: CLI flag overrides check_encryption; strict_extra
+    # drives check_extra (False skips the extra-variable check entirely).
+    effective_check_encryption, check_extra = _resolve_validation_settings(check_encryption)
 
-    # --check-encryption/--no-check-encryption overrides the config default when
-    # passed explicitly; otherwise fall back to [validation].check_encryption.
-    effective_check_encryption = (
-        check_encryption if check_encryption is not None else validation_cfg.check_encryption
-    )
-
-    # Validate. strict_extra=False skips the extra-variable check entirely.
     validator = Validator()
     result = validator.validate(
         env,
         schema_meta,
         check_encryption=effective_check_encryption,
-        check_extra=validation_cfg.strict_extra,
+        check_extra=check_extra,
     )
 
     # Print result

--- a/src/envdrift/cli_commands/validate.py
+++ b/src/envdrift/cli_commands/validate.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import tomllib
 from pathlib import Path
 from typing import Annotated
 
 import typer
 
+from envdrift.config import ValidationConfig, find_config, load_config
 from envdrift.core.parser import EnvParser
 from envdrift.core.schema import SchemaLoader, SchemaLoadError
 from envdrift.core.validator import Validator
@@ -25,9 +27,13 @@ def validate(
     ] = None,
     ci: Annotated[bool, typer.Option("--ci", help="CI mode: exit with code 1 on failure")] = False,
     check_encryption: Annotated[
-        bool,
-        typer.Option("--check-encryption/--no-check-encryption", help="Check encryption"),
-    ] = True,
+        bool | None,
+        typer.Option(
+            "--check-encryption/--no-check-encryption",
+            help="Check that sensitive vars are encrypted "
+            "(default: [validation].check_encryption from envdrift.toml, else on)",
+        ),
+    ] = None,
     fix: Annotated[
         bool, typer.Option("--fix", help="Output template for missing variables")
     ] = False,
@@ -52,8 +58,11 @@ def validate(
         service_dir (Path | None): Optional directory to add to imports when
             resolving the schema.
         ci (bool): When true, exit with code 1 if validation fails.
-        check_encryption (bool): When true, validate encryption-related metadata
-            on sensitive fields.
+        check_encryption (bool | None): Tri-state. When explicitly set via
+            ``--check-encryption``/``--no-check-encryption`` it overrides config;
+            when left unset (None) it falls back to ``[validation].check_encryption``
+            from envdrift.toml (default on). Controls validation of
+            encryption-related metadata on sensitive fields.
         fix (bool): When true and validation fails, print a fix template with
             missing variables and defaults when available.
         verbose (bool): When true, include additional details in the validation
@@ -85,13 +94,30 @@ def validate(
         print_error(str(e))
         raise typer.Exit(code=1) from None
 
-    # Validate
+    # Resolve [validation] settings from envdrift.toml (if present). These seed
+    # the encryption-check default and control extra-variable checking.
+    validation_cfg = ValidationConfig()
+    config_path = find_config()
+    if config_path is not None:
+        try:
+            validation_cfg = load_config(config_path).validation
+        except (OSError, ValueError, tomllib.TOMLDecodeError) as exc:
+            print_error(f"Failed to load envdrift config ({config_path}): {exc}")
+            raise typer.Exit(code=1) from None
+
+    # --check-encryption/--no-check-encryption overrides the config default when
+    # passed explicitly; otherwise fall back to [validation].check_encryption.
+    effective_check_encryption = (
+        check_encryption if check_encryption is not None else validation_cfg.check_encryption
+    )
+
+    # Validate. strict_extra=False skips the extra-variable check entirely.
     validator = Validator()
     result = validator.validate(
         env,
         schema_meta,
-        check_encryption=check_encryption,
-        check_extra=True,
+        check_encryption=effective_check_encryption,
+        check_extra=validation_cfg.strict_extra,
     )
 
     # Print result

--- a/src/envdrift/config.py
+++ b/src/envdrift/config.py
@@ -100,11 +100,16 @@ class EncryptionConfig:
 
 @dataclass
 class ValidationConfig:
-    """Validation settings."""
+    """Validation settings consumed by ``envdrift validate``.
+
+    ``check_encryption`` seeds the default for the
+    ``--check-encryption/--no-check-encryption`` flag (an explicit flag
+    overrides it). ``strict_extra`` controls whether variables absent from the
+    schema are checked at all (``False`` skips the extra-variable check).
+    """
 
     check_encryption: bool = True
     strict_extra: bool = True
-    secret_patterns: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -427,7 +432,6 @@ class EnvdriftConfig:
         validation = ValidationConfig(
             check_encryption=validation_section.get("check_encryption", True),
             strict_extra=validation_section.get("strict_extra", True),
-            secret_patterns=validation_section.get("secret_patterns", []),
         )
 
         # Build vault config (and its nested sync config)
@@ -601,22 +605,15 @@ schema = "config.settings:ProductionSettings"
 environments = ["development", "staging", "production"]
 
 [validation]
-# NOTE: the [validation] keys below are parsed into the config object but are
-# NOT currently consumed by any command (see docs/reference/configuration.md).
-# `envdrift validate` ignores them; the --check-encryption/--no-check-encryption
-# CLI flag (default on) controls encryption checking, and extra variables are
-# always treated as errors.
-# Parsed but not consumed:
+# Consumed by `envdrift validate` (see docs/reference/configuration.md).
+# Default for the encryption check; the --check-encryption/--no-check-encryption
+# CLI flag overrides this when passed explicitly.
 check_encryption = true
 
-# Parsed but not consumed (extra vars are always treated as errors):
+# When true (default), variables not present in the schema are checked and
+# rejected if the schema sets extra="forbid". Set to false to skip the
+# extra-variable check entirely.
 strict_extra = true
-
-# Parsed but not consumed (no command reads these patterns):
-secret_patterns = [
-    "^STRIPE_",
-    "^TWILIO_",
-]
 
 [encryption]
 # Encryption backend: dotenvx (default) or sops

--- a/tests/benchmarks/test_benchmarks.py
+++ b/tests/benchmarks/test_benchmarks.py
@@ -263,7 +263,6 @@ SAMPLE_CONFIG_DICT: dict[str, Any] = {
     "validation": {
         "check_encryption": True,
         "strict_extra": True,
-        "secret_patterns": ["^STRIPE_", "^TWILIO_"],
     },
     "vault": {
         "provider": "azure",

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -348,6 +348,31 @@ class Settings(BaseSettings):
         assert result.exit_code == 1, result.output
         assert "Failed to load envdrift config" in result.output
 
+    def test_config_not_found_race_handled_cleanly(self, tmp_path: Path, monkeypatch):
+        """A ConfigNotFoundError from load_config (TOCTOU) is handled, not raised.
+
+        find_config() and load_config() are two separate filesystem checks; if the
+        file is removed in between, load_config raises ConfigNotFoundError (a plain
+        Exception, not OSError/ValueError). It must surface the clean message.
+        """
+        from envdrift.config import ConfigNotFoundError
+
+        args = self._project(
+            tmp_path,
+            self._FORBID_SCHEMA,
+            "APP_NAME=MyApp\n",
+            "[validation]\ncheck_encryption = true\n",
+        )
+        monkeypatch.chdir(tmp_path)
+
+        def _raise_not_found(_path):
+            raise ConfigNotFoundError("config vanished mid-call")
+
+        monkeypatch.setattr("envdrift.cli_commands.validate.load_config", _raise_not_found)
+        result = runner.invoke(app, args)
+        assert result.exit_code == 1, result.output
+        assert "Failed to load envdrift config" in result.output
+
 
 class TestDiffCommand:
     """Tests for the diff CLI command."""

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -232,6 +232,123 @@ class FixSettings(BaseSettings):
         assert "MISSING_VAR" in result.output or "template" in result.output.lower()
 
 
+class TestValidateConsumesValidationConfig:
+    """`envdrift validate` consumes the [validation] config section (#413).
+
+    Real in-process CLI invocations against a temp project; ``monkeypatch.chdir``
+    makes ``find_config()`` resolve the temp ``envdrift.toml`` deterministically.
+    """
+
+    _FORBID_SCHEMA = """
+from pydantic_settings import BaseSettings
+
+class Settings(BaseSettings):
+    APP_NAME: str
+    DEBUG: bool = False
+    model_config = {"extra": "forbid"}
+"""
+
+    _SENSITIVE_SCHEMA = """
+from pydantic import Field
+from pydantic_settings import BaseSettings
+
+class Settings(BaseSettings):
+    API_KEY: str = Field(json_schema_extra={"sensitive": True})
+"""
+
+    def _project(
+        self, tmp_path: Path, schema_src: str, env_text: str, toml: str | None
+    ) -> list[str]:
+        (tmp_path / "settings.py").write_text(schema_src)
+        (tmp_path / ".env").write_text(env_text)
+        if toml is not None:
+            (tmp_path / "envdrift.toml").write_text(toml)
+        return [
+            "validate",
+            str(tmp_path / ".env"),
+            "--schema",
+            "settings:Settings",
+            "--service-dir",
+            str(tmp_path),
+        ]
+
+    def test_strict_extra_false_skips_extra_check(self, tmp_path: Path, monkeypatch):
+        """strict_extra=false makes validate ignore variables absent from the schema."""
+        args = self._project(
+            tmp_path,
+            self._FORBID_SCHEMA,
+            "APP_NAME=MyApp\nDEBUG=true\nUNKNOWN_VAR=x\n",
+            "[validation]\nstrict_extra = false\ncheck_encryption = false\n",
+        )
+        monkeypatch.chdir(tmp_path)
+        result = runner.invoke(app, [*args, "--ci"])
+        assert result.exit_code == 0, result.output
+        assert "UNKNOWN_VAR" not in result.output
+
+    def test_strict_extra_true_rejects_extra(self, tmp_path: Path, monkeypatch):
+        """strict_extra=true (default) rejects variables absent from a forbid schema."""
+        args = self._project(
+            tmp_path,
+            self._FORBID_SCHEMA,
+            "APP_NAME=MyApp\nDEBUG=true\nUNKNOWN_VAR=x\n",
+            "[validation]\nstrict_extra = true\ncheck_encryption = false\n",
+        )
+        monkeypatch.chdir(tmp_path)
+        result = runner.invoke(app, [*args, "--ci"])
+        assert result.exit_code == 1, result.output
+        assert "UNKNOWN_VAR" in result.output
+
+    def test_check_encryption_config_default_used(self, tmp_path: Path, monkeypatch):
+        """check_encryption=false suppresses the unencrypted-secret check when no flag is passed."""
+        args = self._project(
+            tmp_path,
+            self._SENSITIVE_SCHEMA,
+            "API_KEY=plaintext_secret_value\n",
+            "[validation]\ncheck_encryption = false\n",
+        )
+        monkeypatch.chdir(tmp_path)
+        result = runner.invoke(app, args)
+        assert "UNENCRYPTED SECRETS" not in result.output, result.output
+
+    def test_check_encryption_cli_overrides_config(self, tmp_path: Path, monkeypatch):
+        """An explicit --check-encryption overrides check_encryption=false in config."""
+        args = self._project(
+            tmp_path,
+            self._SENSITIVE_SCHEMA,
+            "API_KEY=plaintext_secret_value\n",
+            "[validation]\ncheck_encryption = false\n",
+        )
+        monkeypatch.chdir(tmp_path)
+        result = runner.invoke(app, [*args, "--check-encryption"])
+        assert "UNENCRYPTED SECRETS" in result.output, result.output
+
+    def test_no_config_uses_defaults(self, tmp_path: Path, monkeypatch):
+        """With no envdrift.toml, defaults apply (extra vars checked) — backward compatible."""
+        args = self._project(
+            tmp_path,
+            self._FORBID_SCHEMA,
+            "APP_NAME=MyApp\nDEBUG=true\nUNKNOWN_VAR=x\n",
+            None,
+        )
+        monkeypatch.chdir(tmp_path)
+        result = runner.invoke(app, [*args, "--no-check-encryption", "--ci"])
+        assert result.exit_code == 1, result.output
+        assert "UNKNOWN_VAR" in result.output
+
+    def test_malformed_config_reports_error(self, tmp_path: Path, monkeypatch):
+        """A malformed envdrift.toml surfaces a clean error, not a traceback."""
+        args = self._project(
+            tmp_path,
+            self._FORBID_SCHEMA,
+            "APP_NAME=MyApp\n",
+            "[validation\ncheck_encryption = true\n",  # missing closing bracket
+        )
+        monkeypatch.chdir(tmp_path)
+        result = runner.invoke(app, args)
+        assert result.exit_code == 1, result.output
+        assert "Failed to load envdrift config" in result.output
+
+
 class TestDiffCommand:
     """Tests for the diff CLI command."""
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -57,18 +57,15 @@ class TestValidationConfig:
         config = ValidationConfig()
         assert config.check_encryption is True
         assert config.strict_extra is True
-        assert config.secret_patterns == []
 
     def test_custom_values(self):
         """Test ValidationConfig with custom values."""
         config = ValidationConfig(
             check_encryption=False,
             strict_extra=False,
-            secret_patterns=["*_KEY", "*_SECRET"],
         )
         assert config.check_encryption is False
         assert config.strict_extra is False
-        assert config.secret_patterns == ["*_KEY", "*_SECRET"]
 
 
 class TestPrecommitConfig:
@@ -120,6 +117,8 @@ class TestEnvdriftConfig:
             "validation": {
                 "check_encryption": False,
                 "strict_extra": False,
+                # secret_patterns was dropped (#413); an old config carrying it
+                # must still load — the now-unknown key is silently ignored.
                 "secret_patterns": ["*_TOKEN"],
             },
             "vault": {
@@ -146,7 +145,9 @@ class TestEnvdriftConfig:
 
         assert config.validation.check_encryption is False
         assert config.validation.strict_extra is False
-        assert config.validation.secret_patterns == ["*_TOKEN"]
+        # secret_patterns was removed from ValidationConfig (#413); the stray
+        # key in the input is tolerated but never surfaces as an attribute.
+        assert not hasattr(config.validation, "secret_patterns")
 
         assert config.vault.provider == "aws"
         assert config.vault.aws_region == "eu-west-1"

--- a/tests/unit/test_config_deferred_validation.py
+++ b/tests/unit/test_config_deferred_validation.py
@@ -290,19 +290,21 @@ secrets_only = true
 class TestExampleConfig:
     """Tests for the in-source EXAMPLE_CONFIG template."""
 
-    def test_validation_keys_documented_as_not_consumed(self):
-        """EXAMPLE_CONFIG must not misrepresent [validation] keys (#413).
+    def test_validation_keys_documented_as_consumed(self):
+        """EXAMPLE_CONFIG documents the [validation] keys as consumed (#413).
 
-        No command reads validation.check_encryption/strict_extra/secret_patterns,
-        so the example comments must say so (matching docs/reference/configuration.md)
-        rather than implying they take effect.
+        ``check_encryption`` and ``strict_extra`` are now read by
+        ``envdrift validate``; ``secret_patterns`` was dropped. The example must
+        reflect that and must not advertise the removed key or the old
+        "not consumed" disclaimer.
         """
-        assert "parsed into the config object but are\n# NOT currently consumed" in EXAMPLE_CONFIG
-        assert "Parsed but not consumed" in EXAMPLE_CONFIG
-        # Guard against the old misleading comments coming back.
-        assert "# Check encryption by default" not in EXAMPLE_CONFIG
-        assert "# Treat extra vars as errors" not in EXAMPLE_CONFIG
-        assert "# Additional secret detection patterns" not in EXAMPLE_CONFIG
+        assert "Consumed by `envdrift validate`" in EXAMPLE_CONFIG
+        assert "check_encryption = true" in EXAMPLE_CONFIG
+        assert "strict_extra = true" in EXAMPLE_CONFIG
+        # The dropped key must not reappear, nor the old "not consumed" wording.
+        assert "secret_patterns" not in EXAMPLE_CONFIG
+        assert "NOT currently consumed" not in EXAMPLE_CONFIG
+        assert "Parsed but not consumed" not in EXAMPLE_CONFIG
 
     def test_example_config_loads_cleanly(self, tmp_path: Path):
         """The shipped EXAMPLE_CONFIG must parse without raising."""


### PR DESCRIPTION
Closes one of the 5 remaining findings from the #413 reliability audit (finding 27).

## Problem

The `[validation]` config section was parsed and type-validated, but **no command ever read it** — `check_encryption`, `strict_extra`, and `secret_patterns` had zero effect. `EXAMPLE_CONFIG` was relabeled "parsed but not consumed" in #425, but the dead surface remained.

## Change (per maintainer decision: wire up the useful two, drop the fuzzy one)

**`envdrift validate` now consumes `[validation]`:**
- **`check_encryption`** seeds the default for `--check-encryption/--no-check-encryption`. The flag is now tri-state (`None` = use config); passing it explicitly still overrides the config value.
- **`strict_extra`** drives the validator's `check_extra`: `false` skips the extra-variable check entirely; `true` (default) keeps today's behavior (reject extras under `extra="forbid"`).
- A **malformed `envdrift.toml`** now surfaces a clean `Failed to load envdrift config` error instead of a traceback.

**`secret_patterns` removed** from `ValidationConfig`, the parser, `EXAMPLE_CONFIG`, and docs. An old config still carrying the key loads fine (the now-unknown key is ignored). The validator keeps its own built-in `SECRET_PATTERNS` — that's unrelated and untouched.

## Tests

Real in-process CLI invocations (`tests/unit/test_cli.py::TestValidateConsumesValidationConfig`):
- `strict_extra` false → extra ignored (exit 0); true → extra rejected (exit 1)
- `check_encryption` config default honored; explicit `--check-encryption` overrides it
- no `envdrift.toml` → defaults (backward compatible)
- malformed config → clean error, no traceback

Touched files: `validate.py` 93%, `config.py` 90% line coverage. Docs (`configuration.md`) + `EXAMPLE_CONFIG` updated to describe the keys as consumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Wires the previously inert `[validation]` config section to `envdrift validate`: `check_encryption` now seeds the tri-state CLI default and `strict_extra` controls whether extra-variable checking runs, while the fuzzy `secret_patterns` field is dropped from the schema entirely.

- `validate.py` gains `_resolve_validation_settings`, a small helper that reads `find_config()` / `load_config()` and returns `(check_encryption, check_extra)`, catching all expected load errors (including the previously-missing `ConfigNotFoundError` TOCTOU race, already addressed in the previous review cycle).
- `config.py` removes `secret_patterns` from `ValidationConfig` and its parser; old configs carrying the key silently ignore it, confirmed by an updated test.
- Six focused in-process CLI tests cover every new path: strict-extra on/off, encryption flag overriding config, missing config (backward compat), malformed TOML, and the TOCTOU race.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are additive, backward compatible, and covered by six focused in-process tests.

The wiring is straightforward: a small helper reads find_config/load_config, handles every expected error class, and feeds two boolean values into the pre-existing validator. Old configs without [validation] get the same defaults as before, and the dropped secret_patterns key is silently ignored on load. The TOCTOU gap flagged in the previous review cycle is closed and regression-tested.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/envdrift/cli_commands/validate.py | Adds `_resolve_validation_settings` to wire the `[validation]` config into the command; tri-states `check_encryption` to `bool | None`; error handling is complete with all expected exceptions caught. |
| src/envdrift/config.py | Removes `secret_patterns` from `ValidationConfig` and its parser; dataclass and `from_dict` are consistent; stray keys in old configs are ignored, as tested. |
| tests/unit/test_cli.py | Adds `TestValidateConsumesValidationConfig` with six in-process CLI tests covering all new branches, including the TOCTOU race via `monkeypatch`. |
| tests/unit/test_config.py | Removes `secret_patterns` assertions; adds a forward-compatibility test that verifies old configs carrying `secret_patterns` still load without error and without surfacing the removed attribute. |
| tests/unit/test_config_deferred_validation.py | Updates `TestExampleConfig` assertions from 'not consumed' guards to 'consumed' guards; consistent with new behavior. |
| tests/benchmarks/test_benchmarks.py | Removes `secret_patterns` from `SAMPLE_CONFIG_DICT`; trivial housekeeping. |
| docs/reference/configuration.md | Updates the `[validation]` section to accurately describe `check_encryption` and `strict_extra` as consumed; removes the 'parsed but not consumed' disclaimer and the `secret_patterns` row. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CLI as envdrift validate
    participant RS as _resolve_validation_settings
    participant FC as find_config()
    participant LC as load_config(path)
    participant V as Validator.validate()

    CLI->>CLI: check schema + env file exist
    CLI->>RS: "check_encryption (bool | None)"
    RS->>FC: find_config()
    FC-->>RS: config_path (or None)
    alt config_path found
        RS->>LC: load_config(config_path)
        alt load OK
            LC-->>RS: EnvdriftConfig.validation
        else OSError / TOMLDecodeError / ValueError / ConfigNotFoundError
            RS-->>CLI: "print_error -> Exit(1)"
        end
    else no config file
        RS->>RS: use ValidationConfig() defaults
    end
    RS-->>CLI: (effective_check_encryption, check_extra)
    CLI->>V: validate(env, schema, check_encryption, check_extra)
    V-->>CLI: ValidationResult
```

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into feat/consume-va..."](https://github.com/jainal09/envdrift/commit/b08e92901c45b9d7ad23fe2e700fe38f071595c0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36296062)</sub>

<!-- /greptile_comment -->