### PR TITLE
fix(init): alias non-identifier keys instead of dropping them

### DIFF
--- a/docs/cli/init.md
+++ b/docs/cli/init.md
@@ -150,7 +150,7 @@ The generated module is always valid, importable Python:
   name plus a Pydantic `alias` so the field still binds to the original variable:
 
   ```python
-  class_: str = Field(alias="class")
+  class_: str = Field(alias='class')
   ```
 
 - **Pydantic-reserved names get an alias.** A key that is a valid identifier but
@@ -160,7 +160,7 @@ The generated module is always valid, importable Python:
   `alias`, so it cannot raise at import or shadow model internals:
 
   ```python
-  field_model_dump: str = Field(alias="model_dump")
+  field_model_dump: str = Field(alias='model_dump')
   ```
 
 - **Non-identifier keys are aliased, not dropped.** Keys that are not

--- a/docs/cli/init.md
+++ b/docs/cli/init.md
@@ -163,10 +163,19 @@ The generated module is always valid, importable Python:
   field_model_dump: str = Field(alias="model_dump")
   ```
 
-- **Non-identifier keys are reported.** Keys the parser cannot read because they
-  are not identifier-style (a leading digit like `2FA_ENABLED`, or a dash like
-  `MY-DASH-VAR`) are skipped and listed in a `[WARN]` line, never silently
-  dropped.
+- **Non-identifier keys are aliased, not dropped.** Keys that are not
+  identifier-style (a leading digit like `2FA_ENABLED`, a dash like
+  `MY-DASH-VAR`, a dot, or an emoji) are emitted with a sanitized attribute name
+  plus a Pydantic `alias`, so every key ends up in the schema and still binds to
+  the original environment variable:
+
+  ```python
+  field_2FA_ENABLED: str = Field(alias="2FA_ENABLED")
+  MY_DASH_VAR: str = Field(alias="MY-DASH-VAR")
+  ```
+
+- **Valid non-ASCII identifiers are kept verbatim.** A key that passes
+  `str.isidentifier()` (e.g. `CAFÉ`, `ΑΛΦΑ`) becomes a bare field with no alias.
 
 - **Invalid class names fail fast.** A `--class-name` that is not a valid Python
   identifier (e.g. `123Bad`) or is a keyword (e.g. `class`) errors with a

--- a/docs/cli/init.md
+++ b/docs/cli/init.md
@@ -170,8 +170,8 @@ The generated module is always valid, importable Python:
   the original environment variable:
 
   ```python
