### PR TITLE
fix(guard): make the findings table readable at narrow terminal widths

### DIFF
--- a/src/envdrift/scanner/output.py
+++ b/src/envdrift/scanner/output.py
@@ -106,13 +106,20 @@ def format_rich(result: AggregatedScanResult, console: Console | None = None) ->
         )
     )
 
-    # Findings table
+    # Findings table. On a narrow terminal drop the secondary Rule and Preview
+    # columns so the essential Sev / Location / Description stay on one readable
+    # line each — five columns can't fit under ~100 cols without Rich squeezing
+    # the severity column down to nothing. Text columns are no_wrap + ellipsis so
+    # a long value truncates with a "…" instead of word-wrapping into fragments.
+    wide = console.width >= 100
     table = Table(show_header=True, header_style="bold", expand=True)
     table.add_column("Sev", width=8, justify="center")
-    table.add_column("Location", style="cyan", no_wrap=True, max_width=40)
-    table.add_column("Rule", style="magenta", max_width=25)
-    table.add_column("Description", overflow="fold")
-    table.add_column("Preview", style="dim", max_width=20)
+    table.add_column("Location", style="cyan", no_wrap=True, max_width=40, overflow="ellipsis")
+    if wide:
+        table.add_column("Rule", style="magenta", no_wrap=True, max_width=20, overflow="ellipsis")
+    table.add_column("Description", ratio=1, no_wrap=True, overflow="ellipsis")
+    if wide:
+        table.add_column("Preview", style="dim", no_wrap=True, max_width=14, overflow="ellipsis")
 
     for finding in sorted(result.unique_findings, key=lambda f: f.severity, reverse=True):
         severity_icon = SEVERITY_ICONS[finding.severity]
@@ -120,13 +127,13 @@ def format_rich(result: AggregatedScanResult, console: Console | None = None) ->
         severity_text = Text(f"[{severity_icon}] {finding.severity.value[:4].upper()}")
         severity_text.stylize(severity_color)
 
-        table.add_row(
-            severity_text,
-            finding.location,
-            finding.rule_id,
-            finding.description,
-            finding.secret_preview or "-",
-        )
+        row: list[str | Text] = [severity_text, finding.location]
+        if wide:
+            row.append(finding.rule_id)
+        row.append(finding.description)
+        if wide:
+            row.append(finding.secret_preview or "-")
+        table.add_row(*row)
 
     console.print(table)
 

--- a/src/envdrift/scanner/output.py
+++ b/src/envdrift/scanner/output.py
@@ -44,6 +44,46 @@ SEVERITY_ICONS: dict[FindingSeverity, str] = {
     FindingSeverity.INFO: ".",
 }
 
