### PR TITLE
fix(decrypt): honest no-op on non-encrypted files, never corrupt them

### DIFF
--- a/docs/cli/decrypt.md
+++ b/docs/cli/decrypt.md
@@ -20,6 +20,14 @@ It can also **verify** that a key stored in your vault can decrypt the file with
 - Viewing encrypted values
 - Migrating to a different encryption system
 
+### Honest no-op on non-encrypted files
+
+If the target file has no encrypted values, `decrypt` reports an honest no-op
+(`Nothing to decrypt: <file> has no encrypted values.`) instead of claiming a
+decryption happened. The file is left byte-for-byte untouched — the backend is
+not invoked at all — so a plaintext file (including one with CRLF line endings)
+or a non-`.env` binary file is never silently rewritten or corrupted.
+
 ## Arguments
 
 | Argument   | Description                     | Default |

--- a/docs/cli/decrypt.md
+++ b/docs/cli/decrypt.md
@@ -20,13 +20,14 @@ It can also **verify** that a key stored in your vault can decrypt the file with
 - Viewing encrypted values
 - Migrating to a different encryption system
 
-### Honest no-op on non-encrypted files
+### Honest no-op on non-encrypted files (dotenvx backend)
 
-If the target file has no encrypted values, `decrypt` reports an honest no-op
-(`Nothing to decrypt: <file> has no encrypted values.`) instead of claiming a
-decryption happened. The file is left byte-for-byte untouched — the backend is
-not invoked at all — so a plaintext file (including one with CRLF line endings)
-or a non-`.env` binary file is never silently rewritten or corrupted.
+With the **dotenvx** backend, if the target file has no encrypted values
+`decrypt` reports an honest no-op (`Nothing to decrypt: <file> has no encrypted
+values.`) instead of claiming a decryption happened. The file is left
+byte-for-byte untouched — dotenvx is not invoked at all — so a plaintext file
+(including one with CRLF line endings) or a non-`.env` binary file is never
+silently rewritten or corrupted.
 
 ## Arguments
 

--- a/src/envdrift/cli_commands/encryption.py
+++ b/src/envdrift/cli_commands/encryption.py
@@ -17,7 +17,11 @@ from envdrift.core.encryption import EncryptionDetector
 from envdrift.core.parser import EnvParser
 from envdrift.core.schema import SchemaLoader, SchemaLoadError
 from envdrift.encryption import EncryptionProvider, get_encryption_backend