-  field_2FA_ENABLED: str = Field(alias="2FA_ENABLED")
-  MY_DASH_VAR: str = Field(alias="MY-DASH-VAR")
+  field_2FA_ENABLED: str = Field(alias='2FA_ENABLED')
+  MY_DASH_VAR: str = Field(alias='MY-DASH-VAR')
   ```
 
 - **Valid non-ASCII identifiers are kept verbatim.** A key that passes

--- a/src/envdrift/api.py
+++ b/src/envdrift/api.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import warnings
 from pathlib import Path
 
 from envdrift.core.diff import DiffEngine, DiffResult
@@ -113,14 +112,11 @@ def init(
         class_name (str): Name to use for the generated Settings class.
         detect_sensitive (bool): If True, attempt to detect sensitive variables and mark them in the generated fields.
 
-    Non-identifier .env keys (leading digits, dashes) are skipped by the strict
-    parser; keys that are valid identifiers but Python keywords (`class`,
-    `import`) are emitted with a sanitized attribute name plus a Pydantic
-    ``alias`` so the generated module always imports cleanly.
-
-    Any keys the strict parser cannot read (e.g. ``2FA_ENABLED``, ``MY-DASH-VAR``)
-    are dropped from the generated module; the API surfaces them via a
-    ``UserWarning`` so callers are not left silently with an incomplete file.
+    Every .env key becomes a field. Keys the strict parser rejects (leading
+    digits, dashes, dots) and Python keywords (`class`, `import`) are emitted
+    with a sanitized attribute name plus a Pydantic ``alias`` so the generated
+    module always imports cleanly while still binding to the original variable;
+    a valid non-ASCII identifier (``CAFÉ``) is emitted unchanged.
 
     Returns:
         Path: The path to the written settings file.
@@ -136,16 +132,7 @@ def init(
 
     result = generate_settings_module(env_file, class_name, detect_sensitive)
 
-    # Warn *before* writing: a caller running under
-    # ``warnings.filterwarnings("error")`` promotes this to an exception, and we
-    # must not leave a half-written settings.py on disk when that happens.
-    if result.unparsed_keys:
-        warnings.warn(
-            "Skipped .env variable(s) the parser cannot read "
-            f"(non-identifier keys): {', '.join(result.unparsed_keys)}",
-            UserWarning,
-            stacklevel=2,
-        )
-
-    output.write_text(result.source)
+    # encoding="utf-8" so a non-ASCII field name/value round-trips on platforms
+    # whose default text encoding is not UTF-8.
+    output.write_text(result.source, encoding="utf-8")
     return output

--- a/src/envdrift/cli_commands/init_cmd.py
+++ b/src/envdrift/cli_commands/init_cmd.py
@@ -102,8 +102,7 @@ def _unparsed_assignments(env_file: Path, env: EnvFile) -> dict[str, str]:
         key = match.group(1)
         if key in env.variables or key in extra:
             continue
-        value = parser._unquote(parser._strip_inline_comment(match.group(2)).strip())
-        extra[key] = value
+        extra[key] = parser.value_from_raw(match.group(2))
     return extra
 
 

--- a/src/envdrift/cli_commands/init_cmd.py
+++ b/src/envdrift/cli_commands/init_cmd.py
@@ -14,12 +14,12 @@ from pydantic_settings import BaseSettings
 
 from envdrift.core.encryption import EncryptionDetector
 from envdrift.core.parser import EnvFile, EnvParser
-from envdrift.output.rich import console, print_error, print_success, print_warning
+from envdrift.output.rich import console, print_error, print_success
 
-# Matches the left-hand side of any `KEY=value` assignment in a raw .env file,
-# accepting keys the strict EnvParser.LINE_PATTERN rejects (leading digits,
-# dashes, etc.) so init can warn about variables it would otherwise drop.
-_RAW_ASSIGNMENT_PATTERN = re.compile(r"^\s*(?:export\s+)?([^\s=#]+)\s*=")
+# Matches `KEY=value` for ANY key the strict EnvParser.LINE_PATTERN rejects
+# (leading digits, dashes, dots, non-ASCII letters, …) so init can still emit a
+# field for it — sanitized + aliased — instead of silently dropping it.
+_RAW_ASSIGNMENT_PATTERN = re.compile(r"^\s*(?:export\s+)?([^\s=#]+)\s*=(.*)$")
 
 # Pydantic protects the ``model_`` attribute namespace: a BaseModel/BaseSettings
 # field whose name starts with this prefix either raises at import (``model_dump``
@@ -57,8 +57,6 @@ class SettingsGeneration:
     source: str
     sensitive_vars: set[str] = field(default_factory=set)
     aliased_count: int = 0
-    # .env keys present in the raw text but rejected by the strict parser.
-    unparsed_keys: list[str] = field(default_factory=list)
 
 
 def _sanitize_identifier(name: str) -> str:
@@ -82,17 +80,31 @@ def _sanitize_identifier(name: str) -> str:
     return sanitized
 
 
-def _raw_assignment_keys(text: str) -> list[str]:
-    """Extract every assignment key from raw .env text (parser-independent)."""
-    keys: list[str] = []
-    for raw_line in text.splitlines():
+def _unparsed_assignments(env_file: Path, env: EnvFile) -> dict[str, str]:
+    """Return ``name -> value`` for assignment lines the strict parser rejected.
+
+    ``EnvParser`` only accepts identifier-style ASCII keys, so ``2FA_ENABLED``,
+    ``X-API-KEY`` or a non-ASCII identifier such as ``CAFÉ`` never become
+    variables. Those keys are recovered here — values are unquoted with the
+    parser's own helpers so the value handling stays single-source — and fed
+    through the same sanitize/alias path as parsed keys instead of being dropped.
+    Keys the parser already accepted are skipped (they come from ``env``).
+    """
+    parser = EnvParser()
+    extra: dict[str, str] = {}
+    for raw_line in env_file.read_text(encoding="utf-8").splitlines():
         line = raw_line.strip()
         if not line or line.startswith("#"):
             continue
         match = _RAW_ASSIGNMENT_PATTERN.match(line)
-        if match:
-            keys.append(match.group(1))
-    return keys
+        if not match:
+            continue
+        key = match.group(1)
+        if key in env.variables or key in extra:
+            continue
+        value = parser._unquote(parser._strip_inline_comment(match.group(2)).strip())
+        extra[key] = value
+    return extra
 
 
 def _needs_sanitizing(name: str) -> bool:
@@ -210,43 +222,31 @@ def _module_header(class_name: str, env_file: Path) -> list[str]:
     ]
 
 
-def _unparsed_keys(env_file: Path, env: EnvFile) -> list[str]:
-    """Return raw .env keys present in the file but rejected by the strict parser.
-
-    The ``EnvParser`` only accepts identifier-style keys, so ``2FA_ENABLED`` or
-    ``MY-DASH-VAR`` never become variables. These are surfaced to the caller to
-    warn about rather than silently drop (``validate`` would later reject them as
-    forbidden extras under ``extra="forbid"``).
-    """
-    raw_keys = _raw_assignment_keys(env_file.read_text(encoding="utf-8"))
-    return [k for k in dict.fromkeys(raw_keys) if k not in env.variables]
-
-
-def _detect_sensitive_vars(env: EnvFile) -> set[str]:
+def _detect_sensitive_vars(values: dict[str, str]) -> set[str]:
     """Return the set of variable names flagged sensitive by name or value."""
     detector = EncryptionDetector()
     return {
         name
-        for name, var in env.variables.items()
-        if detector.is_name_sensitive(name) or detector.is_value_suspicious(var.value)
+        for name, value in values.items()
+        if detector.is_name_sensitive(name) or detector.is_value_suspicious(value)
     }
 
 
-def _render_fields(env: EnvFile, sensitive_vars: set[str]) -> tuple[list[str], int]:
+def _render_fields(values: dict[str, str], sensitive_vars: set[str]) -> tuple[list[str], int]:
     """Render every Settings field line; return the lines and the alias count.
 
     Walks the variables in sorted order so output is deterministic, resolving each
-    to a unique importable attribute name (with an alias when renamed) and an
-    inferred type/default.
+    to a unique importable attribute name (with an alias when the .env key is a
+    non-identifier, keyword, or collides) and an inferred type/default.
     """
     field_lines: list[str] = []
     aliased_count = 0
     used_names: set[str] = set()
-    for var_name, env_var in sorted(env.variables.items()):
+    for var_name, value in sorted(values.items()):
         field_name, alias = _resolve_field_name(var_name, used_names)
         if alias is not None:
             aliased_count += 1
-        type_hint, default_val = _infer_type(env_var.value)
+        type_hint, default_val = _infer_type(value)
         field_lines.append(
             _render_field_line(
                 field_name, type_hint, default_val, alias, var_name in sensitive_vars
@@ -265,11 +265,13 @@ def generate_settings_module(
     Shared by the ``init`` CLI command and the public ``envdrift.api.init`` so
     both entry points generate the same safe, importable Python.
 
-    Guarantees the emitted module is importable:
+    Guarantees the emitted module is importable AND complete (no key dropped):
       * ``class_name`` is validated as a real (non-keyword) identifier.
-      * Each field whose .env key is not a valid identifier (or is a keyword) is
-        emitted with a sanitized attribute name plus a Pydantic ``alias`` so the
-        schema still binds to the original environment variable.
+      * Every .env key becomes a field. A key the strict parser rejects
+        (leading digit, dash, dot, non-ASCII letter) or that is a Python keyword
+        is emitted with a sanitized attribute name plus a Pydantic ``alias`` so
+        the schema still binds to the original environment variable; a valid
+        non-ASCII identifier (``CAFÉ``) becomes a bare field unchanged.
 
     Raises:
         ValueError: If ``class_name`` is not a valid Python identifier.
@@ -278,17 +280,18 @@ def generate_settings_module(
         raise ValueError(f"Invalid class name: {class_name!r} is not a valid Python identifier")
 
     env = EnvParser().parse(env_file)
-    unparsed_keys = _unparsed_keys(env_file, env)
-    sensitive_vars = _detect_sensitive_vars(env) if detect_sensitive else set()
+    # Every assignment in the file, including keys the strict parser rejected.
+    all_values: dict[str, str] = {name: var.value for name, var in env.variables.items()}
+    all_values.update(_unparsed_assignments(env_file, env))
+    sensitive_vars = _detect_sensitive_vars(all_values) if detect_sensitive else set()
 
-    field_lines, aliased_count = _render_fields(env, sensitive_vars)
+    field_lines, aliased_count = _render_fields(all_values, sensitive_vars)
     lines = [*_module_header(class_name, env_file), *field_lines, ""]
 
     return SettingsGeneration(
         source="\n".join(lines),
         sensitive_vars=sensitive_vars,
         aliased_count=aliased_count,
-        unparsed_keys=unparsed_keys,
     )
 
 
@@ -385,18 +388,14 @@ def init(
 
 
 def _write_init_output(result: SettingsGeneration, output: Path, *, force: bool) -> None:
-    """Warn about dropped keys, guard against clobbering, then write the module."""
-    if result.unparsed_keys:
-        print_warning(
-            "Skipped .env variable(s) the parser cannot read "
-            f"(non-identifier keys): {', '.join(result.unparsed_keys)}"
-        )
-
+    """Guard against clobbering an existing file, then write the module."""
     # Guard against clobbering an existing (possibly hand-edited) file.
     if output.exists() and not force:
         print_error(f"Output file already exists: {output} (use --force to overwrite)")
         raise typer.Exit(code=1)
 
-    output.write_text(result.source)
+    # encoding="utf-8" so a non-ASCII field name/value (e.g. a unicode-identifier
+    # key) round-trips on platforms whose default text encoding is not UTF-8.
+    output.write_text(result.source, encoding="utf-8")
     print_success(f"Generated {output}")
     _print_generation_summary(result)

--- a/src/envdrift/core/parser.py
+++ b/src/envdrift/core/parser.py
@@ -202,14 +202,7 @@ class EnvParser:
                 continue
 
             key = match.group(1)
-            # Strip an inline comment from the RAW value first — the whitespace
-            # context distinguishes `K= # c` (comment) from `K=#FF0000` (a value
-            # that begins with `#`) — then strip surrounding whitespace + quotes.
-            value = self._strip_inline_comment(match.group(2))
-            value = value.strip()
-
-            # Remove surrounding quotes
-            value = self._unquote(value)
+            value = self.value_from_raw(match.group(2))
 
             # Determine encryption status and backend
             encryption_status, encryption_backend = self._detect_encryption_status(value)