+# At or above this terminal width the findings table shows all five columns;
+# below it the secondary Rule/Preview columns are dropped so the essential
+# Sev/Location/Description stay on one readable line each.
+_WIDE_TERMINAL_WIDTH = 100
+
+
+def _build_findings_table(result: AggregatedScanResult, *, wide: bool) -> Table:
+    """Build the findings table, dropping secondary columns on a narrow terminal.
+
+    Five columns can't fit under ~100 cols without Rich squeezing the severity
+    column to nothing, so on a narrow terminal only Sev/Location/Description are
+    shown. Text columns are no_wrap + ellipsis (truncate with "…" on one line
+    instead of word-wrapping into fragments); Description is the flexible
+    (ratio=1) column so it absorbs the leftover width without starving Sev.
+    """
+    table = Table(show_header=True, header_style="bold", expand=True)
+    table.add_column("Sev", width=8, justify="center")
+    table.add_column("Location", style="cyan", no_wrap=True, max_width=40, overflow="ellipsis")
+    if wide:
+        table.add_column("Rule", style="magenta", no_wrap=True, max_width=20, overflow="ellipsis")
+    table.add_column("Description", ratio=1, no_wrap=True, overflow="ellipsis")
+    if wide:
+        table.add_column("Preview", style="dim", no_wrap=True, max_width=14, overflow="ellipsis")
+
+    for finding in sorted(result.unique_findings, key=lambda f: f.severity, reverse=True):
+        severity_text = Text(
+            f"[{SEVERITY_ICONS[finding.severity]}] {finding.severity.value[:4].upper()}"
+        )
+        severity_text.stylize(SEVERITY_COLORS[finding.severity])
+
+        row: list[str | Text] = [severity_text, finding.location]
+        if wide:
+            row.append(finding.rule_id)
+        row.append(finding.description)
+        if wide:
+            row.append(finding.secret_preview or "-")
+        table.add_row(*row)
+
+    return table
+
 
 def format_rich(result: AggregatedScanResult, console: Console | None = None) -> None:
     """Format and print results using Rich for terminal output.
@@ -106,36 +146,8 @@ def format_rich(result: AggregatedScanResult, console: Console | None = None) ->
         )
     )
 
-    # Findings table. On a narrow terminal drop the secondary Rule and Preview
-    # columns so the essential Sev / Location / Description stay on one readable
-    # line each — five columns can't fit under ~100 cols without Rich squeezing
-    # the severity column down to nothing. Text columns are no_wrap + ellipsis so
-    # a long value truncates with a "…" instead of word-wrapping into fragments.
-    wide = console.width >= 100
-    table = Table(show_header=True, header_style="bold", expand=True)
-    table.add_column("Sev", width=8, justify="center")
-    table.add_column("Location", style="cyan", no_wrap=True, max_width=40, overflow="ellipsis")
-    if wide:
-        table.add_column("Rule", style="magenta", no_wrap=True, max_width=20, overflow="ellipsis")
-    table.add_column("Description", ratio=1, no_wrap=True, overflow="ellipsis")
-    if wide:
-        table.add_column("Preview", style="dim", no_wrap=True, max_width=14, overflow="ellipsis")
-
-    for finding in sorted(result.unique_findings, key=lambda f: f.severity, reverse=True):
-        severity_icon = SEVERITY_ICONS[finding.severity]
-        severity_color = SEVERITY_COLORS[finding.severity]
-        severity_text = Text(f"[{severity_icon}] {finding.severity.value[:4].upper()}")
-        severity_text.stylize(severity_color)
-
-        row: list[str | Text] = [severity_text, finding.location]
-        if wide:
-            row.append(finding.rule_id)
-        row.append(finding.description)
-        if wide:
-            row.append(finding.secret_preview or "-")
-        table.add_row(*row)
-
-    console.print(table)
+    # Findings table (see _build_findings_table for narrow-terminal handling).
+    console.print(_build_findings_table(result, wide=console.width >= _WIDE_TERMINAL_WIDTH))
 
     # Scan info
     _print_scan_info(result, console)

--- a/src/envdrift/scanner/output.py
+++ b/src/envdrift/scanner/output.py
@@ -58,10 +58,13 @@ def _severity_cell(finding: ScanFinding) -> Text:
 
 
 def _build_full_findings_table(findings: list[ScanFinding]) -> Table:
-    """Full, untruncated findings table for non-interactive output (CI/logs).
+    """Findings table for non-interactive output (``guard --ci``, piped, hooks).
 
-    Every column with untruncated values, so CI logs and pre-commit hook errors
-    keep the rule id, full location, and preview for triage.
+    Keeps all five columns so the rule id and preview are never *dropped* from CI
+    logs (the regression this guards against). Individual values may still
+    ellipsize or fold at a narrow CI width — use ``--format json`` for the
+    complete values. This is the pre-PR layout, kept verbatim so hook/CI output
+    stays stable.
     """
     table = Table(show_header=True, header_style="bold", expand=True)
     table.add_column("Sev", width=8, justify="center")
@@ -173,8 +176,9 @@ def format_rich(result: AggregatedScanResult, console: Console | None = None) ->
     )
 
     # Findings table. A non-interactive console (`guard --ci`, piped, redirected)
-    # gets the full untruncated table; an interactive terminal gets the compact,
-    # width-aware one (dropping secondary columns only when genuinely narrow).
+    # keeps all columns (so CI logs retain the rule id + preview); an interactive
+    # terminal gets the compact, width-aware one (dropping the secondary columns
+    # only when genuinely narrow).
     console.print(
         _build_findings_table(
             result,

--- a/src/envdrift/scanner/output.py
+++ b/src/envdrift/scanner/output.py
@@ -146,8 +146,12 @@ def format_rich(result: AggregatedScanResult, console: Console | None = None) ->
         )
     )
 
