### PR TITLE
fix(encrypt): gitignore the dotenvx .env.keys after encrypting

### DIFF
--- a/src/envdrift/cli_commands/encryption.py
+++ b/src/envdrift/cli_commands/encryption.py
@@ -25,6 +25,7 @@ from envdrift.output.rich import (
     print_success,
     print_warning,
 )
+from envdrift.utils.git import ensure_gitignore_entries
 from envdrift.vault.base import SecretNotFoundError, VaultError
 
 
@@ -55,6 +56,24 @@ def _resolve_config_path(config_path: Path | None, value: Path | str | None) -> 
     if config_path and not path.is_absolute():
         return (config_path.parent / path).resolve()
     return path
+
+
+def _protect_private_keys(env_file: Path) -> None:
+    """Ensure the dotenvx ``.env.keys`` private-key file is gitignored.
+
+    dotenvx writes the private decryption keys to ``.env.keys`` next to the
+    encrypted file; committing it would defeat the encryption entirely. Add it to
+    ``.gitignore`` if it exists and isn't already ignored (a no-op outside a git
+    repo, and for SOPS which writes no ``.env.keys``), and tell the user.
+    """
+    keys_file = env_file.parent / ".env.keys"
+    if not keys_file.exists():
+        return
+    added = ensure_gitignore_entries([keys_file])
+    if added:
+        print_warning(
+            f"Added {', '.join(added)} to .gitignore — never commit your private keys (.env.keys)."
+        )
 
 
 def encrypt_cmd(
@@ -286,6 +305,7 @@ def encrypt_cmd(
             result = encryption_backend.encrypt(env_file, **encrypt_kwargs)
             if result.success:
                 print_success(f"Encrypted {env_file} using {encryption_backend.name}")
+                _protect_private_keys(env_file)
             else:
                 print_error(result.message)
                 raise typer.Exit(code=1)

--- a/tests/integration/test_git_hooks_advanced.py
+++ b/tests/integration/test_git_hooks_advanced.py
@@ -646,10 +646,16 @@ def test_hook_blocks_env_keys_commit(git_hook_env):
     pre_commit = work_dir / ".git" / "hooks" / "pre-commit"
     assert pre_commit.exists()
 
-    # Stage .env.keys file
+    # Stage .env.keys file. `encrypt` now also adds .env.keys to .gitignore
+    # (defense in depth), so a plain `git add` is refused — force-add past the
+    # ignore to exercise the pre-commit hook itself.
     env_keys = work_dir / ".env.keys"
     assert env_keys.exists(), ".env.keys should be created by encryption"
-    _run_git(["add", env_keys.name], cwd=work_dir)
+    gitignore = work_dir / ".gitignore"
+    assert gitignore.exists() and ".env.keys" in gitignore.read_text(), (
+        "encrypt should gitignore .env.keys"
+    )
+    _run_git(["add", "-f", env_keys.name], cwd=work_dir)
 
     # Attempt to commit - should fail
     result = _run_git(

--- a/tests/unit/test_encrypt_key_protection.py
+++ b/tests/unit/test_encrypt_key_protection.py
@@ -1,0 +1,69 @@
+"""Regression tests: `envdrift encrypt` gitignores the dotenvx `.env.keys`.
+
+A new user who encrypts in a git repo must not be able to accidentally commit
+the private decryption keys (which would defeat the encryption). Surfaced by
+dogfooding the first-run flow.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+import envdrift.cli_commands.encryption as enc
+from envdrift.cli_commands.encryption import _protect_private_keys
+
+
+def _git_init(path: Path) -> None:
+    subprocess.run(["git", "init", "-q"], cwd=path, check=True)  # nosec B603, B607
+
+
+class TestProtectPrivateKeys:
+    """Tests for the .env.keys gitignore guard run after a successful encrypt."""
+
+    def test_gitignores_env_keys_and_warns(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _git_init(tmp_path)
+        (tmp_path / ".env.keys").write_text("DOTENV_PRIVATE_KEY_PRODUCTION=abc123\n")
+        monkeypatch.chdir(tmp_path)
+
+        warnings: list[str] = []
+        monkeypatch.setattr(enc, "print_warning", warnings.append)
+
+        _protect_private_keys(Path(".env"))
+
+        assert ".env.keys" in (tmp_path / ".gitignore").read_text()
+        assert any("never commit your private keys" in w for w in warnings)
+
+    def test_noop_when_no_env_keys(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """SOPS (and any flow without a .env.keys) leaves no .gitignore behind."""
+        _git_init(tmp_path)
+        monkeypatch.chdir(tmp_path)
+
+        warnings: list[str] = []
+        monkeypatch.setattr(enc, "print_warning", warnings.append)
+
+        _protect_private_keys(Path(".env"))
+
+        assert not (tmp_path / ".gitignore").exists()
+        assert warnings == []
+
+    def test_no_duplicate_or_warning_when_already_ignored(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _git_init(tmp_path)
+        (tmp_path / ".env.keys").write_text("DOTENV_PRIVATE_KEY=abc\n")
+        (tmp_path / ".gitignore").write_text(".env.keys\n")
+        monkeypatch.chdir(tmp_path)
+
+        warnings: list[str] = []
+        monkeypatch.setattr(enc, "print_warning", warnings.append)
+
+        _protect_private_keys(Path(".env"))
+
+        # Already protected -> no duplicate entry and no (noisy) warning.
+        assert (tmp_path / ".gitignore").read_text().count(".env.keys") == 1
+        assert warnings == []


### PR DESCRIPTION
Surfaced by **dogfooding the first-run flow** — a real safety gap, not a test-found bug.

## Problem

A brand-new user runs:
```
envdrift init
envdrift encrypt .env
```
`encrypt` creates `.env.keys` (the **private decryption keys**) next to the file, but **never adds it to `.gitignore` and prints no warning**. The natural next step — `git add . && git commit` — commits the private key, which **silently defeats the encryption** (anyone with the repo can decrypt).

## Fix

After a successful encrypt, ensure `.env.keys` is gitignored via the existing `ensure_gitignore_entries` helper, and warn when it's newly added:
```
[OK] Encrypted .env using dotenvx
[WARN] Added .env.keys to .gitignore — never commit your private keys (.env.keys).
```
- No-op outside a git repo, and for SOPS (which writes no `.env.keys`).
- Idempotent — no duplicate entry or repeat warning if already ignored.

## Tests

`tests/unit/test_encrypt_key_protection.py` (real git repo, real `ensure_gitignore_entries`): gitignores + warns when `.env.keys` is present; no-ops with no `.env.keys`; no duplicate/warning when already ignored. `encryption.py` stays at 96% coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a post-encryption guard that writes `.env.keys` to `.gitignore` after a successful dotenvx encrypt, preventing accidental commits of private decryption keys. The integration test is updated to force-stage the now-gitignored file, and a new unit test suite covers the three key scenarios.

- `_protect_private_keys` correctly detects `.env.keys`, calls `ensure_gitignore_entries`, and emits a warning only when the entry is newly added — making it idempotent and a no-op for SOPS.
- The smart-encryption early-return path (lines 301–303) exits before `_protect_private_keys` is called, so existing users who trigger a skip on re-encryption never receive the gitignore protection on that run.

<h3>Confidence Score: 4/5</h3>

Safe to merge with one fix — the gitignore guard is never applied when smart-encryption skips re-encryption, leaving .env.keys unprotected for existing users on subsequent runs.

The core _protect_private_keys logic is correct and the new unit/integration tests validate it well. However, the call is placed after the smart-encryption early return, so any user whose content hasn't changed since their last encrypt will hit the skip path and never have their .env.keys gitignored or warned about.

src/envdrift/cli_commands/encryption.py — specifically the ordering of _protect_private_keys relative to the should_skip early return at lines 301–303.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/envdrift/cli_commands/encryption.py | Adds _protect_private_keys helper that gitignores .env.keys after a successful dotenvx encrypt — correct logic, but the call is placed after the smart-encryption early return, so users who trigger that path never receive the protection. |
| tests/unit/test_encrypt_key_protection.py | New unit tests covering the three key scenarios for _protect_private_keys (keys present, keys absent, already ignored) — well-structured with a real git repo and monkeypatched warning capture; no issues. |
| tests/integration/test_git_hooks_advanced.py | Correctly updates test_hook_blocks_env_keys_commit to assert that encrypt now gitignores .env.keys and uses git add -f to force-stage the file past the ignore, preserving the pre-commit hook test. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[envdrift encrypt .env] --> B{Smart encryption\nenabled & no change?}
    B -- Yes --> C[print_success: Skipped re-encryption]
    C --> D[return ← _protect_private_keys\nNEVER called here]
    B -- No --> E[encryption_backend.encrypt]
    E --> F{result.success?}
    F -- No --> G[print_error + Exit 1]
    F -- Yes --> H[print_success: Encrypted]
    H --> I[_protect_private_keys]
    I --> J{.env.keys exists?}
    J -- No --> K[no-op / SOPS path]
    J -- Yes --> L[ensure_gitignore_entries]
    L --> M{Already ignored?}
    M -- Yes --> N[no-op, no warning]
    M -- No --> O[Append .env.keys to .gitignore\n+ print_warning]

    style D fill:#f88,color:#000
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `src/envdrift/cli_commands/encryption.py`, line 301-303 ([link](https://github.com/jainal09/envdrift/blob/c4f83b17203da786efdfb541fe6870a5403d46ab/src/envdrift/cli_commands/encryption.py#L301-L303)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`_protect_private_keys` skipped on smart-encryption no-op**

   When `should_skip_reencryption` returns `True`, the function returns early before `_protect_private_keys` is ever called. A user who upgrades to this version, but previously encrypted without the gitignore guard, could have an unprotected `.env.keys` file. The next `envdrift encrypt` with unchanged content would silently skip the protection step because smart-encryption fires before we ever reach line 308. Moving the `_protect_private_keys` call to fire unconditionally (after the `should_skip` early-return, or before it) would close this gap.

2. `src/envdrift/cli_commands/encryption.py`, line 301-305 ([link](https://github.com/jainal09/envdrift/blob/05bb88fc2a6ece0a0f4c32510a90ca062f3ff726/src/envdrift/cli_commands/encryption.py#L301-L305)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> The `should_skip` block returns early before `_protect_private_keys` is ever called. Moving the call to just before the early return ensures existing users whose encrypted content hasn't changed still get the gitignore guard applied on the next `encrypt` run.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["test(hooks): force-add .env.keys now tha..."](https://github.com/jainal09/envdrift/commit/05bb88fc2a6ece0a0f4c32510a90ca062f3ff726) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36332552)</sub>

<!-- /greptile_comment -->