@@ -226,6 +219,19 @@ class EnvParser:
             env_file.variables[key] = env_var
 
         return env_file
+
+    def value_from_raw(self, raw_value: str) -> str:
+        """Normalize the raw RHS of a ``KEY=value`` line to its final value.
+
+        Strips an unquoted inline comment, then surrounding whitespace, then a
+        single matching pair of surrounding quotes — the same transformation
+        ``parse`` applies. Public so callers that recover assignments the strict
+        ``LINE_PATTERN`` rejects (e.g. ``init`` for non-identifier keys) reuse
+        this canonical handling instead of the private helpers. The whitespace
+        context matters, so pass the RAW value (the regex's ``=`` group),
+        unstripped: ``K= # c`` is a comment but ``K=#FF0000`` is a value.
+        """
+        return self._unquote(self._strip_inline_comment(raw_value).strip())
 
     def _strip_inline_comment(self, value: str) -> str:
         """Strip an unquoted trailing ` #...` comment from a (raw) value.

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -246,47 +246,55 @@ BOOL_FALSE=false
         # No broken module written.
         assert not output.exists()
 
-    def test_init_warns_on_non_identifier_keys(self, tmp_path: Path):
-        """#423: the API surfaces dropped non-identifier keys via a UserWarning.
+    def test_init_aliases_non_identifier_keys(self, tmp_path: Path):
+        """#443: non-identifier keys are aliased into the schema, not dropped.
 
-        Keys the strict parser cannot read (`2FA_ENABLED`, `MY-DASH-VAR`) are
-        omitted from the generated module. The CLI prints a [WARN]; the public API
-        must not silently leave callers with an incomplete file — it warns instead.
-        """
-        env_file = tmp_path / ".env"
-        env_file.write_text("2FA_ENABLED=true\nMY-DASH-VAR=x\nVALID=keep\n")
-        output = tmp_path / "settings.py"
-
-        with pytest.warns(UserWarning, match="non-identifier keys") as record:
-            result = init(env_file, output, detect_sensitive=False)
-
-        assert result == output
-        message = str(record[0].message)
-        assert "2FA_ENABLED" in message
-        assert "MY-DASH-VAR" in message
-        # The parseable variable is still emitted.
-        assert "VALID" in output.read_text()
-
-    def test_init_warnings_as_errors_writes_no_file(self, tmp_path: Path):
-        """#423: under warnings-as-errors, init() must not leave a half-written file.
-
-        The dropped-keys UserWarning is emitted BEFORE the output is written, so a
-        caller running with ``warnings.filterwarnings("error")`` (common in CI/test
-        suites) gets a clean raise and NO output file on disk -- not an incomplete
-        ``settings.py`` plus an exception.
+        Keys the strict parser rejects (`2FA_ENABLED`, `MY-DASH-VAR`) used to be
+        omitted from the generated module (the API warned about the loss). They are
+        now emitted with a sanitized attribute name plus a Pydantic ``alias`` so the
+        schema stays complete and binds to the real variables — no warning needed.
         """
         import warnings
 
         env_file = tmp_path / ".env"
