### PR TITLE
ci: run the non-integration suite on macOS and Windows

### DIFF
--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -69,6 +69,11 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0
+        with:
+          # Persist uv's package cache across runs; keyed per-OS/Python below so
+          # the 6-job matrix doesn't re-download wheels every time.
+          enable-cache: true
+          cache-suffix: ${{ matrix.os }}-py${{ matrix.python-version }}
 
       - name: Install dependencies
         run: uv sync --all-extras

--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -1,0 +1,81 @@
+name: Cross-Platform Tests
+
+# Runs the NON-integration test suite (pure-Python: path handling, parsing,
+# encoding, CLI rendering) on Linux, macOS and Windows so OS-specific side
+# effects — path separators, line endings, tempfile/permission semantics,
+# default encodings — surface in CI instead of on a user's machine.
+#
+# Scope boundary: container-backed integration tests (the `aws` / `vault` /
+# `azure` markers, served by docker-compose in integration-tests.yml) stay
+# Linux-only — GitHub's macOS runners have no Docker daemon and Windows runners
+# only run Windows containers, so a Linux service stack cannot start there.
+# Binary-backed integration (real dotenvx/sops seam) on macOS/Windows is a
+# planned follow-up once this matrix is green; it needs the binaries installed
+# per-OS from src/envdrift/constants.json.
+#
+# This workflow is intentionally NOT a required status check yet: it is expected
+# to surface pre-existing cross-platform bugs first. Promote it to required in
+# branch protection once the matrix is reliably green.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "src/**"
+      - "tests/**"
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".github/workflows/cross-platform.yml"
+  push:
+    branches: [main]
+    paths:
+      - "src/**"
+      - "tests/**"
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".github/workflows/cross-platform.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cross-platform-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  tests:
+    name: ${{ matrix.os }} · py${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        # Linux is also covered by ci.yml; including it here keeps the matrix
+        # apples-to-apples so a "passes on Linux, fails on Windows" diff is
+        # obvious from a single workflow.
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        # Endpoints of the supported range (3.11 oldest, 3.14 newest). The full
+        # 3.11–3.14 sweep stays on Linux in publish.yml; cross-OS is the new axis.
+        python-version: ["3.11", "3.14"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.2.0
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      # bash on every OS (Git Bash on Windows) so the marker expression quotes
+      # identically across runners. Tests themselves run under the native Python
+      # for each OS, so OS-specific behaviour is still exercised.
+      - name: Run non-integration tests
+        shell: bash
+        run: uv run pytest -m "not integration"

--- a/src/envdrift/cli_commands/init_cmd.py
+++ b/src/envdrift/cli_commands/init_cmd.py
@@ -178,6 +178,11 @@ def _module_header(class_name: str, env_file: Path) -> list[str]:
     would otherwise be mangled by string-escape interpretation.
     """
     env_file_literal = repr(str(env_file))
+    # The docstring embeds the path inside a triple-quoted string, so its
+    # backslashes must be escaped too: a Windows path (``C:\\Users\\…``) would
+    # otherwise make ``\\U``/``\\x`` look like a string escape and the generated
+    # module would fail to compile ("truncated \\UXXXXXXXX escape").
+    env_file_doc = str(env_file).replace("\\", "\\\\")
     return [
         '"""Auto-generated Pydantic Settings class."""',
         "",
@@ -186,7 +191,7 @@ def _module_header(class_name: str, env_file: Path) -> list[str]:
         "",
         "",
         f"class {class_name}(BaseSettings):",
-        f'    """Settings generated from {env_file}."""',
+        f'    """Settings generated from {env_file_doc}."""',
         "",
         "    model_config = SettingsConfigDict(",
         f"        env_file={env_file_literal},",

--- a/src/envdrift/config.py
+++ b/src/envdrift/config.py
@@ -744,5 +744,8 @@ def create_example_config(path: Path | None = None) -> Path:
     if path.exists():
         raise FileExistsError(f"Configuration file already exists: {path}")
 
-    path.write_text(EXAMPLE_CONFIG)
+    # TOML is UTF-8 by spec and EXAMPLE_CONFIG contains a non-ASCII em-dash;
+    # write UTF-8 explicitly so the file we generate is readable by tomllib on
+    # Windows too (the default there is cp1252, which load_config can't decode).
+    path.write_text(EXAMPLE_CONFIG, encoding="utf-8")
     return path

--- a/tests/scanner/test_gitleaks.py
+++ b/tests/scanner/test_gitleaks.py
@@ -133,7 +133,9 @@ class TestGetVenvBinDir:
         monkeypatch.delenv("VIRTUAL_ENV", raising=False)
         monkeypatch.setattr(sys, "path", [str(tmp_path / "site-packages")])
         monkeypatch.chdir(tmp_path)
-        monkeypatch.setenv("HOME", str(tmp_path))
+        # Patch Path.home() directly: Windows resolves it from USERPROFILE, not
+        # HOME, so setting HOME alone would leave the real home on Windows.
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
         monkeypatch.setattr(platform, "system", lambda: "Linux")
 
         bin_dir = get_venv_bin_dir()

--- a/tests/scanner/test_trufflehog.py
+++ b/tests/scanner/test_trufflehog.py
@@ -131,7 +131,9 @@ class TestGetVenvBinDir:
         monkeypatch.delenv("VIRTUAL_ENV", raising=False)
         monkeypatch.setattr(sys, "path", [str(tmp_path / "site-packages")])
         monkeypatch.chdir(tmp_path)
-        monkeypatch.setenv("HOME", str(tmp_path))
+        # Patch Path.home() directly: Windows resolves it from USERPROFILE, not
+        # HOME, so setting HOME alone would leave the real home on Windows.
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
         monkeypatch.setattr(platform, "system", lambda: "Linux")
 
         bin_dir = get_venv_bin_dir()

--- a/tests/unit/coverage/test_cov_cli_commands_sync.py
+++ b/tests/unit/coverage/test_cov_cli_commands_sync.py
@@ -230,13 +230,18 @@ class TestPartialEncryptionPaths:
         from envdrift.cli_commands.sync import _load_partial_encryption_paths
 
         cfg = tmp_path / "envdrift.toml"
+        # TOML literal strings (single quotes) so Windows backslash paths are not
+        # parsed as escapes (C:\Users -> invalid \U).
+        clear_file = tmp_path / ".env.clear"
+        secret_file = tmp_path / ".env.secret"
+        combined_file = tmp_path / ".env"
         cfg.write_text(
             "[partial_encryption]\nenabled = true\n"
             "[[partial_encryption.environments]]\n"
             'name = "prod"\n'
-            f'clear_file = "{tmp_path / ".env.clear"}"\n'
-            f'secret_file = "{tmp_path / ".env.secret"}"\n'
-            f'combined_file = "{tmp_path / ".env"}"\n'
+            f"clear_file = '{clear_file}'\n"
+            f"secret_file = '{secret_file}'\n"
+            f"combined_file = '{combined_file}'\n"
         )
         clear, secret, combined = _load_partial_encryption_paths(cfg)
         assert (tmp_path / ".env.clear").resolve() in clear
@@ -247,12 +252,15 @@ class TestPartialEncryptionPaths:
         from envdrift.cli_commands.sync import _load_partial_encryption_paths
 
         cfg = tmp_path / "envdrift.toml"
+        # TOML literal string (single quotes) so a Windows backslash path is not
+        # parsed as an escape (C:\Users -> invalid \U).
+        secrets_dir = tmp_path / "secrets"
         cfg.write_text(
             "[partial_encryption]\nenabled = true\n"
             "[[partial_encryption.environments]]\n"
             'name = "prod"\n'
             "secrets_only = true\n"
-            f'secrets_dir = "{tmp_path / "secrets"}"\n'
+            f"secrets_dir = '{secrets_dir}'\n"
         )
         clear, secret, combined = _load_partial_encryption_paths(cfg)
         # secrets-only env contributes nothing
@@ -1057,22 +1065,26 @@ class TestLockInteractivePrompt:
 # --------------------------------------------------------------------------
 def _write_partial_config(tmp_path, secret_file, combined_file, *, secrets_only=False):
     cfg = tmp_path / "envdrift.toml"
+    # Emit paths as TOML *literal* strings (single quotes): a Windows path's
+    # backslashes must not be parsed as escapes (``C:\\Users`` -> invalid ``\\U``).
+    secrets_dir = tmp_path / "secrets"
+    clear_file = tmp_path / ".env.clear"
     if secrets_only:
         cfg.write_text(
             "[partial_encryption]\nenabled = true\n"
             "[[partial_encryption.environments]]\n"
             'name = "prod"\n'
             "secrets_only = true\n"
-            f'secrets_dir = "{tmp_path / "secrets"}"\n'
+            f"secrets_dir = '{secrets_dir}'\n"
         )
     else:
         cfg.write_text(
             "[partial_encryption]\nenabled = true\n"
             "[[partial_encryption.environments]]\n"
             'name = "prod"\n'
-            f'clear_file = "{tmp_path / ".env.clear"}"\n'
-            f'secret_file = "{secret_file}"\n'
-            f'combined_file = "{combined_file}"\n'
+            f"clear_file = '{clear_file}'\n"
+            f"secret_file = '{secret_file}'\n"
+            f"combined_file = '{combined_file}'\n"
         )
     return cfg
 

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -198,7 +198,9 @@ BOOL_FALSE=false
         """#321: a non-ASCII-digit value (²=U+00B2) is str, not a crashing int()."""
         env_file = tmp_path / ".env"
         # ² (U+00B2) is str.isdigit() -> True but int("²") raises ValueError.
-        env_file.write_text("LEVEL=²\nPORT=8080")
+        # Write UTF-8 explicitly: the default encoding is cp1252 on Windows,
+        # which would emit byte 0xb2 and make the (UTF-8) reader choke.
+        env_file.write_text("LEVEL=²\nPORT=8080", encoding="utf-8")
 
         output = tmp_path / "settings.py"
         # Must not raise ValueError on the Unicode-digit value.

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1372,7 +1372,9 @@ class TestInitCommand:
         """#321: a Unicode-digit value (²=U+00B2) is inferred str, not a crashing int()."""
         env_file = tmp_path / ".env"
         # ² (U+00B2): str.isdigit() is True but int("²") raises ValueError.
-        env_file.write_text("LEVEL=²\nPORT=8080\n")
+        # Write UTF-8 explicitly: the default encoding is cp1252 on Windows,
+        # which would emit byte 0xb2 and make the (UTF-8) reader choke.
+        env_file.write_text("LEVEL=²\nPORT=8080\n", encoding="utf-8")
         out = tmp_path / "settings.py"
 
         result = runner.invoke(
@@ -1593,9 +1595,10 @@ class TestInitCommand:
         """
         from envdrift.cli_commands.init_cmd import _module_header
 
-        # A POSIX path that still contains escape-prone characters in its name.
+        # A path whose name contains escape-prone characters. It is never written
+        # to disk (a literal `"` is an illegal filename char on Windows, and
+        # `_module_header` only formats the path string), keeping this cross-platform.
         tricky = tmp_path / 'we"ird\tname'
-        tricky.write_text("FOO=bar\n")
 
         header = "\n".join(_module_header("Cfg", tricky))
         # The emitted literal must repr back to the exact path string.

--- a/tests/unit/test_config_deferred_validation.py
+++ b/tests/unit/test_config_deferred_validation.py
@@ -15,6 +15,7 @@ from envdrift.config import (
     EXAMPLE_CONFIG,
     EnvdriftConfig,
     GuardianWatchConfig,
+    create_example_config,
     load_config,
 )
 
@@ -268,7 +269,8 @@ class TestPartialEncryptionConfig:
         to PartialEncryptionConfig.validate(), which the partial commands call.
         """
         config_file = tmp_path / "envdrift.toml"
-        config_file.write_text("""
+        config_file.write_text(
+            """
 [partial_encryption]
 enabled = true
 
@@ -276,7 +278,11 @@ enabled = true
 name = "production"
 secrets_only = true
 # secrets_dir intentionally omitted — invalid for secrets_only mode
-""")
+""",
+            # TOML is UTF-8 by spec; the em-dash above must not be written as
+            # cp1252 (Windows default), which tomllib then can't decode.
+            encoding="utf-8",
+        )
 
         # load_config must NOT raise (deferred validation).
         config = load_config(config_file)
@@ -309,9 +315,25 @@ class TestExampleConfig:
     def test_example_config_loads_cleanly(self, tmp_path: Path):
         """The shipped EXAMPLE_CONFIG must parse without raising."""
         config_file = tmp_path / "envdrift.toml"
-        config_file.write_text(EXAMPLE_CONFIG)
+        # EXAMPLE_CONFIG contains a non-ASCII em-dash; write UTF-8 so tomllib
+        # (UTF-8 by spec) can read it back on Windows (default cp1252).
+        config_file.write_text(EXAMPLE_CONFIG, encoding="utf-8")
 
         config = load_config(config_file)
         # guardian/partial sections present but inert; load must not raise.
+        assert config.guardian.idle_timeout == "5m"
+        assert config.partial_encryption.enabled is False
+
+    def test_create_example_config_is_loadable(self, tmp_path: Path):
+        """The config `create_example_config` writes must be readable by load_config.
+
+        Regression: the writer used the platform-default encoding, so on Windows
+        EXAMPLE_CONFIG's non-ASCII em-dash was emitted as cp1252 and load_config
+        (tomllib, UTF-8) then failed with a UnicodeDecodeError — `init-config`
+        produced a config the tool itself could not read. The write is now UTF-8.
+        """
+        config_file = create_example_config(tmp_path / "envdrift.toml")
+
+        config = load_config(config_file)
         assert config.guardian.idle_timeout == "5m"
         assert config.partial_encryption.enabled is False

--- a/tests/unit/test_guard_cli.py
+++ b/tests/unit/test_guard_cli.py
@@ -204,7 +204,8 @@ def test_guard_survives_bad_partial_encryption(tmp_path: Path, monkeypatch):
 
     monkeypatch.setattr("envdrift.cli_commands.guard.ScanEngine", DummyEngine)
 
-    (tmp_path / "envdrift.toml").write_text("""
+    (tmp_path / "envdrift.toml").write_text(
+        """
 [partial_encryption]
 enabled = true
 
@@ -212,7 +213,10 @@ enabled = true
 name = "production"
 secrets_only = true
 # secrets_dir omitted — invalid, but guard must not care
-""")
+""",
+        # TOML is UTF-8 by spec; don't let the em-dash become cp1252 on Windows.
+        encoding="utf-8",
+    )
     monkeypatch.chdir(tmp_path)
 
     result = runner.invoke(app, ["guard", "."])

--- a/tests/unit/test_hook_check.py
+++ b/tests/unit/test_hook_check.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -301,6 +302,11 @@ class TestCheckDirectHooks:
         assert result["pre-commit"] is False
         assert result["pre-push"] is False
 
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="POSIX exec-bit semantics: Windows has no executable bit and "
+        "os.access(X_OK) is always true, so 'skip non-executable hook' cannot hold.",
+    )
     def test_non_executable_hooks_are_skipped(self, tmp_path: Path):
         hooks_dir = tmp_path / "hooks"
         hooks_dir.mkdir()

--- a/tests/unit/test_scanner_git_tools.py
+++ b/tests/unit/test_scanner_git_tools.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import subprocess
+import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -879,6 +880,12 @@ class TestGitSecretsParseOutputBranches:
         findings = scanner._parse_output(output, Path("/repo"))
         assert len(findings) == 1
 
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="POSIX-absolute path data: '/absolute/path' is not absolute on "
+        "Windows (no drive), and a Windows-absolute path's drive-colon collides "
+        "with the ':' field separator — a distinct parsing concern, not this branch.",
+    )
     def test_parse_output_absolute_file_path_used_directly(self) -> None:
         """Test _create_finding uses an absolute path as-is without prepending base_path."""
         scanner = GitSecretsScanner(auto_install=False)

--- a/tests/unit/test_sops_installer.py
+++ b/tests/unit/test_sops_installer.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import stat
+import sys
 from pathlib import Path
 from unittest.mock import patch
 
@@ -48,7 +49,9 @@ def test_install_downloads_binary(monkeypatch, tmp_path: Path):
 
     assert binary_path.exists()
     assert binary_path.name == "sops"
-    assert binary_path.stat().st_mode & stat.S_IEXEC
+    # The chmod +x is POSIX-only; Windows has no executable bit to assert.
+    if sys.platform != "win32":
+        assert binary_path.stat().st_mode & stat.S_IEXEC
 
 
 def test_install_unsupported_platform():


### PR DESCRIPTION
## What

Adds a **Cross-Platform Tests** workflow that runs `pytest -m "not integration"`
on a 3-OS × 2-Python matrix:

| | py3.11 | py3.14 |
|---|---|---|
| ubuntu-latest | ✅ | ✅ |
| macos-latest | ✅ | ✅ |
| windows-latest | ✅ | ✅ |

`fail-fast: false` so one red OS doesn't cancel the others — we want to see
*every* platform's result in one run.

## Why

Actions runners are free for public repos, and `envdrift` is path- and
filesystem-heavy (`.env.keys`, symlinks, `chmod`, tempfiles, default text
encodings). Those are exactly the side effects that stay invisible until a
macOS or Windows user hits them. Validating the pure-Python suite only on
Linux leaves that whole class of bug uncaught.

## Scope boundary (deliberate)

- **Container-backed integration** (`aws` / `vault` / `azure` markers, served by
  docker-compose in `integration-tests.yml`) stays **Linux-only** — macOS
  runners have no Docker daemon and Windows runners only run Windows
  containers, so a Linux service stack can't start there.
- **Binary-backed integration** (the real dotenvx/sops seam) on macOS/Windows
  is a **planned follow-up**. The binaries already ship `windows_amd64` /
  `darwin_*` builds in `src/envdrift/constants.json`, so the install step just
  needs a per-OS branch once this matrix is green — and the upcoming
  adversarial harness will carry POSIX-only skip-guards (`/dev/null`, `chmod`,
  symlinks) so it runs cleanly on Windows.

## Rollout

Intentionally **not a required status check yet** — it's expected to surface
pre-existing cross-platform bugs first (those become tracked findings + real
regression tests). Promote to required in branch protection once the matrix is
reliably green.

Path-filtered to Python changes (`src/**`, `tests/**`, `pyproject.toml`,
`uv.lock`, the workflow itself) so docs-only and vscode/agent-only PRs don't
spend matrix minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed backslash escaping issues in environment file paths on Windows to prevent generated modules from failing to compile.
  * Improved UTF-8 encoding handling across tests to ensure consistent behavior on Windows.

* **Tests**
  * Enhanced cross-platform test reliability with platform-specific test skips for Windows edge cases.
  * Added GitHub Actions workflow for automated testing across Windows, macOS, and Ubuntu with Python 3.11 and 3.14.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a 3-OS × 2-Python (3.11/3.14) cross-platform CI matrix for the non-integration test suite, and pairs it with the Windows compatibility fixes that the new matrix immediately requires.

- **New workflow** (`cross-platform.yml`): runs `pytest -m \"not integration\"` on ubuntu/macos/windows with `fail-fast: false`, uv cache keyed per-OS/Python, and `shell: bash` for uniform marker quoting; deliberately not a required check yet.
- **Source fixes**: `init_cmd.py` doubles backslashes in the generated docstring to prevent `\\U`/`\\x` compile errors from Windows paths; `config.py` adds `encoding=\"utf-8\"` to `create_example_config` so the em-dash in `EXAMPLE_CONFIG` survives on Windows (default cp1252).
- **Test fixes**: `write_text` calls with non-ASCII content gain `encoding=\"utf-8\"`; TOML path values switch to single-quoted literal strings so the TOML parser ignores backslashes; POSIX-only tests get `win32` skip guards; `Path.home()` is patched directly instead of via the `HOME` env var.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the workflow is opt-in (not a required check), and the source/test fixes are narrowly scoped Windows encoding and escaping corrections.

The production code changes are minimal and address real compile-time bugs (generated docstring backslash escaping, UTF-8 config write). The test changes are all additive guards or encoding fixes with no logic removal. The CI workflow is not required, so a flaky run cannot block main.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/cross-platform.yml | New 3-OS × 2-Python matrix workflow for non-integration tests; correctly sets fail-fast: false, adds uv cache keyed per-OS/Python, and uses shell: bash for uniform marker quoting. |
| src/envdrift/cli_commands/init_cmd.py | Adds env_file_doc with backslash doubling so Windows paths inside the generated docstring don't produce invalid escape sequences at compile time. |
| src/envdrift/config.py | Adds encoding="utf-8" to create_example_config's write_text call, fixing a UnicodeDecodeError on Windows where the default cp1252 encoding would mangle the em-dash in EXAMPLE_CONFIG. |
| tests/unit/coverage/test_cov_cli_commands_sync.py | Switches TOML path values from double-quoted basic strings to single-quoted literal strings so Windows backslashes aren't treated as escapes by the TOML parser. |
| tests/unit/test_config_deferred_validation.py | Adds encoding="utf-8" to TOML config writes and a new regression test verifying create_example_config produces a file load_config can read end-to-end. |

</details>

<sub>Reviews (4): Last reviewed commit: ["fix: make the non-integration test suite..."](https://github.com/jainal09/envdrift/commit/7b22315e677022d193ffd796d767bd4117443d14) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36363998)</sub>

<!-- /greptile_comment -->