-    # Findings table (see _build_findings_table for narrow-terminal handling).
-    console.print(_build_findings_table(result, wide=console.width >= _WIDE_TERMINAL_WIDTH))
+    # Findings table. Only an interactive, genuinely narrow terminal drops the
+    # secondary columns (for readability) — a non-interactive console (`guard
+    # --ci`, piped, or redirected) reports width 80 but must keep all columns so
+    # CI logs retain the rule id and redacted preview for triage.
+    wide = (not console.is_terminal) or console.width >= _WIDE_TERMINAL_WIDTH
+    console.print(_build_findings_table(result, wide=wide))
 
     # Scan info
     _print_scan_info(result, console)

--- a/src/envdrift/scanner/output.py
+++ b/src/envdrift/scanner/output.py
@@ -50,17 +50,41 @@ SEVERITY_ICONS: dict[FindingSeverity, str] = {
 _WIDE_TERMINAL_WIDTH = 100
 
 
-def _build_findings_table(result: AggregatedScanResult, *, wide: bool) -> Table:
-    """Build the findings table, dropping secondary columns on a narrow terminal.
+def _severity_cell(finding: ScanFinding) -> Text:
+    """Render the styled severity cell, e.g. a red ``[X] CRIT``."""
+    cell = Text(f"[{SEVERITY_ICONS[finding.severity]}] {finding.severity.value[:4].upper()}")
+    cell.stylize(SEVERITY_COLORS[finding.severity])
+    return cell
 
-    Five columns can't fit under ~100 cols without Rich squeezing the severity
-    column to nothing, so on a narrow terminal only Sev/Location/Description are
-    shown. Text columns are no_wrap + ellipsis (truncate with "…" on one line
-    instead of word-wrapping into fragments); Description is the flexible
-    (ratio=1) column so it absorbs the leftover width without starving Sev.
+
+def _build_findings_table(result: AggregatedScanResult, *, interactive: bool, wide: bool) -> Table:
+    """Build the findings table.
+
+    Non-interactive output (``guard --ci``, piped, or redirected) gets the full
+    table — every column, untruncated values — so CI logs keep the rule id, full
+    location, and preview for triage. An interactive terminal gets a compact,
+    width-aware table: text columns are no_wrap + ellipsis (truncate with "…" on
+    one line instead of word-wrapping into fragments), Description is the flexible
+    (ratio=1) column so it absorbs the leftover width without starving the fixed
+    Sev column, and below ~100 cols the secondary Rule/Preview columns drop.
     """
+    findings = sorted(result.unique_findings, key=lambda f: f.severity, reverse=True)
     table = Table(show_header=True, header_style="bold", expand=True)
     table.add_column("Sev", width=8, justify="center")
+
+    if not interactive:
+        # Full, untruncated table for logs/CI.
+        table.add_column("Location", style="cyan", no_wrap=True, max_width=40)
+        table.add_column("Rule", style="magenta", max_width=25)
+        table.add_column("Description", overflow="fold")
+        table.add_column("Preview", style="dim", max_width=20)
+        for f in findings:
+            table.add_row(
+                _severity_cell(f), f.location, f.rule_id, f.description, f.secret_preview or "-"
+            )
+        return table
+
+    # Compact, readable table for an interactive terminal.
     table.add_column("Location", style="cyan", no_wrap=True, max_width=40, overflow="ellipsis")
     if wide:
         table.add_column("Rule", style="magenta", no_wrap=True, max_width=20, overflow="ellipsis")
@@ -68,18 +92,13 @@ def _build_findings_table(result: AggregatedScanResult, *, wide: bool) -> Table:
     if wide:
         table.add_column("Preview", style="dim", no_wrap=True, max_width=14, overflow="ellipsis")
 
-    for finding in sorted(result.unique_findings, key=lambda f: f.severity, reverse=True):
-        severity_text = Text(
-            f"[{SEVERITY_ICONS[finding.severity]}] {finding.severity.value[:4].upper()}"
-        )
-        severity_text.stylize(SEVERITY_COLORS[finding.severity])
-
-        row: list[str | Text] = [severity_text, finding.location]
+    for f in findings:
+        row: list[str | Text] = [_severity_cell(f), f.location]
         if wide:
-            row.append(finding.rule_id)
-        row.append(finding.description)
+            row.append(f.rule_id)
+        row.append(f.description)
         if wide:
-            row.append(finding.secret_preview or "-")
+            row.append(f.secret_preview or "-")
         table.add_row(*row)
 
     return table
@@ -146,12 +165,16 @@ def format_rich(result: AggregatedScanResult, console: Console | None = None) ->
         )
     )
 
-    # Findings table. Only an interactive, genuinely narrow terminal drops the
-    # secondary columns (for readability) — a non-interactive console (`guard
-    # --ci`, piped, or redirected) reports width 80 but must keep all columns so
-    # CI logs retain the rule id and redacted preview for triage.
-    wide = (not console.is_terminal) or console.width >= _WIDE_TERMINAL_WIDTH
-    console.print(_build_findings_table(result, wide=wide))
+    # Findings table. A non-interactive console (`guard --ci`, piped, redirected)
+    # gets the full untruncated table; an interactive terminal gets the compact,
+    # width-aware one (dropping secondary columns only when genuinely narrow).
+    console.print(
+        _build_findings_table(
+            result,
+            interactive=console.is_terminal,
+            wide=console.width >= _WIDE_TERMINAL_WIDTH,
+        )
+    )
 
     # Scan info
     _print_scan_info(result, console)

--- a/src/envdrift/scanner/output.py
+++ b/src/envdrift/scanner/output.py
@@ -57,41 +57,41 @@ def _severity_cell(finding: ScanFinding) -> Text:
     return cell
 
 
-def _build_findings_table(result: AggregatedScanResult, *, interactive: bool, wide: bool) -> Table:
-    """Build the findings table.
+def _build_full_findings_table(findings: list[ScanFinding]) -> Table:
+    """Full, untruncated findings table for non-interactive output (CI/logs).
 
-    Non-interactive output (``guard --ci``, piped, or redirected) gets the full
-    table — every column, untruncated values — so CI logs keep the rule id, full
-    location, and preview for triage. An interactive terminal gets a compact,
-    width-aware table: text columns are no_wrap + ellipsis (truncate with "…" on
-    one line instead of word-wrapping into fragments), Description is the flexible
-    (ratio=1) column so it absorbs the leftover width without starving the fixed
-    Sev column, and below ~100 cols the secondary Rule/Preview columns drop.
+    Every column with untruncated values, so CI logs and pre-commit hook errors
+    keep the rule id, full location, and preview for triage.
     """
-    findings = sorted(result.unique_findings, key=lambda f: f.severity, reverse=True)
     table = Table(show_header=True, header_style="bold", expand=True)
     table.add_column("Sev", width=8, justify="center")
+    table.add_column("Location", style="cyan", no_wrap=True, max_width=40)
+    table.add_column("Rule", style="magenta", max_width=25)
+    table.add_column("Description", overflow="fold")
+    table.add_column("Preview", style="dim", max_width=20)
+    for f in findings:
+        table.add_row(
+            _severity_cell(f), f.location, f.rule_id, f.description, f.secret_preview or "-"
+        )
+    return table
 
-    if not interactive:
-        # Full, untruncated table for logs/CI.
-        table.add_column("Location", style="cyan", no_wrap=True, max_width=40)
-        table.add_column("Rule", style="magenta", max_width=25)
-        table.add_column("Description", overflow="fold")
-        table.add_column("Preview", style="dim", max_width=20)
-        for f in findings:
-            table.add_row(
-                _severity_cell(f), f.location, f.rule_id, f.description, f.secret_preview or "-"
-            )
-        return table
 
-    # Compact, readable table for an interactive terminal.
+def _build_compact_findings_table(findings: list[ScanFinding], *, wide: bool) -> Table:
+    """Compact, width-aware findings table for an interactive terminal.
+
+    Text columns are no_wrap + ellipsis (truncate with "…" on one line instead of
+    word-wrapping into fragments), Description is the flexible (ratio=1) column so
+    it absorbs the leftover width without starving the fixed Sev column, and below
+    ~100 cols the secondary Rule/Preview columns drop.
+    """
+    table = Table(show_header=True, header_style="bold", expand=True)
+    table.add_column("Sev", width=8, justify="center")
     table.add_column("Location", style="cyan", no_wrap=True, max_width=40, overflow="ellipsis")
     if wide:
         table.add_column("Rule", style="magenta", no_wrap=True, max_width=20, overflow="ellipsis")
     table.add_column("Description", ratio=1, no_wrap=True, overflow="ellipsis")
     if wide:
         table.add_column("Preview", style="dim", no_wrap=True, max_width=14, overflow="ellipsis")
-
     for f in findings:
         row: list[str | Text] = [_severity_cell(f), f.location]
         if wide:
@@ -100,8 +100,15 @@ def _build_findings_table(result: AggregatedScanResult, *, interactive: bool, wi
         if wide:
             row.append(f.secret_preview or "-")
         table.add_row(*row)
-
     return table
+
+
+def _build_findings_table(result: AggregatedScanResult, *, interactive: bool, wide: bool) -> Table:
+    """Dispatch to the full (non-interactive) or compact (interactive) table."""
+    findings = sorted(result.unique_findings, key=lambda f: f.severity, reverse=True)
+    if not interactive:
+        return _build_full_findings_table(findings)
+    return _build_compact_findings_table(findings, wide=wide)
 
 
 def format_rich(result: AggregatedScanResult, console: Console | None = None) -> None:

--- a/tests/scanner/test_output.py
+++ b/tests/scanner/test_output.py
@@ -388,6 +388,49 @@ class TestRichOutput:
         assert "Findings Summary" in output
         assert "Remediation" in output
 
+    def _aws_finding_result(self) -> AggregatedScanResult:
+        findings = [
+            ScanFinding(
+                file_path=Path(".env"),
+                rule_id="aws-access-key-id",
+                rule_description="AWS key",
+                description="AWS key found",
+                severity=FindingSeverity.CRITICAL,
+                scanner="native",
+                secret_preview="AKIA1234",
+            )
+        ]
+        return AggregatedScanResult(
+            results=[ScanResult(scanner_name="native", findings=findings)],
+            total_findings=1,
+            unique_findings=findings,
+            scanners_used=["native"],
+            total_duration_ms=1,
+        )
+
+    def test_format_rich_narrow_terminal_keeps_severity_drops_secondary(self):
+        """Narrow terminal: keep Sev/Location/Description on one line each and drop
+        the Rule/Preview columns, so the severity column isn't squeezed to nothing.
+        """
+        console = Console(record=True, force_terminal=True, width=80)
+        format_rich(self._aws_finding_result(), console)
+        out = console.export_text()
+
+        assert "CRIT" in out  # severity column rendered (not collapsed to width 0)
+        assert "AWS key found" in out  # description present on one line
+        assert "aws-access-key-id" not in out  # Rule column dropped at narrow width
+        assert "AKIA1234" not in out  # Preview column dropped at narrow width
+
+    def test_format_rich_wide_terminal_shows_all_columns(self):
+        """Wide terminal shows the Rule and Preview columns too."""
+        console = Console(record=True, force_terminal=True, width=140)
+        format_rich(self._aws_finding_result(), console)
+        out = console.export_text()
+
+        assert "CRIT" in out
+        assert "aws-access-key-id" in out  # Rule column present
+        assert "AKIA1234" in out  # Preview column present
+
     def test_format_rich_shows_scanner_errors(self):
         """Scanner errors render a dedicated panel."""
         result = AggregatedScanResult(

--- a/tests/scanner/test_output.py
+++ b/tests/scanner/test_output.py
@@ -388,7 +388,8 @@ class TestRichOutput:
         assert "Findings Summary" in output
         assert "Remediation" in output
 
-    def _aws_finding_result(self) -> AggregatedScanResult:
+    @staticmethod
+    def _aws_finding_result() -> AggregatedScanResult:
         findings = [
             ScanFinding(
                 file_path=Path(".env"),
@@ -430,6 +431,27 @@ class TestRichOutput:
         assert "CRIT" in out
         assert "aws-access-key-id" in out  # Rule column present
         assert "AKIA1234" in out  # Preview column present
+
+    def test_build_findings_table_column_count(self):
+        """Narrow drops to 3 columns (Sev/Location/Description); wide keeps all 5."""
+        from envdrift.scanner.output import _build_findings_table
+
+        narrow = _build_findings_table(self._aws_finding_result(), wide=False)
+        wide = _build_findings_table(self._aws_finding_result(), wide=True)
+        assert len(narrow.columns) == 3
+        assert len(wide.columns) == 5
+
+    def test_format_rich_threshold_99_is_narrow(self):
+        """Width 99 (one below the threshold) drops the secondary Preview column."""
+        console = Console(record=True, force_terminal=True, width=99)
+        format_rich(self._aws_finding_result(), console)
+        assert "AKIA1234" not in console.export_text()
+
+    def test_format_rich_threshold_100_is_wide(self):
+        """Width 100 (exactly the threshold) shows the secondary Preview column."""
+        console = Console(record=True, force_terminal=True, width=100)
+        format_rich(self._aws_finding_result(), console)
+        assert "AKIA1234" in console.export_text()
 
     def test_format_rich_shows_scanner_errors(self):
         """Scanner errors render a dedicated panel."""

--- a/tests/scanner/test_output.py
+++ b/tests/scanner/test_output.py
@@ -456,13 +456,17 @@ class TestRichOutput:
         assert "AKIA1234" in out  # Preview column present
 
     def test_build_findings_table_column_count(self):
-        """Narrow drops to 3 columns (Sev/Location/Description); wide keeps all 5."""
+        """Interactive narrow drops to 3 columns; interactive wide keeps 5;
+        non-interactive (CI/logs) always keeps all 5 regardless of width."""
         from envdrift.scanner.output import _build_findings_table
 
-        narrow = _build_findings_table(self._aws_finding_result(), wide=False)
-        wide = _build_findings_table(self._aws_finding_result(), wide=True)
+        r = self._aws_finding_result()
+        narrow = _build_findings_table(r, interactive=True, wide=False)
+        wide = _build_findings_table(r, interactive=True, wide=True)
+        ci = _build_findings_table(r, interactive=False, wide=False)
         assert len(narrow.columns) == 3
         assert len(wide.columns) == 5
+        assert len(ci.columns) == 5  # non-interactive keeps all columns even when narrow
 
     def test_format_rich_threshold_99_is_narrow(self):
         """Width 99 (one below the threshold) drops the secondary Preview column."""

--- a/tests/scanner/test_output.py
+++ b/tests/scanner/test_output.py
@@ -388,14 +388,22 @@ class TestRichOutput:
         assert "Findings Summary" in output
         assert "Remediation" in output
 
-    @staticmethod
-    def _aws_finding_result() -> AggregatedScanResult:
+    # A long, realistic description: a revert to overflow="fold" would wrap its
+    # tail onto extra lines (the regression this PR fixes), so the truncation
+    # assertion below would catch it.
+    _LONG_DESCRIPTION = (
+        "Potential AWS Access Key ID detected; rotate this credential immediately "
+        "and remove it from version control history"
+    )
+
+    @classmethod
+    def _aws_finding_result(cls) -> AggregatedScanResult:
         findings = [
             ScanFinding(
                 file_path=Path(".env"),
                 rule_id="aws-access-key-id",
                 rule_description="AWS key",
-                description="AWS key found",
+                description=cls._LONG_DESCRIPTION,
                 severity=FindingSeverity.CRITICAL,
                 scanner="native",
                 secret_preview="AKIA1234",
@@ -410,17 +418,32 @@ class TestRichOutput:
         )
 
     def test_format_rich_narrow_terminal_keeps_severity_drops_secondary(self):
-        """Narrow terminal: keep Sev/Location/Description on one line each and drop
-        the Rule/Preview columns, so the severity column isn't squeezed to nothing.
+        """Interactive narrow terminal: keep Sev/Location/Description (one line
+        each, ellipsized) and drop the Rule/Preview columns.
         """
         console = Console(record=True, force_terminal=True, width=80)
         format_rich(self._aws_finding_result(), console)
         out = console.export_text()
 
         assert "CRIT" in out  # severity column rendered (not collapsed to width 0)
-        assert "AWS key found" in out  # description present on one line
+        # Description on ONE line, ellipsized — its head shows, the tail is
+        # truncated away (a fold-revert would wrap the tail onto a second line).
+        assert "Potential AWS Access Key ID detected" in out
+        assert "…" in out
+        assert "version control history" not in out
         assert "aws-access-key-id" not in out  # Rule column dropped at narrow width
         assert "AKIA1234" not in out  # Preview column dropped at narrow width
+
+    def test_format_rich_non_interactive_keeps_all_columns(self):
+        """A non-interactive console (`guard --ci`, piped) keeps all five columns
+        even at the default width 80, so CI logs retain rule_id and the preview.
+        """
+        console = Console(record=True, force_terminal=False, no_color=True, width=80)
+        format_rich(self._aws_finding_result(), console)
+        out = console.export_text()
+
+        assert "aws-access-key-id" in out  # Rule kept for CI triage
+        assert "AKIA1234" in out  # Preview kept
 
     def test_format_rich_wide_terminal_shows_all_columns(self):
         """Wide terminal shows the Rule and Preview columns too."""


### PR DESCRIPTION
Final dogfood finding (#3) — the `guard` results table was unreadable at default/80-col terminal widths.

## Before (80 cols)

The Description column folded character-by-character and the Sev column got squeezed away:
```
┃   ┃ Location  ┃ Rule    ┃ Descript ┃ Preview ┃
│   │ /tmp/.e…  │ aws-ac… │ Potential│ AKIA**… │
│   │           │         │ AWS Acce │         │
│   │           │         │ ss Key   │         │
│   │           │         │ ID       │         │
```

## After

**80 cols** — one clean line per finding; Sev kept; Rule/Preview dropped:
```
┃   Sev    ┃ Location                  ┃ Description                           ┃
│ [X] CRIT │ /tmp/gt/.env:3:4          │ Potential AWS Access Key ID detected  │
│ [!] HIGH │ /tmp/gt/.env:2:14         │ Potential PostgreSQL Connection Stri… │
```
**140 cols** — all five columns:
```
┃   Sev    ┃ Location          ┃ Rule              ┃ Description                  ┃ Preview        ┃
│ [X] CRIT │ /tmp/gt/.env:3:4  │ aws-access-key-id │ Potential AWS Access Key ID… │ AKIA*********…  │
```

## How

- Text columns are `no_wrap` + `overflow="ellipsis"` → long values truncate with `…` on one line instead of folding into vertical fragments.
- **Description is the flexible (`ratio=1`) column** so it absorbs the leftover width and ellipsizes — *without* starving the fixed-width Sev column (the subtle bug: a `no_wrap` non-ratio column under `expand=True` makes Rich collapse the severity column to zero).
- Below ~100 cols, drop the secondary `Rule`/`Preview` columns; keep the essential Sev / Location / Description.

## Tests

`tests/scanner/test_output.py`: the severity column survives and Rule/Preview are dropped at width 80, and all columns appear at width 140.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the `guard` findings table being unreadable at narrow (80-col) terminals by making Description the flexible `ratio=1` column with `no_wrap + overflow="ellipsis"`, and dropping the secondary Rule/Preview columns below `_WIDE_TERMINAL_WIDTH = 100`.

- Non-interactive consoles (`--ci`, piped) continue to use the pre-PR five-column layout verbatim, so CI logs remain stable.
- Interactive terminals get a compact, width-aware table: three columns at narrow widths and five at wide widths.
- Tests pin the exact boundary (99 = narrow, 100 = wide) and verify column counts and ellipsis truncation directly.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is purely presentational, touches only the Rich table layout, and the non-interactive CI path is preserved verbatim.

The non-interactive code path retains the original five-column table unchanged, so CI/hook consumers are unaffected. The interactive path is well-exercised by boundary tests at widths 79, 80, 99, 100, and 140, plus a direct column-count unit test. No data is mutated and no control-flow outside the table renderer is touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/envdrift/scanner/output.py | Extracts severity-cell rendering and table construction into helper functions; introduces `_WIDE_TERMINAL_WIDTH`, `_build_full_findings_table` (CI), and `_build_compact_findings_table` (interactive). Logic is correct and symmetric. |
| tests/scanner/test_output.py | Adds six targeted tests: narrow/wide/non-interactive rendering, column-count unit test, and exact threshold boundary tests at width 99 and 100. Coverage is thorough for the changed behaviour. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["format_rich(result, console)"] --> B{console.is_terminal?}
    B -- No --> C["_build_full_findings_table(findings)\n5 columns, overflow=fold\n(pre-PR CI layout)"]
    B -- Yes --> D{console.width >= 100?}
    D -- No narrow --> E["_build_compact_findings_table(findings, wide=False)\n3 cols: Sev / Location / Description\nno_wrap + overflow=ellipsis"]
    D -- Yes wide --> F["_build_compact_findings_table(findings, wide=True)\n5 cols: Sev / Location / Rule / Description / Preview\nno_wrap + overflow=ellipsis"]
    C --> G["console.print(table)"]
    E --> G
    F --> G
```

<sub>Reviews (6): Last reviewed commit: ["docs(guard): correct non-interactive tab..."](https://github.com/jainal09/envdrift/commit/e57618d45d6d60ec566e0d7b69f5eb6b2e59ebde) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36347597)</sub>

<!-- /greptile_comment -->