-        env_file.write_text("2FA_ENABLED=true\nVALID=keep\n")
+        env_file.write_text("2FA_ENABLED=true\nMY-DASH-VAR=x\nVALID=keep\n", encoding="utf-8")
         output = tmp_path / "settings.py"
 
         with warnings.catch_warnings():
-            warnings.simplefilter("error", UserWarning)
-            with pytest.raises(UserWarning, match="non-identifier keys"):
-                init(env_file, output, detect_sensitive=False)
+            warnings.simplefilter("error")  # any spurious warning fails the test
+            result = init(env_file, output, detect_sensitive=False)
 
-        assert not output.exists()
+        assert result == output
+        content = output.read_text(encoding="utf-8")
+        # Every key is represented, with aliases back to the original names.
+        assert "alias='2FA_ENABLED'" in content
+        assert "alias='MY-DASH-VAR'" in content
+        assert "VALID" in content
+        # The raw non-identifier names never appear as bare attribute annotations.
+        assert "\n    2FA_ENABLED:" not in content
+        assert "\n    MY-DASH-VAR:" not in content
+
+    def test_init_non_identifier_keys_keep_module_importable(self, tmp_path: Path):
+        """#443: a module with aliased non-identifier keys imports cleanly.
+
+        Previously these keys were dropped (and the API emitted a UserWarning); now
+        they are aliased in, so the generated module must both contain them and
+        import without a SyntaxError.
+        """
+        import importlib.util
+
+        env_file = tmp_path / ".env"
+        env_file.write_text("2FA_ENABLED=true\nMY-DASH-VAR=x\nVALID=keep\n", encoding="utf-8")
+        output = tmp_path / "settings.py"
+
+        init(env_file, output, class_name="Cfg", detect_sensitive=False)
+
+        spec = importlib.util.spec_from_file_location("gen_alias_api_settings", output)
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        aliases = {f.alias for f in module.Cfg.model_fields.values() if f.alias}
+        assert {"2FA_ENABLED", "MY-DASH-VAR"} <= aliases
 
     def test_init_no_warning_when_all_keys_parse(self, tmp_path: Path):
         """#423: the API stays warning-free when every key is parseable."""

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1411,25 +1411,63 @@ class TestInitCommand:
         assert "invalid class name" in result.output.lower()
         assert not out.exists()
 
