### PR TITLE
fix(encrypt): verify on-disk outcome and refuse content-free files

### DIFF
--- a/docs/cli/encrypt.md
+++ b/docs/cli/encrypt.md
@@ -21,6 +21,19 @@ The `encrypt` command works with [dotenvx](https://dotenvx.com/) or
 
 If `--backend` is omitted, envdrift uses the configured backend (envdrift.toml/pyproject.toml) or defaults to dotenvx.
 
+### Safety guarantees
+
+The `encrypt` command verifies its own outcome rather than trusting the backend's
+exit code (dotenvx can exit `0` without encrypting):
+
+- **Refuses content-free files.** An empty, blank-line-only, or comment-only file
+  has no variables to encrypt, so the command declines with a non-zero exit
+  instead of letting dotenvx scaffold a placeholder-secrets template into it.
+- **Reports silent encryption failures.** When the key is missing or malformed
+  (a `.env.keys` that is a directory, garbage, or a mismatched key), the file is
+  re-read after the call; if any plaintext value survives, the command fails
+  loudly instead of printing `[OK]`.
+
 ## Arguments
 
 | Argument   | Description           | Default |

--- a/src/envdrift/core/partial_encryption.py
+++ b/src/envdrift/core/partial_encryption.py
@@ -252,6 +252,31 @@ def has_plaintext_secret_value(file_path: Path) -> bool:
     return any(_line_has_plaintext_secret(raw_line) for raw_line in content.splitlines())
 
 
+def file_has_assignment(file_path: Path) -> bool:
+    """Return True if the file contains at least one ``KEY=value`` assignment.
+
+    Deliberately looser than ``EnvParser`` (and robust to non-UTF-8 bytes via
+    ``errors="replace"``): it counts ANY assignment line, including keys the
+    strict parser rejects (a leading digit like ``1PW``, a dash like
+    ``X-API-KEY``, or a non-ASCII identifier). Used to decide whether a file has
+    anything to encrypt — a parser-variable count would miss non-identifier-keyed
+    secrets and wrongly report the file as empty, and ``EnvParser.parse`` would
+    raise ``UnicodeDecodeError`` on a non-UTF-8 file.
+    """
+    if not file_path.exists():
+        return False
+
+    content = file_path.read_text(encoding="utf-8", errors="replace")
+    for raw_line in content.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        key, sep, _ = line.partition("=")
+        if sep and key.strip():
+            return True
+    return False
+
+
 def is_file_encrypted(file_path: Path) -> bool:
     """Return True only when the file actually contains CIPHERTEXT.
 

--- a/src/envdrift/encryption/dotenvx.py
+++ b/src/envdrift/encryption/dotenvx.py
@@ -111,15 +111,20 @@ class DotenvxEncryptionBackend(EncryptionBackend):
                 file_path=env_file,
             )
 
-        # Refuse to "encrypt" a file with no variables. Handed an empty or
+        # Refuse to "encrypt" a file with no assignments. Handed an empty or
         # comment-only file, dotenvx scaffolds a placeholder-secrets template
         # (HELLO, AWS_ACCESS_KEY_ID, ...) into it and still exits 0, so a blind
         # delegation fabricates secrets the user never wrote and destroys the
-        # original content. Detect zero parseable variables up front and decline
-        # rather than letting that happen (envdrift #443).
-        from envdrift.core.parser import EnvParser
+        # original content. ``file_has_assignment`` counts ANY assignment line
+        # (including non-identifier keys like ``X-API-KEY`` the strict parser
+        # rejects) and tolerates non-UTF-8 bytes, so it neither false-refuses a
+        # file of non-identifier secrets nor crashes on a non-UTF-8 file (#443).
+        from envdrift.core.partial_encryption import (
+            file_has_assignment,
+            has_plaintext_secret_value,
+        )
 
-        if not EnvParser().parse(env_file).variables:
+        if not file_has_assignment(env_file):
             return EncryptionResult(
                 success=False,
                 message=(
@@ -135,7 +140,6 @@ class DotenvxEncryptionBackend(EncryptionBackend):
                 f"dotenvx is not installed.\n{self.install_instructions()}"
             )
 
-        from envdrift.core.partial_encryption import has_plaintext_secret_value
         from envdrift.integrations.dotenvx import DotenvxError
 
         try:

--- a/src/envdrift/encryption/dotenvx.py
+++ b/src/envdrift/encryption/dotenvx.py
@@ -111,11 +111,31 @@ class DotenvxEncryptionBackend(EncryptionBackend):
                 file_path=env_file,
             )
 
+        # Refuse to "encrypt" a file with no variables. Handed an empty or
+        # comment-only file, dotenvx scaffolds a placeholder-secrets template
+        # (HELLO, AWS_ACCESS_KEY_ID, ...) into it and still exits 0, so a blind
+        # delegation fabricates secrets the user never wrote and destroys the
+        # original content. Detect zero parseable variables up front and decline
+        # rather than letting that happen (envdrift #443).
+        from envdrift.core.parser import EnvParser
+
+        if not EnvParser().parse(env_file).variables:
+            return EncryptionResult(
+                success=False,
+                message=(
+                    f"Nothing to encrypt: {env_file} has no variables. Refusing "
+                    "to run the encryptor, which would otherwise scaffold "
+                    "placeholder secrets into the file."
+                ),
+                file_path=env_file,
+            )
+
         if not self.is_installed():
             raise EncryptionNotFoundError(
                 f"dotenvx is not installed.\n{self.install_instructions()}"
             )
 
+        from envdrift.core.partial_encryption import has_plaintext_secret_value
         from envdrift.integrations.dotenvx import DotenvxError
 
         try:
@@ -126,13 +146,30 @@ class DotenvxEncryptionBackend(EncryptionBackend):
                 env=kwargs.get("env"),
                 cwd=kwargs.get("cwd"),
             )
-            return EncryptionResult(
-                success=True,
-                message=f"Encrypted {env_file}",
-                file_path=env_file,
-            )
         except DotenvxError as e:
             raise EncryptionBackendError(f"dotenvx encryption failed: {e}") from e
+
+        # Verify the encryption actually took effect rather than trusting the
+        # exit code. dotenvx can exit 0 *without* encrypting when the private key
+        # is missing or malformed (e.g. .env.keys is a directory, garbage, or a
+        # mismatched key); it only prints a warning to stderr. Re-read the file
+        # and confirm no plaintext value survived (envdrift #443).
+        if has_plaintext_secret_value(env_file):
+            return EncryptionResult(
+                success=False,
+                message=(
+                    f"Encryption did not take effect: {env_file} still contains "
+                    "plaintext values. This usually means the encryption key was "
+                    "missing or invalid."
+                ),
+                file_path=env_file,
+            )
+
+        return EncryptionResult(
+            success=True,
+            message=f"Encrypted {env_file}",
+            file_path=env_file,
+        )
 
     def decrypt(
         self,

--- a/tests/integration/test_encrypt_outcome_bench.py
+++ b/tests/integration/test_encrypt_outcome_bench.py
@@ -1,0 +1,162 @@
+"""Real-outcome bench for the dotenvx ``encrypt`` seam (envdrift #443).
+
+Every test drives the REAL encryption seam (``DotenvxEncryptionBackend`` over the
+real ``dotenvx`` binary) and asserts the TRUE on-disk state after the call —
+never just the returned ``success`` flag or an ``[OK]`` message. This is the
+discipline the adversarial sweep showed was missing:
+
+* dotenvx **fabricates** a placeholder-secrets template (``HELLO``,
+  ``AWS_ACCESS_KEY_ID`` …) when handed an empty / content-free file, and exits 0;
+* dotenvx exits 0 **without encrypting** when the private key is missing or
+  malformed (``.env.keys`` is a directory, garbage, or a mismatched key).
+
+The pre-#443 backend trusted the exit code and reported ``success=True`` in both
+cases, so the only way to catch the regression is to re-read the file. Tests that
+need the real binary skip-gate cleanly when it is absent.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from envdrift.encryption.dotenvx import DotenvxEncryptionBackend
+
+# Mark all tests in this module
+pytestmark = [pytest.mark.integration]
+
+
+@pytest.fixture
+def dotenvx_on_path() -> None:
+    """Skip the test if the real ``dotenvx`` binary is not installed."""
+    if shutil.which("dotenvx") is None:
+        pytest.skip("dotenvx binary not found on PATH")
+
+
+# --- Empty / content-free input must NOT fabricate secrets (#1, #8, #23) -------
+# The empty-variable guard runs before dotenvx is invoked, so these assert the
+# guard itself and do not require the binary.
+
+
+def test_encrypt_empty_file_refuses_and_leaves_it_untouched(tmp_path: Path) -> None:
+    """#1/#8: a 0-byte .env must be declined, not scaffolded into a fake template."""
+    env_file = tmp_path / ".env"
+    env_file.write_text("")  # genuinely 0 bytes
+
+    result = DotenvxEncryptionBackend().encrypt(env_file)
+
+    assert result.success is False
+    assert "nothing to encrypt" in result.message.lower()
+    # The original empty file is byte-identical — NOT a 3KB fabricated template.
+    after = env_file.read_text()
+    assert after == ""
+    assert "HELLO" not in after
+    assert "AWS_ACCESS_KEY_ID" not in after
+    # No private-key file littered for a file that was never encrypted.
+    assert not (tmp_path / ".env.keys").exists()
+
+
+def test_encrypt_blank_lines_only_file_refuses(tmp_path: Path) -> None:
+    """#8: a file of only blank lines carries no variable — decline, don't fabricate."""
+    env_file = tmp_path / ".env"
+    env_file.write_text("\n\n\n\n")
+    before = env_file.read_text()
+
+    result = DotenvxEncryptionBackend().encrypt(env_file)
+
+    assert result.success is False
+    assert env_file.read_text() == before
+    assert not (tmp_path / ".env.keys").exists()
+
+
+def test_encrypt_comment_only_file_refuses_instead_of_noop_ok(tmp_path: Path) -> None:
+    """#23: a comment-only file used to print [OK] while doing nothing — now declined."""
+    env_file = tmp_path / ".env"
+    env_file.write_text("# only comments here\n# nothing else\n")
+    before = env_file.read_text()
+
+    result = DotenvxEncryptionBackend().encrypt(env_file)
+
+    assert result.success is False
+    assert env_file.read_text() == before  # byte-identical, no silent no-op
+    assert not (tmp_path / ".env.keys").exists()
+
+
+# --- Silent crypto-seam failure must be reported, not reported as success ------
+# dotenvx exits 0 but leaves plaintext when the key is broken; the backend must
+# verify the on-disk outcome and report failure (#4, #5, #6, #7).
+
+
+def test_encrypt_with_keys_dir_reports_failure_not_success(
+    tmp_path: Path, dotenvx_on_path: None
+) -> None:
+    """#4/#7: .env.keys as a directory -> dotenvx can't write its key, exits 0, file stays plaintext."""
+    env_file = tmp_path / ".env"
+    env_file.write_text("API_KEY=supersecret123\nDB_PASS=hunter2\n")
+    (tmp_path / ".env.keys").mkdir()  # dotenvx cannot write a key here
+
+    result = DotenvxEncryptionBackend().encrypt(env_file, cwd=tmp_path)
+
+    # The fix: we must NOT claim success while the secret sits in plaintext.
+    assert result.success is False
+    assert "did not take effect" in result.message.lower()
+    # On-disk truth: the secret really is still plaintext (we are not lying).
+    assert "API_KEY=supersecret123" in env_file.read_text()
+
+
+def test_encrypt_with_garbage_keys_file_reports_failure(
+    tmp_path: Path, dotenvx_on_path: None
+) -> None:
+    """#5: a malformed .env.keys -> nothing gets encrypted, but exit code is 0."""
+    env_file = tmp_path / ".env"
+    env_file.write_text("API_KEY=supersecret123\nDB_PASS=hunter2\n")
+    (tmp_path / ".env.keys").write_text("garbage not a key\nDOTENV_PRIVATE_KEY=zzz_not_hex\n")
+
+    result = DotenvxEncryptionBackend().encrypt(env_file, cwd=tmp_path)
+
+    assert result.success is False
+    on_disk = env_file.read_text()
+    assert "API_KEY=supersecret123" in on_disk
+    assert "encrypted:" not in on_disk
+
+
+def test_reencrypt_with_corrupted_keys_does_not_hide_plaintext_leak(
+    tmp_path: Path, dotenvx_on_path: None
+) -> None:
+    """#6: corrupt the key, append a new plaintext secret -> the leak must be reported, not OK'd."""
+    env_file = tmp_path / ".env"
+    env_file.write_text("API_KEY=supersecret123\n")
+
+    first = DotenvxEncryptionBackend().encrypt(env_file, cwd=tmp_path)
+    assert first.success is True  # valid first encrypt
+
+    # Corrupt the key file, then add a brand-new plaintext secret.
+    (tmp_path / ".env.keys").write_text("not a key @@@\nDOTENV_PRIVATE_KEY=NOTHEX_zzz\n")
+    env_file.write_text(env_file.read_text() + "NEW_SECRET=plaintextleak999\n")
+
+    result = DotenvxEncryptionBackend().encrypt(env_file, cwd=tmp_path)
+
+    assert result.success is False  # must not report OK while a plaintext secret survives
+    assert "NEW_SECRET=plaintextleak999" in env_file.read_text()
+
+
+# --- Control: the happy path must still succeed (no false-positive) ------------
+
+
+def test_encrypt_real_file_succeeds_and_removes_all_plaintext(
+    tmp_path: Path, dotenvx_on_path: None
+) -> None:
+    """The outcome check must NOT false-fail a genuine encryption."""
+    env_file = tmp_path / ".env"
+    env_file.write_text("API_KEY=supersecret123\nDB_PASS=hunter2\n")
+
+    result = DotenvxEncryptionBackend().encrypt(env_file, cwd=tmp_path)
+
+    assert result.success is True
+    on_disk = env_file.read_text()
+    assert "encrypted:" in on_disk
+    # The plaintext values are gone from disk.
+    assert "supersecret123" not in on_disk
+    assert "hunter2" not in on_disk

--- a/tests/integration/test_encrypt_outcome_bench.py
+++ b/tests/integration/test_encrypt_outcome_bench.py
@@ -84,6 +84,28 @@ def test_encrypt_comment_only_file_refuses_instead_of_noop_ok(tmp_path: Path) ->
     assert not (tmp_path / ".env.keys").exists()
 
 
+def test_encrypt_file_of_only_non_identifier_keys_is_not_refused(
+    tmp_path: Path, dotenvx_on_path: None
+) -> None:
+    """#444 review regression: non-identifier keys are content, not emptiness.
+
+    A file whose only keys are non-identifier (``X-API-KEY``, ``1PASSWORD``) parses
+    to zero *strict-parser* variables, so an EnvParser-based empty-guard would
+    wrongly refuse it and leave real secrets unencrypted. The guard counts raw
+    assignments instead, so this file is encrypted normally.
+    """
+    env_file = tmp_path / ".env"
+    env_file.write_text("X-API-KEY=supersecret123\n1PASSWORD=hunter2\n", encoding="utf-8")
+
+    result = DotenvxEncryptionBackend().encrypt(env_file, cwd=tmp_path)
+
+    assert result.success is True, result.message
+    on_disk = env_file.read_text()
+    assert "encrypted:" in on_disk
+    assert "supersecret123" not in on_disk
+    assert "hunter2" not in on_disk
+
+
 # --- Silent crypto-seam failure must be reported, not reported as success ------
 # dotenvx exits 0 but leaves plaintext when the key is broken; the backend must
 # verify the on-disk outcome and report failure (#4, #5, #6, #7).

--- a/tests/unit/test_encryption_backends.py
+++ b/tests/unit/test_encryption_backends.py
@@ -246,6 +246,15 @@ class TestDotenvxEncryptionBackend:
         env_file = tmp_path / ".env"
         env_file.write_text("KEY=value")
 
+        # The mock must model the seam's real effect: a genuine dotenvx encrypt
+        # rewrites the file with ciphertext. The backend now verifies the
+        # on-disk outcome (envdrift #443), so a no-op mock would correctly read
+        # as "encryption did not take effect". Make the mock honest.
+        def _fake_encrypt(**_kwargs):
+            env_file.write_text('KEY="encrypted:BExampleCiphertext"')
+
+        mock_wrapper.encrypt.side_effect = _fake_encrypt
+
         backend = DotenvxEncryptionBackend()
         result = backend.encrypt(env_file)
 

--- a/tests/unit/test_partial_encryption.py
+++ b/tests/unit/test_partial_encryption.py
@@ -14,12 +14,45 @@ from envdrift.config import PartialEncryptionEnvironmentConfig
 from envdrift.core.partial_encryption import (
     PartialEncryptionError,
     combine_files,
+    file_has_assignment,
     has_plaintext_secret_value,
     is_file_encrypted,
     pull_secrets_only,
     push_partial_encryption,
     push_secrets_only,
 )
+
+
+class TestFileHasAssignment:
+    """``file_has_assignment`` underpins the encrypt empty-guard (#443/#444)."""
+
+    def test_true_for_identifier_keys(self, tmp_path: Path) -> None:
+        f = tmp_path / ".env"
+        f.write_text("FOO=bar\n", encoding="utf-8")
+        assert file_has_assignment(f) is True
+
+    def test_true_for_non_identifier_keys(self, tmp_path: Path) -> None:
+        """Dash/digit keys the strict parser rejects are still real content."""
+        f = tmp_path / ".env"
+        f.write_text("X-API-KEY=secret\n1PASSWORD=hunter2\n", encoding="utf-8")
+        assert file_has_assignment(f) is True
+
+    def test_true_for_non_utf8_file_without_crashing(self, tmp_path: Path) -> None:
+        """A non-UTF-8 byte must not raise UnicodeDecodeError (errors='replace')."""
+        f = tmp_path / ".env"
+        f.write_bytes(b"API_KEY=caf\xe9\n")  # 0xe9 = latin-1 'é', invalid UTF-8
+        assert file_has_assignment(f) is True
+
+    def test_false_for_empty_comment_only_and_blank(self, tmp_path: Path) -> None:
+        empty = tmp_path / "empty.env"
+        empty.write_text("", encoding="utf-8")
+        comments = tmp_path / "comments.env"
+        comments.write_text("# just a comment\n\n   \n", encoding="utf-8")
+        keyless = tmp_path / "keyless.env"
+        keyless.write_text("=novalue\n", encoding="utf-8")  # no key before '='
+        assert file_has_assignment(empty) is False
+        assert file_has_assignment(comments) is False
+        assert file_has_assignment(keyless) is False
 
 
 @pytest.fixture


### PR DESCRIPTION
## What

The dotenvx `encrypt` backend trusted the subprocess **exit code**. The
adversarial sweep (#443) showed dotenvx exits `0` in two dangerous cases, so
`envdrift` reported success while doing harm. This fixes the shared backend seam
and adds a **real-outcome** integration bench.

## The bugs (all verified, all HIGH)

| # | Input | dotenvx behaviour | old envdrift result |
|---|---|---|---|
| #1/#8 | empty / blank-line-only `.env` | scaffolds a 14-var **fake-secrets template** (HELLO, AWS keys, Stripe…) and exits 0 | `[OK] Encrypted` — original destroyed, fabricated secrets written |
| #23 | comment-only `.env` | no-op, exits 0 | `[OK] Encrypted` — silent no-op + orphan `.env.keys` |
| #4/#7 | `.env.keys` is a **directory** | can't write key, leaves plaintext, exits 0 | `[OK] Encrypted` — secrets in cleartext |
| #5 | **garbage** `.env.keys` | encrypts nothing, exits 0 | `[OK] Encrypted` |
| #6 | re-encrypt with **corrupted** key + new plaintext secret | leaves new secret in cleartext, exits 0 | `[OK] Encrypted` — plaintext leak |

## The fix — outcome verification at the seam

Both checks live in the **shared backend** (`encryption/dotenvx.py`), so
`encrypt`, `lock`, `sync` and `vault` are all covered (true single-source), and
both reuse existing primitives (no parallel logic):

1. **Before** delegating: refuse a file with zero parseable variables
   (`EnvParser`) → dotenvx can never scaffold a fake template.
2. **After** delegating: re-read the file and fail if any plaintext value
   survived (`has_plaintext_secret_value`) → never claim success while secrets
   sit in cleartext, regardless of dotenvx's exit code.

## The bench — real, not mocked

`tests/integration/test_encrypt_outcome_bench.py` drives the **real dotenvx
binary** and asserts the **true on-disk state** for every case (re-reads the
file; never trusts the `success` flag or `[OK]`). Proven real:

```
fix stashed  → 6 failed, 1 passed   (the bug reproduces; control passes)
fix restored → 7 passed
```

The one pre-existing unit test that mocked the wrapper to a no-op and asserted
`success is True` is updated to model the seam's real effect (write ciphertext)
so it stays honest under the new outcome check — that mock-of-the-behaviour was
exactly why the bug shipped.

## Scope

dotenvx backend only. SOPS backend, the `decrypt` seam, and the traceback /
machine-output / init-validate themes from #443 are follow-up themed PRs. Full
non-integration suite green (2468 passed); local gates (ruff/format/pyrefly/
bandit/markdownlint) clean.

Refs #443

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "Safety guarantees" section for the encrypt command describing its validation behavior.

* **Improvements**
  * Encrypt now refuses to run on empty or content-free files.
  * Encrypt re-checks files after running to detect and report silent encryption failures.
  * Removed encrypt's --verify-vault; vault verification moved to decrypt --verify-vault.

* **Tests**
  * Added integration and unit tests covering outcome validation and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a class of silent encryption failures in the dotenvx backend where dotenvx exits `0` without actually encrypting — fabricating a secrets template for empty files, or leaving plaintext values on disk when the key is missing or malformed. The fix adds two outcome-verification checks at the seam in `DotenvxEncryptionBackend.encrypt()` so that `lock`, `sync`, and `vault` all benefit.

- **Pre-guard** (`file_has_assignment`): refuses files with no assignment lines before dotenvx is invoked, preventing the fake-template scaffolding on empty/comment-only input; the helper uses `errors="replace"` to tolerate non-UTF-8 bytes and counts non-identifier keys (`X-API-KEY`, `1PASSWORD`) that `EnvParser` would skip.
- **Post-check** (`has_plaintext_secret_value`): re-reads the on-disk file after the subprocess returns and fails loudly if any plaintext value survived, catching the key-missing / key-corrupted / dir-instead-of-file failure modes that dotenvx silently ignores.
- **Tests**: integration bench drives the real dotenvx binary for 7 cases (6 adversarial + 1 happy path) and asserts true on-disk state; unit test updated so the mock models the actual ciphertext side-effect the post-check now requires.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changed paths are guarded by the new pre/post checks and covered by both unit and real-binary integration tests.

The two new checks (file_has_assignment before delegation, has_plaintext_secret_value after) are logically correct, mutually consistent in what they treat as content, and robust to the known edge cases (non-identifier keys, non-UTF-8 bytes, empty values). The unit test update honestly models the on-disk side-effect the post-check now depends on. The integration bench verifies all five adversarial scenarios against the real binary. No net-new failure modes are introduced.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/envdrift/encryption/dotenvx.py | Adds pre-guard (file_has_assignment) and post-check (has_plaintext_secret_value) to encrypt(); DotenvxError catch correctly moved outside the result path so the post-check always runs; deferred import inside the method is intentional and correct. |
| src/envdrift/core/partial_encryption.py | New file_has_assignment helper is deliberately looser than EnvParser: counts any key=value line, tolerates non-UTF-8 via errors="replace", does not exclude DOTENV_PUBLIC_KEY lines (intentional — they are real content). Logic is correct and well-tested. |
| tests/integration/test_encrypt_outcome_bench.py | Comprehensive real-binary bench covering 7 cases; correctly skips when dotenvx is absent; all assertions verify on-disk state rather than the returned flag. The non-identifier-key regression test (#444 review case) is appropriately guarded by dotenvx_on_path. |
| tests/unit/test_encryption_backends.py | Unit test for encrypt() updated to model the real seam effect (mock writes ciphertext to disk) so it stays honest under the new post-check; no issues. |
| tests/unit/test_partial_encryption.py | TestFileHasAssignment covers identifier keys, non-identifier keys, non-UTF-8 bytes, empty/comment/blank/keyless inputs; all meaningful edge cases for the new helper are exercised. |
| docs/cli/encrypt.md | Documentation accurately describes the two new guarantees; no issues. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["encrypt(env_file)"] --> B{file exists?}
    B -- No --> C["EncryptionResult(success=False, 'File not found')"]
    B -- Yes --> D{file_has_assignment?}
    D -- No --> E["EncryptionResult(success=False, 'Nothing to encrypt')"]
    D -- Yes --> F{dotenvx installed?}
    F -- No --> G["raise EncryptionNotFoundError"]
    F -- Yes --> H["wrapper.encrypt()"]
    H -- DotenvxError --> I["raise EncryptionBackendError"]
    H -- exits 0 --> J{has_plaintext_secret_value?}
    J -- True plaintext survives --> K["EncryptionResult(success=False, 'did not take effect')"]
    J -- False all encrypted --> L["EncryptionResult(success=True)"]
```

<sub>Reviews (2): Last reviewed commit: ["fix(encrypt): make the empty-guard robus..."](https://github.com/jainal09/envdrift/commit/3e0fb3bfb92eb3a4cdab6e7e94dfb7a388d88b33) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36380599)</sub>

<!-- /greptile_comment -->