### PR TITLE
fix(push): valid TOML enable-hint and quiet git noise outside a repo

### DIFF
--- a/src/envdrift/cli_commands/partial.py
+++ b/src/envdrift/cli_commands/partial.py
@@ -102,12 +102,19 @@ def push(
     if not config.partial_encryption.enabled:
         print_error("Partial encryption is not enabled in configuration")
         console.print("\nTo enable partial encryption, add to your envdrift.toml:")
+        # markup=False so the literal `[[partial_encryption.environments]]` TOML
+        # header isn't parsed as Rich markup and collapsed to `[]` — a new user
+        # copying the example would otherwise get invalid TOML.
         console.print(
-            "[cyan][[partial_encryption.environments]][/cyan]\n"
-            '[cyan]name = "production"[/cyan]\n'
-            '[cyan]clear_file = ".env.production.clear"[/cyan]\n'
-            '[cyan]secret_file = ".env.production.secret"[/cyan]\n'
-            '[cyan]combined_file = ".env.production"[/cyan]'
+            "[partial_encryption]\n"
+            "enabled = true\n\n"
+            "[[partial_encryption.environments]]\n"
+            'name = "production"\n'
+            'clear_file = ".env.production.clear"\n'
+            'secret_file = ".env.production.secret"\n'
+            'combined_file = ".env.production"',
+            style="cyan",
+            markup=False,
         )
         raise typer.Exit(code=1)
 

--- a/src/envdrift/core/partial_encryption.py
+++ b/src/envdrift/core/partial_encryption.py
@@ -424,12 +424,19 @@ def _run_git_update_index(flag: str, path: Path) -> bool:
         stderr = result.stderr
         if isinstance(stderr, (bytes, bytearray)):
             stderr = stderr.decode(errors="replace")
+        message = (stderr or "").strip()
+        # Running outside a git repo isn't an error worth surfacing — skip-worktree
+        # is simply not applicable there, so log it at debug like git-unavailable
+        # (otherwise `push`/`pull` in a non-repo dir print scary git noise).
+        if "not a git repository" in message.lower():
+            logger.debug("git update-index %s skipped (not a git repo): %s", flag, path)
+            return False
         logger.warning(
             "git update-index %s failed for %s (exit %s): %s",
             flag,
             path,
             result.returncode,
-            (stderr or "").strip(),
+            message,
         )
         return False
     return True

--- a/tests/unit/test_partial_cli.py
+++ b/tests/unit/test_partial_cli.py
@@ -193,6 +193,11 @@ def test_push_fails_when_partial_encryption_disabled(monkeypatch):
     result = runner.invoke(app, ["push"])
     assert result.exit_code == 1
     assert "not enabled" in result.output.lower()
+    # The enable hint must be valid, copy-pasteable TOML — the `[[...]]` array
+    # header must render literally, not get eaten by Rich markup into "[]".
+    assert "[[partial_encryption.environments]]" in result.output
+    assert "[partial_encryption]" in result.output
+    assert "\n[]\n" not in result.output
 
 
 def test_pull_fails_when_partial_encryption_disabled(monkeypatch):

--- a/tests/unit/test_partial_encryption.py
+++ b/tests/unit/test_partial_encryption.py
@@ -1182,6 +1182,31 @@ def test_git_skip_worktree_returns_false_on_nonzero(tmp_path: Path, caplog):
     assert "not in the index" in caplog.text
 
 
+def test_git_skip_worktree_quiet_outside_repo(tmp_path: Path, caplog):
+    """Outside a git repo, _git_skip_worktree returns False but stays quiet
+    (debug, not warning) so push/pull in a non-repo dir don't print git noise."""
+    import logging
+    from subprocess import CompletedProcess
+
+    from envdrift.core.partial_encryption import _git_skip_worktree
+
+    with (
+        patch(
+            "envdrift.core.partial_encryption.subprocess.run",
+            return_value=CompletedProcess(
+                args=[],
+                returncode=128,
+                stdout=b"",
+                stderr=b"fatal: not a git repository (or any of the parent directories): .git",
+            ),
+        ),
+        caplog.at_level(logging.WARNING),
+    ):
+        assert _git_skip_worktree(tmp_path / ".env.secret") is False
+    # The not-a-repo case must not emit a WARNING.
+    assert "update-index" not in caplog.text
+
+
 def test_git_unskip_worktree_returns_false_on_git_missing(tmp_path: Path):
     """_git_unskip_worktree returns False (not raising) when git is unavailable."""
     from envdrift.core.partial_encryption import _git_unskip_worktree


### PR DESCRIPTION
Two more first-run rough edges from **dogfooding the partial-encryption `push` flow**.

## #1 — the enable-hint printed invalid TOML

`push` with no config told the user to add this — but rendered it through Rich markup, which ate the `[[…]]` array header:
```
To enable partial encryption, add to your envdrift.toml:
[]                                    ← was [[partial_encryption.environments]]
name = "production"
...
```
A user copying it gets invalid TOML. **Fixed** by printing the example with `markup=False` (same class of bug as the `\[guardian]` escape in #418) and including the `[partial_encryption]` / `enabled = true` header so it's a complete, copy-pasteable block:
```
[partial_encryption]
enabled = true

[[partial_encryption.environments]]
name = "production"
clear_file = ".env.production.clear"
...
```

## #2 — scary git noise outside a repo

`push`/`pull-partial` in a non-git directory printed:
```
git update-index --no-skip-worktree failed for .env.prod.secret (exit 128): fatal: not a git repository
  ✓ Generated .env.prod (2 clear + 1 encrypted)
```
The operation **succeeded** — skip-worktree is just N/A outside a repo. **Fixed** by logging the not-a-repo case at `debug` instead of `warning`.

## Tests

- The enable hint contains the literal `[[partial_encryption.environments]]` (not `[]`).
- `_git_skip_worktree` stays quiet (no WARNING) on a "not a git repository" error and still returns False; a genuine failure still warns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed display of TOML configuration snippets in CLI output — bracketed sections now render correctly without formatting interference.
  * Improved git operation error handling — gracefully handles operations outside repositories without unnecessary warning messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two first-run UX rough edges in the partial encryption commands: Rich markup eating the `[[partial_encryption.environments]]` TOML array header in the enable-hint, and noisy git warnings when running outside a repository.

- **TOML hint fix (`partial.py`)**: Replaces per-span `[cyan]…[/cyan]` markup with `style=\"cyan\"` + `markup=False`, so the `[[…]]` header is printed literally and the full `[partial_encryption] / enabled = true` preamble is included for a complete, copy-pasteable block.
- **Git noise fix (`partial_encryption.py`)**: In `_run_git_update_index`, stderr messages containing `\"not a git repository\"` now route to `logger.debug` instead of `logger.warning`, matching the treatment of git being entirely unavailable.
- **Tests**: New assertions verify the hint output is valid TOML, and a new test confirms the not-a-repo path emits no WARNING-level log.

<h3>Confidence Score: 5/5</h3>

Both changes are narrow, well-tested bug fixes with no behavioural regressions — safe to merge.

The TOML-hint change is a mechanical swap from Rich markup tags to markup=False with an equivalent style= parameter, verified by new output-content assertions. The git-noise change adds a single string check before the existing warning path and is covered by a new caplog test. No logic paths were removed or restructured.

The docstring in _run_git_update_index is now slightly stale and worth a one-line update, but nothing requires blocking the merge.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/envdrift/cli_commands/partial.py | Replaces Rich markup tags with markup=False + style="cyan" so the TOML array header isn't eaten; also adds the required [partial_encryption] / enabled = true preamble to the hint. |
| src/envdrift/core/partial_encryption.py | Adds "not a git repository" check to route to debug instead of warning; docstring for _run_git_update_index no longer fully reflects the updated logging tiers. |
| tests/unit/test_partial_cli.py | Adds three TOML-validity assertions to the existing push-disabled test; straightforward and correct. |
| tests/unit/test_partial_encryption.py | New test correctly verifies that the not-a-repo path returns False and emits nothing at WARNING level. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[push / pull-partial called] --> B{partial_encryption.enabled?}
    B -- No --> C[print_error + enable-hint\nmarkup=False, style=cyan\nfull TOML block]
    C --> D[Exit code 1]
    B -- Yes --> E[_validate_partial_config_or_exit]
    E --> F[Process environments]
    F --> G[_git_skip_worktree / _git_unskip_worktree]
    G --> H[subprocess.run git update-index]
    H --> I{returncode == 0?}
    I -- Yes --> J[return True]
    I -- No --> K{stderr contains 'not a git repository'?}
    K -- Yes --> L[logger.debug — silent\nreturn False]
    K -- No --> M[logger.warning — visible\nreturn False]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/envdrift/core/partial_encryption.py`, line 409-412 ([link](https://github.com/jainal09/envdrift/blob/078e36e99e1d450e0fdd7b1b4e2adbc8199c5412/src/envdrift/core/partial_encryption.py#L409-L412)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The docstring still says "A non-zero exit … is logged as a warning rather than failing silently", but the "not a git repository" case introduced here is now silently downgraded to debug. The mismatch will mislead the next reader into thinking all non-zero exits surface as warnings.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(push): valid TOML enable-hint and qu..."](https://github.com/jainal09/envdrift/commit/078e36e99e1d450e0fdd7b1b4e2adbc8199c5412) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36348294)</sub>

<!-- /greptile_comment -->