-    def test_init_warns_on_non_identifier_keys(self, tmp_path: Path) -> None:
-        """#413: .env keys the parser cannot read are warned about, not dropped.
+    def test_init_aliases_non_identifier_keys(self, tmp_path: Path) -> None:
+        """#443: .env keys the parser cannot read are aliased in, not dropped.
 
         `2FA_ENABLED` (leading digit) and `MY-DASH-VAR` (dash) never enter the
-        parsed variable set, so init previously omitted them with no warning.
+        strict parser's variable set, so init used to omit them and warn. They are
+        now emitted with a sanitized attribute name plus a Pydantic ``alias`` so the
+        schema stays complete and the module still imports.
         """
         env_file = tmp_path / ".env"
-        env_file.write_text("2FA_ENABLED=true\nMY-DASH-VAR=x\nVALID=keep\n")
+        env_file.write_text("2FA_ENABLED=true\nMY-DASH-VAR=x\nVALID=keep\n", encoding="utf-8")
         out = tmp_path / "settings.py"
 
         result = runner.invoke(
             app, ["init", str(env_file), "--output", str(out), "--class-name", "Cfg"]
         )
         assert result.exit_code == 0, result.output
-        # Both un-parseable keys are named in the warning output.
-        assert "2FA_ENABLED" in result.output
-        assert "MY-DASH-VAR" in result.output
-        # The parseable variable is still emitted.
-        assert "VALID" in out.read_text()
+        content = out.read_text(encoding="utf-8")
+        # Both keys are aliased into the schema rather than dropped/warned.
+        assert "alias='2FA_ENABLED'" in content
+        assert "alias='MY-DASH-VAR'" in content
+        assert "VALID" in content
+
+        # The generated module must still import (no SyntaxError from raw names).
+        spec = importlib.util.spec_from_file_location("gen_alias_settings", out)
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        aliases = {f.alias for f in module.Cfg.model_fields.values() if f.alias}
+        assert {"2FA_ENABLED", "MY-DASH-VAR"} <= aliases
+
+    def test_init_unicode_identifier_keys_become_bare_fields(self, tmp_path: Path) -> None:
+        """#443: valid non-ASCII identifiers are real fields; only true non-identifiers alias.
+
+        ``CAFÉ`` / ``ΑΛΦΑ`` pass ``str.isidentifier()`` and must become bare
+        attributes (no alias); an emoji key ``KEY🔑`` is not an identifier and is
+        sanitized + aliased like any other non-identifier key.
+        """
+        env_file = tmp_path / ".env"
+        # Greek capital letters are intentional (testing non-ASCII identifiers).
+        env_file.write_text("CAFÉ=a\nΑΛΦΑ=b\nKEY🔑=c\n", encoding="utf-8")  # noqa: RUF001
+        out = tmp_path / "settings.py"
+
+        result = runner.invoke(
+            app, ["init", str(env_file), "--output", str(out), "--class-name", "Cfg"]
+        )
+        assert result.exit_code == 0, result.output
+
+        spec = importlib.util.spec_from_file_location("gen_unicode_settings", out)
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        fields = module.Cfg.model_fields
+        # Unicode-letter identifiers are kept verbatim (no alias).
+        assert "CAFÉ" in fields and fields["CAFÉ"].alias is None
+        assert "ΑΛΦΑ" in fields and fields["ΑΛΦΑ"].alias is None
+        # The emoji key is aliased back to its original name.
+        assert {f.alias for f in fields.values() if f.alias == "KEY🔑"} == {"KEY🔑"}
 
     def test_sanitize_identifier_produces_valid_non_keyword_names(self) -> None:
         """#413: the sanitizer always yields a valid, non-keyword identifier."""