-from envdrift.encryption.base import EncryptionBackendError, EncryptionNotFoundError
+from envdrift.encryption.base import (
+    EncryptionBackendError,
+    EncryptionNotFoundError,
+    EncryptionResult,
+)
 from envdrift.output.rich import (
     console,
     print_encryption_report,
@@ -491,6 +495,22 @@ def _verify_decryption_with_vault(
         return False
 
 
+def _report_decrypt_result(result: EncryptionResult, env_file: Path, backend_name: str) -> None:
+    """Print a decrypt outcome and exit nonzero on failure.
+
+    Distinguishes a real decryption from an honest no-op (``changed=False`` — e.g.
+    a file with no encrypted values) so the message is accurate instead of a
+    misleading "Decrypted".
+    """
+    if not result.success:
+        print_error(result.message)
+        raise typer.Exit(code=1)
+    if result.changed:
+        print_success(f"Decrypted {env_file} using {backend_name}")
+    else:
+        print_warning(result.message)
+
+
 def decrypt_cmd(
     env_file: Annotated[Path, typer.Argument(help="Path to encrypted .env file")] = Path(".env"),
     backend: Annotated[
@@ -672,15 +692,7 @@ def decrypt_cmd(
             raise typer.Exit(code=1)
 
         result = encryption_backend.decrypt(env_file)
-        if result.success:
-            if result.changed:
-                print_success(f"Decrypted {env_file} using {encryption_backend.name}")
-            else:
-                # Honest no-op: the file had no encrypted values to decrypt.
-                print_warning(result.message)
-        else:
-            print_error(result.message)
-            raise typer.Exit(code=1)
+        _report_decrypt_result(result, env_file, encryption_backend.name)
 
     except EncryptionNotFoundError as e:
         print_error(str(e))

--- a/src/envdrift/cli_commands/encryption.py
+++ b/src/envdrift/cli_commands/encryption.py
@@ -673,7 +673,11 @@ def decrypt_cmd(
 
         result = encryption_backend.decrypt(env_file)
         if result.success:
-            print_success(f"Decrypted {env_file} using {encryption_backend.name}")
+            if result.changed:
+                print_success(f"Decrypted {env_file} using {encryption_backend.name}")
+            else:
+                # Honest no-op: the file had no encrypted values to decrypt.
+                print_warning(result.message)
         else:
             print_error(result.message)
             raise typer.Exit(code=1)

--- a/src/envdrift/encryption/base.py
+++ b/src/envdrift/encryption/base.py
@@ -35,6 +35,10 @@ class EncryptionResult:
     success: bool
     message: str
     file_path: Path | None = None
+    # False when the operation succeeded but made no change (e.g. decrypting a
+    # file that has no encrypted values). Lets callers report an honest no-op
+    # instead of a misleading "Decrypted".
+    changed: bool = True
 
 
 class EncryptionBackend(ABC):

--- a/src/envdrift/encryption/dotenvx.py
+++ b/src/envdrift/encryption/dotenvx.py
@@ -203,6 +203,23 @@ class DotenvxEncryptionBackend(EncryptionBackend):
                 file_path=env_file,
             )
 
+        from envdrift.core.partial_encryption import is_file_encrypted
+
+        # Nothing to decrypt: the file holds no ciphertext value. dotenvx would
+        # still rewrite it (line-ending normalization, header cleanup) and exit 0
+        # — and handed a binary blob it corrupts the file outright — so report an
+        # honest no-op instead of a misleading "[OK] Decrypted" and never invoke
+        # the backend on a file that isn't encrypted. ``is_file_encrypted`` reads
+        # with errors="replace", so a binary/non-UTF-8 file cannot crash here
+        # (envdrift #443).
+        if not is_file_encrypted(env_file):
+            return EncryptionResult(
+                success=True,
+                changed=False,
+                message=f"Nothing to decrypt: {env_file} has no encrypted values.",
+                file_path=env_file,
+            )
+
         if not self.is_installed():
             raise EncryptionNotFoundError(
                 f"dotenvx is not installed.\n{self.install_instructions()}"
@@ -218,13 +235,27 @@ class DotenvxEncryptionBackend(EncryptionBackend):
                 env=kwargs.get("env"),
                 cwd=kwargs.get("cwd"),
             )
-            return EncryptionResult(
-                success=True,
-                message=f"Decrypted {env_file}",
-                file_path=env_file,
-            )
         except DotenvxError as e:
             raise EncryptionBackendError(f"dotenvx decryption failed: {e}") from e
+
+        # Verify the decryption took effect rather than trusting the exit code:
+        # dotenvx can exit 0 while leaving ciphertext in place when the key is
+        # missing or invalid. If any encrypted value survived, report failure.
+        if is_file_encrypted(env_file):
+            return EncryptionResult(
+                success=False,
+                message=(
+                    f"Decryption did not take effect: {env_file} still contains "
+                    "encrypted values. The decryption key may be missing or invalid."
+                ),
+                file_path=env_file,
+            )
+
+        return EncryptionResult(
+            success=True,
+            message=f"Decrypted {env_file}",
+            file_path=env_file,
+        )
 
     def detect_encryption_status(self, value: str) -> EncryptionStatus:
         """

--- a/src/envdrift/encryption/dotenvx.py
+++ b/src/envdrift/encryption/dotenvx.py
@@ -244,6 +244,7 @@ class DotenvxEncryptionBackend(EncryptionBackend):
         if is_file_encrypted(env_file):
             return EncryptionResult(
                 success=False,
+                changed=False,
                 message=(
                     f"Decryption did not take effect: {env_file} still contains "
                     "encrypted values. The decryption key may be missing or invalid."

--- a/tests/integration/test_decrypt_outcome_bench.py
+++ b/tests/integration/test_decrypt_outcome_bench.py
@@ -1,0 +1,124 @@
+"""Real-outcome bench for the dotenvx ``decrypt`` seam (envdrift #443).
+
+Every test drives the REAL decryption seam (``DotenvxEncryptionBackend`` over the
+real ``dotenvx`` binary) and asserts the TRUE on-disk state. The adversarial
+sweep showed the pre-#443 backend reported ``[OK] Decrypted`` unconditionally:
+
+* on a plaintext file it claimed a decryption happened (and dotenvx's line-ending
+  normalisation silently rewrote bytes);
+* on a binary blob it corrupted the file outright while still exiting 0.
+
+The fix reports an honest no-op (``changed=False``) and never invokes dotenvx on
+a file that holds no ciphertext, so a non-encrypted/binary file is left byte-for-
+byte untouched. Tests that need the real binary skip-gate cleanly when absent.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from envdrift.encryption.base import EncryptionBackendError
+from envdrift.encryption.dotenvx import DotenvxEncryptionBackend
+
+# Mark all tests in this module
+pytestmark = [pytest.mark.integration]
+
+
+@pytest.fixture
+def dotenvx_on_path() -> None:
+    """Skip the test if the real ``dotenvx`` binary is not installed."""
+    if shutil.which("dotenvx") is None:
+        pytest.skip("dotenvx binary not found on PATH")
+
+
+# --- A non-encrypted file is an honest no-op, never mutated --------------------
+# These assert the guard, which runs before dotenvx is invoked (no binary needed).
+
+
+def test_decrypt_plaintext_file_is_honest_noop(tmp_path: Path) -> None:
+    """#18: a plaintext .env reports 'nothing to decrypt', not '[OK] Decrypted'."""
+    env_file = tmp_path / ".env"
+    env_file.write_text("API_KEY=plainvalue\nPORT=8080\n", encoding="utf-8")
+    before = env_file.read_bytes()
+
+    result = DotenvxEncryptionBackend().decrypt(env_file)
+
+    assert result.success is True
+    assert result.changed is False
+    assert "nothing to decrypt" in result.message.lower()
+    # The file is byte-identical: no spurious rewrite.
+    assert env_file.read_bytes() == before
+
+
+def test_decrypt_crlf_plaintext_file_leaves_bytes_untouched(tmp_path: Path) -> None:
+    """#15: a non-encrypted CRLF file must not have its CR bytes stripped."""
+    env_file = tmp_path / ".env"
+    env_file.write_bytes(b"API_KEY=plainvalue\r\nPORT=8080\r\n")
+    before = env_file.read_bytes()
+
+    result = DotenvxEncryptionBackend().decrypt(env_file)
+
+    assert result.changed is False
+    assert env_file.read_bytes() == before  # CRLF preserved exactly
+
+
+def test_decrypt_binary_blob_is_not_corrupted(tmp_path: Path) -> None:
+    """#2: a binary blob must not be corrupted (or crash) — it has no ciphertext."""
+    env_file = tmp_path / ".env"
+    blob = bytes(range(256)) * 4  # includes NUL and non-UTF-8 bytes
+    env_file.write_bytes(blob)
+
+    result = DotenvxEncryptionBackend().decrypt(env_file)
+
+    assert result.success is True
+    assert result.changed is False
+    # The blob is byte-for-byte intact (no silent corruption, no UnicodeDecodeError).
+    assert env_file.read_bytes() == blob
+
+
+# --- A genuinely encrypted file round-trips; a bad key is reported -------------
+
+
+def test_decrypt_encrypted_file_restores_plaintext(tmp_path: Path, dotenvx_on_path: None) -> None:
+    """Control: a real encrypt→decrypt round-trip restores the plaintext."""
+    env_file = tmp_path / ".env"
+    env_file.write_text("API_KEY=supersecret123\n", encoding="utf-8")
+    backend = DotenvxEncryptionBackend()
+
+    assert backend.encrypt(env_file, cwd=tmp_path).success is True
+    assert "encrypted:" in env_file.read_text()
+
+    result = backend.decrypt(env_file, cwd=tmp_path)
+
+    assert result.success is True
+    assert result.changed is True
+    on_disk = env_file.read_text()
+    assert "encrypted:" not in on_disk
+    assert "API_KEY=supersecret123" in on_disk
+
+
+def test_decrypt_with_corrupted_key_errors_and_preserves_ciphertext(
+    tmp_path: Path, dotenvx_on_path: None
+) -> None:
+    """A key that cannot decrypt the ciphertext must error cleanly, not corrupt it.
+
+    dotenvx exits non-zero with INVALID_PRIVATE_KEY here, which the wrapper turns
+    into a clean ``EncryptionBackendError`` (the CLI renders it as ``[ERROR]
+    Decryption failed`` + exit 1). The ciphertext on disk must be untouched.
+    """
+    env_file = tmp_path / ".env"
+    env_file.write_text("API_KEY=supersecret123\n", encoding="utf-8")
+    backend = DotenvxEncryptionBackend()
+    assert backend.encrypt(env_file, cwd=tmp_path).success is True
+
+    # Corrupt the key so dotenvx cannot decrypt the ciphertext.
+    (tmp_path / ".env.keys").write_text("not a key @@@\nDOTENV_PRIVATE_KEY=NOTHEX_zzz\n")
+
+    with pytest.raises(EncryptionBackendError):
+        backend.decrypt(env_file, cwd=tmp_path)
+
+    # The ciphertext is still on disk — a failed decrypt must not corrupt it.
+    assert "encrypted:" in env_file.read_text()

--- a/tests/unit/coverage/test_cov_cli_commands_encryption.py
+++ b/tests/unit/coverage/test_cov_cli_commands_encryption.py
@@ -728,5 +728,30 @@ def test_decrypt_not_found_error_exits_nonzero(monkeypatch, tmp_path: Path):
     assert "dotenvx binary missing" in result.output
 
 
+def test_decrypt_noop_reports_nothing_to_decrypt(monkeypatch, tmp_path):
+    """#443: the CLI prints an honest no-op (not 'Decrypted') when changed=False."""
+    env_file = tmp_path / ".env"
+    env_file.write_text("API_KEY=plainvalue\n")
+    _no_hook_errors(monkeypatch)
+    monkeypatch.setattr(f"{ENC_MOD}._load_encryption_config", lambda: (EnvdriftConfig(), None))
+
+    class NoopBackend(DummyEncryptionBackend):
+        def decrypt(self, env_file, **kwargs):  # type: ignore[override]
+            return EncryptionResult(
+                success=True,
+                changed=False,
+                message=f"Nothing to decrypt: {env_file} has no encrypted values.",
+                file_path=Path(env_file),
+            )
+
+    monkeypatch.setattr(f"{ENC_MOD}.get_encryption_backend", lambda *a, **k: NoopBackend())
+
+    result = runner.invoke(app, ["decrypt", str(env_file), "--backend", "dotenvx"])
+
+    assert result.exit_code == 0, result.output
+    # Normalise whitespace: Rich may soft-wrap the long tmp path in the message.
+    assert "nothing to decrypt" in " ".join(result.output.lower().split())
+
+
 if __name__ == "__main__":  # pragma: no cover
     raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/unit/test_encryption_backends.py
+++ b/tests/unit/test_encryption_backends.py
@@ -291,10 +291,20 @@ class TestDotenvxEncryptionBackend:
         env_file = tmp_path / ".env"
         env_file.write_text("KEY=encrypted:abc")
 
+        # The mock must model the seam's real effect: a genuine dotenvx decrypt
+        # replaces ciphertext with plaintext. The backend now verifies the on-disk
+        # outcome (envdrift #443), so a no-op mock would correctly read as
+        # "decryption did not take effect". Make the mock honest.
+        def _fake_decrypt(**_kwargs):
+            env_file.write_text("KEY=value")
+
+        mock_wrapper.decrypt.side_effect = _fake_decrypt
+
         backend = DotenvxEncryptionBackend()
         result = backend.decrypt(env_file)
 
         assert result.success is True
+        assert result.changed is True
         assert "Decrypted" in result.message
 
     @patch("envdrift.integrations.dotenvx.DotenvxWrapper")

--- a/tests/unit/test_encryption_backends.py
+++ b/tests/unit/test_encryption_backends.py
@@ -307,6 +307,45 @@ class TestDotenvxEncryptionBackend:
         assert result.changed is True
         assert "Decrypted" in result.message
 
+    def test_decrypt_noop_on_file_with_no_ciphertext(self, tmp_path):
+        """#443: a file with no encrypted values is an honest no-op, not 'Decrypted'.
+
+        The pre-check returns before dotenvx is consulted, so this needs no binary.
+        """
+        env_file = tmp_path / ".env"
+        env_file.write_text("API_KEY=plainvalue\nPORT=8080\n")
+        before = env_file.read_bytes()
+
+        result = DotenvxEncryptionBackend().decrypt(env_file)
+
+        assert result.success is True
+        assert result.changed is False
+        assert "nothing to decrypt" in result.message.lower()
+        assert env_file.read_bytes() == before  # not rewritten
+
+    @patch("envdrift.integrations.dotenvx.DotenvxWrapper")
+    def test_decrypt_reports_failure_when_ciphertext_survives(self, mock_wrapper_class, tmp_path):
+        """#443: dotenvx exiting 0 without decrypting must be caught by the outcome check.
+
+        Models the silent-failure seam: the wrapper "succeeds" but leaves the
+        ciphertext on disk (a missing/invalid key). The backend re-reads the file
+        and reports failure instead of trusting the exit code.
+        """
+        mock_wrapper = MagicMock()
+        mock_wrapper.is_installed.return_value = True
+        mock_wrapper.decrypt.side_effect = lambda **_kwargs: None  # no-op: ciphertext stays
+        mock_wrapper_class.return_value = mock_wrapper
+
+        env_file = tmp_path / ".env"
+        env_file.write_text('API_KEY="encrypted:BExampleCiphertext"')
+
+        result = DotenvxEncryptionBackend().decrypt(env_file)
+
+        assert result.success is False
+        assert result.changed is False
+        assert "did not take effect" in result.message.lower()
+        assert "encrypted:" in env_file.read_text()  # ciphertext untouched, not lost
+
     @patch("envdrift.integrations.dotenvx.DotenvxWrapper")
     def test_encrypt_wraps_dotenvx_error(self, mock_wrapper_class, tmp_path):
         """encrypt should wrap dotenvx errors."""


### PR DESCRIPTION
## What

The adversarial sweep (#443) found the dotenvx `decrypt` backend reported
`[OK] Decrypted` **unconditionally**, trusting the exit code:

- a **plaintext** `.env` was reported as decrypted, and dotenvx's line-ending
  normalisation silently rewrote bytes (stripping `CR` on CRLF files);
- a **binary blob** handed to `decrypt` was **corrupted outright** while exiting 0.

## Fix

A pre-check at the shared backend seam: if the file holds no ciphertext value
(`is_file_encrypted`, which reads `errors="replace"` so binary input can't crash
it), report an **honest no-op** and never invoke dotenvx. A new
`EncryptionResult.changed` flag lets the CLI print `Nothing to decrypt: …`
instead of a misleading `Decrypted`. After a real decrypt, verify no ciphertext
survived (bad-key backstop) rather than trusting the exit code.

## The bench (real dotenvx)

`tests/integration/test_decrypt_outcome_bench.py` asserts true on-disk state:
plaintext no-op leaves bytes identical · CRLF bytes preserved · a **binary blob
is byte-for-byte intact** (no corruption, no `UnicodeDecodeError`) · a real
round-trip restores plaintext · a corrupted key errors cleanly without
corrupting the ciphertext. Proven **red-without-fix → green-with-fix**.

The mocked unit decrypt test is updated to model the seam's real effect (write
plaintext) so it stays honest under the new outcome check. Full non-integration
suite green (2466); all gates clean; `docs/cli/decrypt.md` synced.

## Scope

dotenvx backend only. The binary→`UnicodeDecodeError` traceback on the
**auto-detect** and **SOPS** paths (#443 #16/#17) is the separate traceback /
sops theme.

Refs #443

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two file-corruption bugs in the dotenvx `decrypt` backend: it was calling dotenvx unconditionally, which caused plaintext files to be silently rewritten (stripping CRLF bytes) and binary blobs to be corrupted outright, while still reporting success. The fix adds a pre-check using `is_file_encrypted` (reading with `errors="replace"` to tolerate binary input) and returns an honest no-op result (`changed=False`) without ever invoking dotenvx when no ciphertext is present. A post-decrypt backstop re-reads the file after a real decrypt to confirm ciphertext was removed rather than trusting the exit code.

- **`EncryptionResult.changed`** flag added to `base.py` so the CLI can distinguish a real decryption from a no-op and print an accurate message.
- **`_report_decrypt_result`** extracted in `encryption.py` to route the three outcomes (success, no-op, failure) to the correct console output and exit code.
- **Integration bench** (`test_decrypt_outcome_bench.py`) asserts true on-disk byte state for plaintext, CRLF, binary, round-trip, and corrupted-key scenarios; the first three run without the dotenvx binary at all.

<h3>Confidence Score: 5/5</h3>

Safe to merge. The change is additive and defensive: it only prevents dotenvx from being invoked when there is nothing to decrypt, and adds a post-decrypt check to catch silent key failures.

The pre-check, post-decrypt backstop, and the `changed` flag are all covered by unit tests (including the exact backstop scenario where exit 0 leaves ciphertext) and integration tests that assert byte-level file identity. The `is_file_encrypted` function used for both checks already existed and is tested separately. No logic paths were removed; the change only adds guards before and after the existing dotenvx invocation.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/envdrift/encryption/dotenvx.py | Core fix: pre-check with `is_file_encrypted` before invoking dotenvx, and post-decrypt backstop that re-reads the file to confirm ciphertext was removed rather than trusting exit code 0. Both checks use `errors="replace"` so binary files can't crash the guard. Logic is correct for all documented edge cases. |
| src/envdrift/encryption/base.py | Adds `changed: bool = True` field to `EncryptionResult` dataclass. Default of `True` is correct for backwards compatibility; existing callers that don't set it (encrypt path, file-not-found) continue to signal "changed" as before, and the field is only consumed in the `success=True` branch of `_report_decrypt_result`. |
| src/envdrift/cli_commands/encryption.py | Extracts `_report_decrypt_result` helper to distinguish real decryption (`changed=True` → success message) from honest no-op (`changed=False` → warning message) and failure (exit 1). The surrounding `decrypt_cmd` `is_installed()` guard at line 689 still fires before the backend's no-op path for users without dotenvx installed, but that is pre-existing behaviour unchanged by this PR. |
| tests/integration/test_decrypt_outcome_bench.py | New integration bench covering: plaintext no-op, CRLF byte-identity, binary blob non-corruption (all three run without the dotenvx binary), plus binary-requiring round-trip restore and corrupted-key error-without-corruption. Tests correctly skip when the binary is absent via the `dotenvx_on_path` fixture. |
| tests/unit/test_encryption_backends.py | Updated `test_decrypt_success` to write plaintext in the mock (so the post-decrypt `is_file_encrypted` check passes), and added two new unit tests: honest no-op for plaintext files and the backstop path where ciphertext survives exit 0. All three key scenarios are now covered at the unit level. |
| tests/unit/coverage/test_cov_cli_commands_encryption.py | Adds `test_decrypt_noop_reports_nothing_to_decrypt` which verifies the CLI prints a "nothing to decrypt" warning (exit 0) when the backend returns `changed=False`. Uses a dummy backend so it doesn't touch dotenvx at all. |
| docs/cli/decrypt.md | Documentation-only addition describing the honest no-op behaviour for the dotenvx backend. Accurately reflects the new logic. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CLI as decrypt_cmd (CLI)
    participant B as DotenvxEncryptionBackend
    participant IFE as is_file_encrypted()
    participant DX as dotenvx binary

    CLI->>CLI: is_installed() guard (pre-existing)
    CLI->>B: decrypt(env_file)
    B->>IFE: "is_file_encrypted(env_file) [errors=replace]"
    alt No ciphertext in file (plaintext / binary blob)
        IFE-->>B: False
        B-->>CLI: "EncryptionResult(success=True, changed=False)"
        CLI->>CLI: print_warning(Nothing to decrypt)
    else File has ciphertext values
        IFE-->>B: True
        B->>B: is_installed() check
        B->>DX: wrapper.decrypt(env_file)
        alt dotenvx exits non-zero
            DX-->>B: DotenvxError
            B-->>CLI: raises EncryptionBackendError
            CLI->>CLI: print_error + exit 1
        else dotenvx exits 0
            DX-->>B: ok
            B->>IFE: is_file_encrypted(env_file) [post-decrypt backstop]
            alt Ciphertext survived (bad/missing key)
                IFE-->>B: True
                B-->>CLI: "EncryptionResult(success=False, changed=False)"
                CLI->>CLI: print_error + exit 1
            else All ciphertext decrypted
                IFE-->>B: False
                B-->>CLI: "EncryptionResult(success=True, changed=True)"
                CLI->>CLI: print_success(Decrypted)
            end
        end
    end
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `tests/unit/test_encryption_backends.py`, line 275-299 ([link](https://github.com/jainal09/envdrift/blob/8df3d5ba018508649bc43547b4bb5e0b0f4ac00c/tests/unit/test_encryption_backends.py#L275-L299)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Post-decrypt backstop path has no unit test**

   The PR's key new invariant is "if dotenvx exits 0 but ciphertext survives, report `success=False`." The updated `test_decrypt_success` exercises the happy path (mock writes plaintext → `is_file_encrypted` returns False → success). The `DotenvxError` path is covered by `test_decrypt_wraps_dotenvx_error`. But there is no unit test where the mock leaves the file encrypted (i.e., does not write plaintext), which is the exact scenario the backstop at lines 200–211 of `dotenvx.py` is designed to catch. Without it, a regression that removes or short-circuits the post-decrypt check would go undetected by the unit suite.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["fix(decrypt): address review — coverage,..."](https://github.com/jainal09/envdrift/commit/c735d76ce4f6cb8c2d1435e2eb70426620458571) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36441478)</sub>

<!-- /greptile_comment -->