### PR DESCRIPTION
## What

The adversarial sweep (#443) found `init` silently **drops** every `.env` key the
strict `EnvParser` rejects — so a secret under a dash/digit/dot/emoji key never
reaches the schema, and its drift is invisible to `validate` too (round-trip
hole). Worse, it even discarded **valid** non-ASCII identifiers (`CAFÉ`, `ΑΛΦΑ`).

## Fix

The sanitize/alias machinery already existed but only ran on parser-accepted
keys. Feed the parser-rejected keys through the same path:

| `.env` key | before | after |
|---|---|---|
| `1PASSWORD_TOKEN` | dropped + `[WARN]` | `field_1PASSWORD_TOKEN: str = Field(alias='1PASSWORD_TOKEN')` |
| `X-API-KEY` | dropped | `X_API_KEY: str = Field(alias='X-API-KEY')` |
| `KEY🔑` | dropped | sanitized + aliased |
| `CAFÉ`, `ΑΛΦΑ` | dropped as "non-identifier" | bare field, no alias |

Values for recovered keys are unquoted with the parser's own helpers
(single-source). The old drop-and-warn path — including the public
`api.init` `UserWarning` — is removed; there's nothing left to drop.

Also: write the generated module with `encoding="utf-8"` (`init_cmd` + `api`) so a
non-ASCII field name round-trips on platforms whose default encoding isn't UTF-8
(the Windows leg of the matrix, #445).

## Tests / docs

Updated the old drop/warn tests (`test_cli`, `test_api`) to the new alias
behaviour, added a case asserting Unicode identifiers stay bare while an emoji
key aliases, and verified end-to-end on macOS (all keys land in the schema, the
module imports, aliases bind back). Full non-integration suite green (2467);
ruff/format/pyrefly/bandit/markdownlint clean. Docs synced (`docs/cli/init.md`).

Refs #443, #445

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Environment variables with non-identifier names (e.g., `2FA_ENABLED`, `MY-DASH-VAR`) are now included in generated settings with proper field aliases.
  * Enhanced support for Unicode identifiers in environment variable names.

* **Bug Fixes**
  * Output files now use UTF-8 encoding explicitly.
  * Settings schema generation preserves all environment variables.

* **Documentation**
  * Updated guides for variable name handling and sanitization practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a data-loss bug where `init` silently dropped every `.env` key the strict `EnvParser` rejected (leading digits, dashes, dots, emoji, and valid non-ASCII identifiers like `CAFÉ`). Rejected keys are now recovered via a second raw-assignment scan, run through the existing sanitize/alias pipeline, and emitted as aliased fields — so the generated module is both complete and importable.

- `EnvParser.value_from_raw` is promoted to a public method so the recovery path (`_unparsed_assignments`) reuses canonical unquoting logic without calling private helpers.
- The `SettingsGeneration.unparsed_keys` field and all drop/warn paths (`UserWarning` in `api.init`, `[WARN]` in CLI) are removed since no key is dropped any more.
- File writes in both `init_cmd` and `api` now pass `encoding=\"utf-8\"` explicitly, ensuring non-ASCII field names round-trip correctly on platforms whose default encoding isn't UTF-8.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change recovers previously-dropped keys and aliases them into the schema without altering any existing key paths.

Every changed code path has a clear, well-reasoned implementation: deduplication in `_unparsed_assignments` prevents double-emission, `value_from_raw` is the single source of unquoting for both parsed and recovered keys, and the `_sanitize_identifier` / `_resolve_field_name` logic that already handled keywords is unchanged. End-to-end importability tests cover the non-identifier and Unicode edge cases.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/envdrift/cli_commands/init_cmd.py | Core of the fix: `_unparsed_assignments` now returns a `name -> value` dict for parser-rejected keys, `generate_settings_module` merges it with parsed keys before rendering, and drop/warn paths are removed. |
| src/envdrift/core/parser.py | Introduces `value_from_raw` as a public method on `EnvParser`, consolidating inline-comment-strip + unquote into a single canonical path. |
| src/envdrift/api.py | Removes the `warnings.warn` path and adds `encoding='utf-8'` to `output.write_text`. |
| tests/unit/test_api.py | Replaces warn/drop tests with alias-content checks and an importability proof; adds a no-spurious-warnings guard. |
| tests/unit/test_cli.py | Mirrors API test updates for the CLI path; new test verifies Greek/emoji edge cases end-to-end by importing the generated module. |
| docs/cli/init.md | Updates the non-identifier key section from warn-and-drop to alias, syncing docs with the new behaviour. |

</details>

<sub>Reviews (4): Last reviewed commit: ["docs(init): make all alias examples sing..."](https://github.com/jainal09/envdrift/commit/11c893d0a834bce335574221a1d5c54d109d63d5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36441419)</sub>

<!-- /greptile_comment -->