### PR TITLE
fix(init/validate): handle non-identifier & Unicode env keys end-to-end

### DIFF
--- a/docs/cli/init.md
+++ b/docs/cli/init.md
@@ -150,7 +150,7 @@ The generated module is always valid, importable Python:
   name plus a Pydantic `alias` so the field still binds to the original variable:
 
   ```python
-  class_: str = Field(alias="class")
+  class_: str = Field(alias='class')
   ```
 
 - **Pydantic-reserved names get an alias.** A key that is a valid identifier but
@@ -160,7 +160,7 @@ The generated module is always valid, importable Python:
   `alias`, so it cannot raise at import or shadow model internals:
 
   ```python
-  field_model_dump: str = Field(alias="model_dump")
+  field_model_dump: str = Field(alias='model_dump')
   ```
 
 - **Non-identifier keys are aliased, not dropped.** Keys that are not

--- a/docs/cli/init.md
+++ b/docs/cli/init.md
@@ -177,6 +177,11 @@ The generated module is always valid, importable Python:
 - **Valid non-ASCII identifiers are kept verbatim.** A key that passes
   `str.isidentifier()` (e.g. `CAFÉ`, `ΑΛΦΑ`) becomes a bare field with no alias.
 
+- **The round-trip holds.** `envdrift validate` parses the `.env` the same way
+  (recovering non-identifier / non-ASCII keys) and matches schema fields by their
+  alias, so `init` → `validate` passes instead of falsely flagging the aliased
+  fields as missing.
+
 - **Invalid class names fail fast.** A `--class-name` that is not a valid Python
   identifier (e.g. `123Bad`) or is a keyword (e.g. `class`) errors with a
   non-zero exit code instead of writing a module that would raise `SyntaxError`

--- a/docs/cli/init.md
+++ b/docs/cli/init.md
@@ -163,10 +163,19 @@ The generated module is always valid, importable Python:
   field_model_dump: str = Field(alias="model_dump")
   ```
 
-- **Non-identifier keys are reported.** Keys the parser cannot read because they
-  are not identifier-style (a leading digit like `2FA_ENABLED`, or a dash like
-  `MY-DASH-VAR`) are skipped and listed in a `[WARN]` line, never silently
-  dropped.
+- **Non-identifier keys are aliased, not dropped.** Keys that are not
+  identifier-style (a leading digit like `2FA_ENABLED`, a dash like
+  `MY-DASH-VAR`, a dot, or an emoji) are emitted with a sanitized attribute name
+  plus a Pydantic `alias`, so every key ends up in the schema and still binds to
+  the original environment variable:
+
+  ```python
+  field_2FA_ENABLED: str = Field(alias="2FA_ENABLED")
+  MY_DASH_VAR: str = Field(alias="MY-DASH-VAR")
+  ```
+
+- **Valid non-ASCII identifiers are kept verbatim.** A key that passes
+  `str.isidentifier()` (e.g. `CAFÉ`, `ΑΛΦΑ`) becomes a bare field with no alias.
 
 - **Invalid class names fail fast.** A `--class-name` that is not a valid Python
   identifier (e.g. `123Bad`) or is a keyword (e.g. `class`) errors with a

--- a/docs/cli/init.md
+++ b/docs/cli/init.md
@@ -170,8 +170,8 @@ The generated module is always valid, importable Python:
   the original environment variable:
 
   ```python
-  field_2FA_ENABLED: str = Field(alias="2FA_ENABLED")
-  MY_DASH_VAR: str = Field(alias="MY-DASH-VAR")
+  field_2FA_ENABLED: str = Field(alias='2FA_ENABLED')
+  MY_DASH_VAR: str = Field(alias='MY-DASH-VAR')
   ```
 
 - **Valid non-ASCII identifiers are kept verbatim.** A key that passes

--- a/src/envdrift/api.py
+++ b/src/envdrift/api.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import warnings
 from pathlib import Path
 
 from envdrift.core.diff import DiffEngine, DiffResult
@@ -113,14 +112,11 @@ def init(
         class_name (str): Name to use for the generated Settings class.
         detect_sensitive (bool): If True, attempt to detect sensitive variables and mark them in the generated fields.
 
-    Non-identifier .env keys (leading digits, dashes) are skipped by the strict
-    parser; keys that are valid identifiers but Python keywords (`class`,
-    `import`) are emitted with a sanitized attribute name plus a Pydantic
-    ``alias`` so the generated module always imports cleanly.
-
-    Any keys the strict parser cannot read (e.g. ``2FA_ENABLED``, ``MY-DASH-VAR``)
-    are dropped from the generated module; the API surfaces them via a
-    ``UserWarning`` so callers are not left silently with an incomplete file.
+    Every .env key becomes a field. Keys the strict parser rejects (leading
+    digits, dashes, dots) and Python keywords (`class`, `import`) are emitted
+    with a sanitized attribute name plus a Pydantic ``alias`` so the generated
+    module always imports cleanly while still binding to the original variable;
+    a valid non-ASCII identifier (``CAFÉ``) is emitted unchanged.
 
     Returns:
         Path: The path to the written settings file.
@@ -136,16 +132,7 @@ def init(
 
     result = generate_settings_module(env_file, class_name, detect_sensitive)
 
-    # Warn *before* writing: a caller running under
-    # ``warnings.filterwarnings("error")`` promotes this to an exception, and we
-    # must not leave a half-written settings.py on disk when that happens.
-    if result.unparsed_keys:
-        warnings.warn(
-            "Skipped .env variable(s) the parser cannot read "
-            f"(non-identifier keys): {', '.join(result.unparsed_keys)}",
-            UserWarning,
-            stacklevel=2,
-        )
-
-    output.write_text(result.source)
+    # encoding="utf-8" so a non-ASCII field name/value round-trips on platforms
+    # whose default text encoding is not UTF-8.
+    output.write_text(result.source, encoding="utf-8")
     return output

--- a/src/envdrift/cli_commands/init_cmd.py
+++ b/src/envdrift/cli_commands/init_cmd.py
@@ -102,8 +102,7 @@ def _unparsed_assignments(env_file: Path, env: EnvFile) -> dict[str, str]:
         key = match.group(1)
         if key in env.variables or key in extra:
             continue
-        value = parser._unquote(parser._strip_inline_comment(match.group(2)).strip())
-        extra[key] = value
+        extra[key] = parser.value_from_raw(match.group(2))
     return extra
 
 

--- a/src/envdrift/cli_commands/init_cmd.py
+++ b/src/envdrift/cli_commands/init_cmd.py
@@ -14,12 +14,12 @@ from pydantic_settings import BaseSettings
 
 from envdrift.core.encryption import EncryptionDetector
 from envdrift.core.parser import EnvFile, EnvParser
-from envdrift.output.rich import console, print_error, print_success, print_warning
+from envdrift.output.rich import console, print_error, print_success
 
-# Matches the left-hand side of any `KEY=value` assignment in a raw .env file,
-# accepting keys the strict EnvParser.LINE_PATTERN rejects (leading digits,
-# dashes, etc.) so init can warn about variables it would otherwise drop.
-_RAW_ASSIGNMENT_PATTERN = re.compile(r"^\s*(?:export\s+)?([^\s=#]+)\s*=")
+# Matches `KEY=value` for ANY key the strict EnvParser.LINE_PATTERN rejects
+# (leading digits, dashes, dots, non-ASCII letters, …) so init can still emit a
+# field for it — sanitized + aliased — instead of silently dropping it.
+_RAW_ASSIGNMENT_PATTERN = re.compile(r"^\s*(?:export\s+)?([^\s=#]+)\s*=(.*)$")
 
 # Pydantic protects the ``model_`` attribute namespace: a BaseModel/BaseSettings
 # field whose name starts with this prefix either raises at import (``model_dump``
@@ -57,8 +57,6 @@ class SettingsGeneration:
     source: str
     sensitive_vars: set[str] = field(default_factory=set)
     aliased_count: int = 0
-    # .env keys present in the raw text but rejected by the strict parser.
-    unparsed_keys: list[str] = field(default_factory=list)
 
 
 def _sanitize_identifier(name: str) -> str:
@@ -82,17 +80,31 @@ def _sanitize_identifier(name: str) -> str:
     return sanitized
 
 
-def _raw_assignment_keys(text: str) -> list[str]:
-    """Extract every assignment key from raw .env text (parser-independent)."""
-    keys: list[str] = []
-    for raw_line in text.splitlines():
+def _unparsed_assignments(env_file: Path, env: EnvFile) -> dict[str, str]:
+    """Return ``name -> value`` for assignment lines the strict parser rejected.
+
+    ``EnvParser`` only accepts identifier-style ASCII keys, so ``2FA_ENABLED``,
+    ``X-API-KEY`` or a non-ASCII identifier such as ``CAFÉ`` never become
+    variables. Those keys are recovered here — values are unquoted with the
+    parser's own helpers so the value handling stays single-source — and fed
+    through the same sanitize/alias path as parsed keys instead of being dropped.
+    Keys the parser already accepted are skipped (they come from ``env``).
+    """
+    parser = EnvParser()
+    extra: dict[str, str] = {}
+    for raw_line in env_file.read_text(encoding="utf-8").splitlines():
         line = raw_line.strip()
         if not line or line.startswith("#"):
             continue
         match = _RAW_ASSIGNMENT_PATTERN.match(line)
-        if match:
-            keys.append(match.group(1))
-    return keys
+        if not match:
+            continue
+        key = match.group(1)
+        if key in env.variables or key in extra:
+            continue
+        value = parser._unquote(parser._strip_inline_comment(match.group(2)).strip())
+        extra[key] = value
+    return extra
 
 
 def _needs_sanitizing(name: str) -> bool:
@@ -210,43 +222,31 @@ def _module_header(class_name: str, env_file: Path) -> list[str]:
     ]
 
 
-def _unparsed_keys(env_file: Path, env: EnvFile) -> list[str]:
-    """Return raw .env keys present in the file but rejected by the strict parser.
-
-    The ``EnvParser`` only accepts identifier-style keys, so ``2FA_ENABLED`` or
-    ``MY-DASH-VAR`` never become variables. These are surfaced to the caller to
-    warn about rather than silently drop (``validate`` would later reject them as
-    forbidden extras under ``extra="forbid"``).
-    """
-    raw_keys = _raw_assignment_keys(env_file.read_text(encoding="utf-8"))
-    return [k for k in dict.fromkeys(raw_keys) if k not in env.variables]
-
-
-def _detect_sensitive_vars(env: EnvFile) -> set[str]:
+def _detect_sensitive_vars(values: dict[str, str]) -> set[str]:
     """Return the set of variable names flagged sensitive by name or value."""
     detector = EncryptionDetector()
     return {
         name
-        for name, var in env.variables.items()
-        if detector.is_name_sensitive(name) or detector.is_value_suspicious(var.value)
+        for name, value in values.items()
+        if detector.is_name_sensitive(name) or detector.is_value_suspicious(value)
     }
 
 
-def _render_fields(env: EnvFile, sensitive_vars: set[str]) -> tuple[list[str], int]:
+def _render_fields(values: dict[str, str], sensitive_vars: set[str]) -> tuple[list[str], int]:
     """Render every Settings field line; return the lines and the alias count.
 
     Walks the variables in sorted order so output is deterministic, resolving each
-    to a unique importable attribute name (with an alias when renamed) and an
-    inferred type/default.
+    to a unique importable attribute name (with an alias when the .env key is a
+    non-identifier, keyword, or collides) and an inferred type/default.
     """
     field_lines: list[str] = []
     aliased_count = 0
     used_names: set[str] = set()
-    for var_name, env_var in sorted(env.variables.items()):
+    for var_name, value in sorted(values.items()):
         field_name, alias = _resolve_field_name(var_name, used_names)
         if alias is not None:
             aliased_count += 1
-        type_hint, default_val = _infer_type(env_var.value)
+        type_hint, default_val = _infer_type(value)
         field_lines.append(
             _render_field_line(
                 field_name, type_hint, default_val, alias, var_name in sensitive_vars
@@ -265,11 +265,13 @@ def generate_settings_module(
     Shared by the ``init`` CLI command and the public ``envdrift.api.init`` so
     both entry points generate the same safe, importable Python.
 
-    Guarantees the emitted module is importable:
+    Guarantees the emitted module is importable AND complete (no key dropped):
       * ``class_name`` is validated as a real (non-keyword) identifier.
-      * Each field whose .env key is not a valid identifier (or is a keyword) is
-        emitted with a sanitized attribute name plus a Pydantic ``alias`` so the
-        schema still binds to the original environment variable.
+      * Every .env key becomes a field. A key the strict parser rejects
+        (leading digit, dash, dot, non-ASCII letter) or that is a Python keyword
+        is emitted with a sanitized attribute name plus a Pydantic ``alias`` so
+        the schema still binds to the original environment variable; a valid
+        non-ASCII identifier (``CAFÉ``) becomes a bare field unchanged.
 
     Raises:
         ValueError: If ``class_name`` is not a valid Python identifier.
@@ -278,17 +280,18 @@ def generate_settings_module(
         raise ValueError(f"Invalid class name: {class_name!r} is not a valid Python identifier")
 
     env = EnvParser().parse(env_file)
-    unparsed_keys = _unparsed_keys(env_file, env)
-    sensitive_vars = _detect_sensitive_vars(env) if detect_sensitive else set()
+    # Every assignment in the file, including keys the strict parser rejected.
+    all_values: dict[str, str] = {name: var.value for name, var in env.variables.items()}
+    all_values.update(_unparsed_assignments(env_file, env))
+    sensitive_vars = _detect_sensitive_vars(all_values) if detect_sensitive else set()
 
-    field_lines, aliased_count = _render_fields(env, sensitive_vars)
+    field_lines, aliased_count = _render_fields(all_values, sensitive_vars)
     lines = [*_module_header(class_name, env_file), *field_lines, ""]
 
     return SettingsGeneration(
         source="\n".join(lines),
         sensitive_vars=sensitive_vars,
         aliased_count=aliased_count,
-        unparsed_keys=unparsed_keys,
     )
 
 
@@ -385,18 +388,14 @@ def init(
 
 
 def _write_init_output(result: SettingsGeneration, output: Path, *, force: bool) -> None:
-    """Warn about dropped keys, guard against clobbering, then write the module."""
-    if result.unparsed_keys:
-        print_warning(
-            "Skipped .env variable(s) the parser cannot read "
-            f"(non-identifier keys): {', '.join(result.unparsed_keys)}"
-        )
-
+    """Guard against clobbering an existing file, then write the module."""
     # Guard against clobbering an existing (possibly hand-edited) file.
     if output.exists() and not force:
         print_error(f"Output file already exists: {output} (use --force to overwrite)")
         raise typer.Exit(code=1)
 
-    output.write_text(result.source)
+    # encoding="utf-8" so a non-ASCII field name/value (e.g. a unicode-identifier
+    # key) round-trips on platforms whose default text encoding is not UTF-8.
+    output.write_text(result.source, encoding="utf-8")
     print_success(f"Generated {output}")
     _print_generation_summary(result)

--- a/src/envdrift/cli_commands/init_cmd.py
+++ b/src/envdrift/cli_commands/init_cmd.py
@@ -13,13 +13,8 @@ import typer
 from pydantic_settings import BaseSettings
 
 from envdrift.core.encryption import EncryptionDetector
-from envdrift.core.parser import EnvFile, EnvParser
+from envdrift.core.parser import EnvParser
 from envdrift.output.rich import console, print_error, print_success
-
-# Matches `KEY=value` for ANY key the strict EnvParser.LINE_PATTERN rejects
-# (leading digits, dashes, dots, non-ASCII letters, …) so init can still emit a
-# field for it — sanitized + aliased — instead of silently dropping it.
-_RAW_ASSIGNMENT_PATTERN = re.compile(r"^\s*(?:export\s+)?([^\s=#]+)\s*=(.*)$")
 
 # Pydantic protects the ``model_`` attribute namespace: a BaseModel/BaseSettings
 # field whose name starts with this prefix either raises at import (``model_dump``
@@ -78,32 +73,6 @@ def _sanitize_identifier(name: str) -> str:
     while keyword.iskeyword(sanitized) or keyword.issoftkeyword(sanitized):
         sanitized = f"{sanitized}_"
     return sanitized
-
-
-def _unparsed_assignments(env_file: Path, env: EnvFile) -> dict[str, str]:
-    """Return ``name -> value`` for assignment lines the strict parser rejected.
-
-    ``EnvParser`` only accepts identifier-style ASCII keys, so ``2FA_ENABLED``,
-    ``X-API-KEY`` or a non-ASCII identifier such as ``CAFÉ`` never become
-    variables. Those keys are recovered here — values are unquoted with the
-    parser's own helpers so the value handling stays single-source — and fed
-    through the same sanitize/alias path as parsed keys instead of being dropped.
-    Keys the parser already accepted are skipped (they come from ``env``).
-    """
-    parser = EnvParser()
-    extra: dict[str, str] = {}
-    for raw_line in env_file.read_text(encoding="utf-8").splitlines():
-        line = raw_line.strip()
-        if not line or line.startswith("#"):
-            continue
-        match = _RAW_ASSIGNMENT_PATTERN.match(line)
-        if not match:
-            continue
-        key = match.group(1)
-        if key in env.variables or key in extra:
-            continue
-        extra[key] = parser.value_from_raw(match.group(2))
-    return extra
 
 
 def _needs_sanitizing(name: str) -> bool:
@@ -278,10 +247,11 @@ def generate_settings_module(
     if _needs_sanitizing(class_name):
         raise ValueError(f"Invalid class name: {class_name!r} is not a valid Python identifier")
 
-    env = EnvParser().parse(env_file)
-    # Every assignment in the file, including keys the strict parser rejected.
+    # lenient=True so non-identifier / non-ASCII keys are recovered and emitted
+    # (sanitized + aliased) rather than dropped; ``validate`` parses the same way
+    # so the round-trip holds.
+    env = EnvParser().parse(env_file, lenient=True)
     all_values: dict[str, str] = {name: var.value for name, var in env.variables.items()}
-    all_values.update(_unparsed_assignments(env_file, env))
     sensitive_vars = _detect_sensitive_vars(all_values) if detect_sensitive else set()
 
     field_lines, aliased_count = _render_fields(all_values, sensitive_vars)

--- a/src/envdrift/cli_commands/init_cmd.py
+++ b/src/envdrift/cli_commands/init_cmd.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import keyword
 import re
 import shlex
+import unicodedata
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Annotated
@@ -86,32 +87,37 @@ def _needs_sanitizing(name: str) -> bool:
     return not name.isidentifier() or keyword.iskeyword(name) or _is_pydantic_reserved(name)
 
 
-def _bump_until_unique(name: str, used_names: set[str]) -> str:
-    """Append ``_`` until ``name`` is absent from ``used_names``."""
-    while name in used_names:
-        name = f"{name}_"
-    return name
+def _nfkc(name: str) -> str:
+    """The form Python stores an identifier as — it NFKC-folds them at compile."""
+    return unicodedata.normalize("NFKC", name)
 
 
-def _resolve_field_name(var_name: str, used_names: set[str]) -> tuple[str, str | None]:
+def _resolve_field_name(var_name: str, used_folded: set[str]) -> tuple[str, str | None]:
     """Pick a unique, importable attribute name for ``var_name``.
 
     Returns ``(field_name, alias)`` where ``alias`` is the original env var name
-    whenever the attribute name differs from it (so pydantic-settings still binds
-    to the real variable). ``used_names`` is updated in place with the chosen name.
+    whenever the attribute Python ends up binding differs from it, so
+    pydantic-settings still binds to the real variable. ``used_folded`` tracks the
+    chosen names by their **NFKC-normalized** form and is updated in place.
 
-    The alias is set whenever a rename happens — both when sanitizing a
-    non-identifier/keyword key *and* when bumping a name that collides with an
-    already-used one. Without the collision-case alias, a key like ``class_`` that
-    collapses onto the sanitized form of ``class`` would be renamed to ``class__``
-    and silently lose its binding to the ``class_`` env var.
+    Python normalizes identifiers with NFKC at compile time, so two distinct keys
+    that fold to the same identifier (NFC ``CAFÉ`` vs NFD ``CAFÉ``; the ligature
+    ``ﬁle`` vs ``file``) would silently collapse to a single attribute on import,
+    dropping one env var. Tracking the *folded* form makes the second one bump to
+    a distinct name; aliasing it — and any key whose folded form differs from the
+    raw key, or that was sanitized — preserves binding to the exact original key.
     """
     sanitize = _needs_sanitizing(var_name)
     field_name = _sanitize_identifier(var_name) if sanitize else var_name
-    # Any rename (sanitize or collision bump) must alias back to the original key.
-    alias = var_name if sanitize or field_name in used_names else None
-    field_name = _bump_until_unique(field_name, used_names)
-    used_names.add(field_name)
+    bumped = False
+    while _nfkc(field_name) in used_folded:
+        field_name = f"{field_name}_"
+        bumped = True
+    used_folded.add(_nfkc(field_name))
+    # Alias whenever the attribute Python actually binds (the NFKC fold of the
+    # written name) is not exactly the original key: a sanitize, a collision bump,
+    # or NFKC folding a bare unicode name (ligature / NFD) all change it.
+    alias = var_name if (sanitize or bumped or _nfkc(field_name) != var_name) else None
     return field_name, alias
 
 
@@ -209,9 +215,9 @@ def _render_fields(values: dict[str, str], sensitive_vars: set[str]) -> tuple[li
     """
     field_lines: list[str] = []
     aliased_count = 0
-    used_names: set[str] = set()
+    used_folded: set[str] = set()
     for var_name, value in sorted(values.items()):
-        field_name, alias = _resolve_field_name(var_name, used_names)
+        field_name, alias = _resolve_field_name(var_name, used_folded)
         if alias is not None:
             aliased_count += 1
         type_hint, default_val = _infer_type(value)

--- a/src/envdrift/cli_commands/validate.py
+++ b/src/envdrift/cli_commands/validate.py
@@ -115,10 +115,12 @@ def validate(
         print_error(str(e))
         raise typer.Exit(code=1) from None
 
-    # Parse env file
+    # Parse env file. lenient=True so non-identifier / non-ASCII keys (which init
+    # emits as alias-backed schema fields) are present and can be matched against
+    # the schema by alias — keeping the init→validate round-trip intact.
     parser = EnvParser()
     try:
-        env = parser.parse(env_file)
+        env = parser.parse(env_file, lenient=True)
     except FileNotFoundError as e:
         print_error(str(e))
         raise typer.Exit(code=1) from None

--- a/src/envdrift/core/parser.py
+++ b/src/envdrift/core/parser.py
@@ -202,14 +202,7 @@ class EnvParser:
                 continue
 
             key = match.group(1)
-            # Strip an inline comment from the RAW value first — the whitespace
-            # context distinguishes `K= # c` (comment) from `K=#FF0000` (a value
-            # that begins with `#`) — then strip surrounding whitespace + quotes.
-            value = self._strip_inline_comment(match.group(2))
-            value = value.strip()
-
-            # Remove surrounding quotes
-            value = self._unquote(value)
+            value = self.value_from_raw(match.group(2))
 
             # Determine encryption status and backend
             encryption_status, encryption_backend = self._detect_encryption_status(value)
@@ -226,6 +219,19 @@ class EnvParser:
             env_file.variables[key] = env_var
 
         return env_file
+
+    def value_from_raw(self, raw_value: str) -> str:
+        """Normalize the raw RHS of a ``KEY=value`` line to its final value.
+
+        Strips an unquoted inline comment, then surrounding whitespace, then a
+        single matching pair of surrounding quotes — the same transformation
+        ``parse`` applies. Public so callers that recover assignments the strict
+        ``LINE_PATTERN`` rejects (e.g. ``init`` for non-identifier keys) reuse
+        this canonical handling instead of the private helpers. The whitespace
+        context matters, so pass the RAW value (the regex's ``=`` group),
+        unstripped: ``K= # c`` is a comment but ``K=#FF0000`` is a value.
+        """
+        return self._unquote(self._strip_inline_comment(raw_value).strip())
 
     def _strip_inline_comment(self, value: str) -> str:
         """Strip an unquoted trailing ` #...` comment from a (raw) value.

--- a/src/envdrift/core/parser.py
+++ b/src/envdrift/core/parser.py
@@ -146,12 +146,23 @@ class EnvParser:
     # (a value beginning with `#`). Leading/trailing whitespace is stripped after.
     LINE_PATTERN = re.compile(r"^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=(.*)$")
 
-    def parse(self, path: Path | str) -> EnvFile:
+    # Lenient variant for ``lenient=True``: accepts ANY key the strict pattern
+    # rejects (leading digit ``1PW``, dash ``X-API-KEY``, dot, non-ASCII letter
+    # ``CAFÉ``). ``init`` and ``validate`` use it so a non-identifier key is
+    # represented end-to-end (in the generated schema *and* matched against the
+    # .env), keeping the init→validate round-trip intact. Other callers keep the
+    # strict pattern so their behaviour is unchanged.
+    LENIENT_LINE_PATTERN = re.compile(r"^(?:export\s+)?([^\s=#]+)\s*=(.*)$")
+
+    def parse(self, path: Path | str, *, lenient: bool = False) -> EnvFile:
         """
         Parse a .env file and produce an EnvFile representing its parsed contents.
 
         Parameters:
             path (Path | str): Filesystem path to the .env file.
+            lenient (bool): When True, also recover keys the strict pattern
+                rejects (non-identifier / non-ASCII), so the parsed variable set
+                matches every assignment in the file.
 
         Returns:
             EnvFile: Parsed file containing variables and comments.
@@ -165,23 +176,26 @@ class EnvParser:
             raise FileNotFoundError(f"ENV file not found: {path}")
 
         content = path.read_text(encoding="utf-8")
-        env_file = self.parse_string(content)
+        env_file = self.parse_string(content, lenient=lenient)
         env_file.path = path
 
         return env_file
 
-    def parse_string(self, content: str) -> EnvFile:
+    def parse_string(self, content: str, *, lenient: bool = False) -> EnvFile:
         """
         Parse .env formatted text, extracting variables (with detected encryption status) and comments.
 
         Parameters:
             content (str): The complete text content of a .env file to parse.
+            lenient (bool): When True, accept non-identifier / non-ASCII keys too
+                (see ``LENIENT_LINE_PATTERN``).
 
         Returns:
             EnvFile: An EnvFile populated with parsed EnvVar entries keyed by variable name and a list of comment lines.
         """
         env_file = EnvFile(path=Path())
         lines = content.splitlines()
+        pattern = self.LENIENT_LINE_PATTERN if lenient else self.LINE_PATTERN
 
         for line_num, line in enumerate(lines, start=1):
             original_line = line
@@ -197,7 +211,7 @@ class EnvParser:
                 continue
 
             # Parse KEY=value
-            match = self.LINE_PATTERN.match(line)
+            match = pattern.match(line)
             if not match:
                 continue
 

--- a/src/envdrift/core/schema.py
+++ b/src/envdrift/core/schema.py
@@ -27,6 +27,10 @@ class FieldMetadata:
     description: str | None
     field_type: type
     annotation: str
+    # The Pydantic alias (the real env-var name) when the attribute name differs,
+    # e.g. a field ``X_API_KEY`` with ``Field(alias='X-API-KEY')``. Validation
+    # matches the .env against this when present so a non-identifier key resolves.
+    alias: str | None = None
 
     @property
     def is_optional(self) -> bool:
@@ -249,6 +253,11 @@ class SchemaLoader:
             else:
                 type_str = "Any"
 
+            # The real env-var name when it differs from the attribute name
+            # (validation_alias takes precedence over alias when both are set).
+            field_alias = field_info.validation_alias or field_info.alias
+            field_alias = field_alias if isinstance(field_alias, str) else None
+
             schema.fields[field_name] = FieldMetadata(
                 name=field_name,
                 required=is_required,
@@ -257,6 +266,7 @@ class SchemaLoader:
                 description=description,
                 field_type=annotation if annotation else type(None),
                 annotation=type_str,
+                alias=field_alias,
             )
 
         return schema

--- a/src/envdrift/core/validator.py
+++ b/src/envdrift/core/validator.py
@@ -6,7 +6,7 @@ import re
 from dataclasses import dataclass, field
 
 from envdrift.core.parser import EncryptionStatus, EnvFile
-from envdrift.core.schema import SchemaMetadata
+from envdrift.core.schema import FieldMetadata, SchemaMetadata
 
 
 @dataclass
@@ -126,7 +126,13 @@ class Validator:
         # `api_key` field. Mirror that here by matching names case-insensitively
         # so an UPPERCASE .env against a lowercase schema is not falsely
         # reported as both missing_required and extra_vars (see issue #306).
-        schema_names_lower = {name.lower() for name in schema.fields}
+        # A field is matched against the .env by its alias when it has one (the
+        # real env-var name, e.g. ``X-API-KEY`` for attribute ``X_API_KEY``),
+        # else by its attribute name — mirroring how pydantic-settings binds.
+        def _lookup_key(fm: FieldMetadata) -> str:
+            return (fm.alias or fm.name).lower()
+
+        schema_names_lower = {_lookup_key(fm) for fm in schema.fields.values()}
 
         # One pass over the env vars derives everything case-insensitive matching
         # needs (Pydantic Settings defaults to case_insensitive):
@@ -156,12 +162,12 @@ class Validator:
 
         # Check for missing required variables
         for field_name, field_meta in schema.fields.items():
-            if field_meta.required and field_name.lower() not in env_names_lower:
+            if field_meta.required and _lookup_key(field_meta) not in env_names_lower:
                 result.missing_required.add(field_name)
 
         # Check for missing optional variables (as warning)
         for field_name, field_meta in schema.fields.items():
-            if not field_meta.required and field_name.lower() not in env_names_lower:
+            if not field_meta.required and _lookup_key(field_meta) not in env_names_lower:
                 result.missing_optional.add(field_name)
 
         # Check for extra variables
@@ -178,7 +184,7 @@ class Validator:
         # Check encryption status for sensitive variables
         if check_encryption:
             for field_name, field_meta in schema.fields.items():
-                env_var = env_by_lower.get(field_name.lower())
+                env_var = env_by_lower.get(_lookup_key(field_meta))
                 if env_var is None:
                     continue
 
@@ -206,7 +212,7 @@ class Validator:
 
         # Basic type validation
         for field_name, field_meta in schema.fields.items():
-            env_var = env_by_lower.get(field_name.lower())
+            env_var = env_by_lower.get(_lookup_key(field_meta))
             if env_var is None:
                 continue
 

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -246,47 +246,55 @@ BOOL_FALSE=false
         # No broken module written.
         assert not output.exists()
 
-    def test_init_warns_on_non_identifier_keys(self, tmp_path: Path):
-        """#423: the API surfaces dropped non-identifier keys via a UserWarning.
+    def test_init_aliases_non_identifier_keys(self, tmp_path: Path):
+        """#443: non-identifier keys are aliased into the schema, not dropped.
 
-        Keys the strict parser cannot read (`2FA_ENABLED`, `MY-DASH-VAR`) are
-        omitted from the generated module. The CLI prints a [WARN]; the public API
-        must not silently leave callers with an incomplete file — it warns instead.
-        """
-        env_file = tmp_path / ".env"
-        env_file.write_text("2FA_ENABLED=true\nMY-DASH-VAR=x\nVALID=keep\n")
-        output = tmp_path / "settings.py"
-
-        with pytest.warns(UserWarning, match="non-identifier keys") as record:
-            result = init(env_file, output, detect_sensitive=False)
-
-        assert result == output
-        message = str(record[0].message)
-        assert "2FA_ENABLED" in message
-        assert "MY-DASH-VAR" in message
-        # The parseable variable is still emitted.
-        assert "VALID" in output.read_text()
-
-    def test_init_warnings_as_errors_writes_no_file(self, tmp_path: Path):
-        """#423: under warnings-as-errors, init() must not leave a half-written file.
-
-        The dropped-keys UserWarning is emitted BEFORE the output is written, so a
-        caller running with ``warnings.filterwarnings("error")`` (common in CI/test
-        suites) gets a clean raise and NO output file on disk -- not an incomplete
-        ``settings.py`` plus an exception.
+        Keys the strict parser rejects (`2FA_ENABLED`, `MY-DASH-VAR`) used to be
+        omitted from the generated module (the API warned about the loss). They are
+        now emitted with a sanitized attribute name plus a Pydantic ``alias`` so the
+        schema stays complete and binds to the real variables — no warning needed.
         """
         import warnings
 
         env_file = tmp_path / ".env"
-        env_file.write_text("2FA_ENABLED=true\nVALID=keep\n")
+        env_file.write_text("2FA_ENABLED=true\nMY-DASH-VAR=x\nVALID=keep\n", encoding="utf-8")
         output = tmp_path / "settings.py"
 
         with warnings.catch_warnings():
-            warnings.simplefilter("error", UserWarning)
-            with pytest.raises(UserWarning, match="non-identifier keys"):
-                init(env_file, output, detect_sensitive=False)
+            warnings.simplefilter("error")  # any spurious warning fails the test
+            result = init(env_file, output, detect_sensitive=False)
 
-        assert not output.exists()
+        assert result == output
+        content = output.read_text(encoding="utf-8")
+        # Every key is represented, with aliases back to the original names.
+        assert "alias='2FA_ENABLED'" in content
+        assert "alias='MY-DASH-VAR'" in content
+        assert "VALID" in content
+        # The raw non-identifier names never appear as bare attribute annotations.
+        assert "\n    2FA_ENABLED:" not in content
+        assert "\n    MY-DASH-VAR:" not in content
+
+    def test_init_non_identifier_keys_keep_module_importable(self, tmp_path: Path):
+        """#443: a module with aliased non-identifier keys imports cleanly.
+
+        Previously these keys were dropped (and the API emitted a UserWarning); now
+        they are aliased in, so the generated module must both contain them and
+        import without a SyntaxError.
+        """
+        import importlib.util
+
+        env_file = tmp_path / ".env"
+        env_file.write_text("2FA_ENABLED=true\nMY-DASH-VAR=x\nVALID=keep\n", encoding="utf-8")
+        output = tmp_path / "settings.py"
+
+        init(env_file, output, class_name="Cfg", detect_sensitive=False)
+
+        spec = importlib.util.spec_from_file_location("gen_alias_api_settings", output)
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        aliases = {f.alias for f in module.Cfg.model_fields.values() if f.alias}
+        assert {"2FA_ENABLED", "MY-DASH-VAR"} <= aliases
 
     def test_init_no_warning_when_all_keys_parse(self, tmp_path: Path):
         """#423: the API stays warning-free when every key is parseable."""

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1469,6 +1469,34 @@ class TestInitCommand:
         # The emoji key is aliased back to its original name.
         assert {f.alias for f in fields.values() if f.alias == "KEY🔑"} == {"KEY🔑"}
 
+    def test_init_then_validate_round_trip_with_non_identifier_keys(self, tmp_path: Path) -> None:
+        """#443: the documented init→validate workflow PASSES for non-identifier keys.
+
+        init aliases ``X-API-KEY`` / ``2FA_ENABLED`` and keeps ``CAFÉ``; validate
+        parses the same .env leniently and matches by alias, so it validates
+        cleanly instead of falsely reporting the aliased fields as MISSING (the
+        regression this combined init+validate change fixes).
+        """
+        env_file = tmp_path / ".env"
+        env_file.write_text(
+            "DATABASE_URL=postgres://x\n2FA_ENABLED=true\nX-API-KEY=abc123\nCAFÉ=yes\n",
+            encoding="utf-8",
+        )
+        out = tmp_path / "settings.py"
+
+        init_res = runner.invoke(
+            app, ["init", str(env_file), "--output", str(out), "--class-name", "Cfg"]
+        )
+        assert init_res.exit_code == 0, init_res.output
+
+        val_res = runner.invoke(
+            app,
+            ["validate", str(env_file), "--schema", "settings:Cfg", "--service-dir", str(tmp_path)],
+        )
+        assert val_res.exit_code == 0, val_res.output
+        # Width-independent: Rich may wrap the long tmp path before the verdict.
+        assert "passed" in " ".join(val_res.output.lower().split())
+
     def test_sanitize_identifier_produces_valid_non_keyword_names(self) -> None:
         """#413: the sanitizer always yields a valid, non-keyword identifier."""
         from envdrift.cli_commands.init_cmd import _sanitize_identifier

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1469,6 +1469,39 @@ class TestInitCommand:
         # The emoji key is aliased back to its original name.
         assert {f.alias for f in fields.values() if f.alias == "KEY🔑"} == {"KEY🔑"}
 
+    def test_init_nfkc_colliding_keys_stay_distinct_fields(self, tmp_path: Path) -> None:
+        """#449: keys that NFKC-fold to the same identifier must NOT collapse.
+
+        Python NFKC-normalizes identifiers at compile time, so an NFC vs NFD
+        accented key, and a ligature vs its ASCII expansion, would otherwise merge
+        into a single attribute on import -- silently dropping a var. Each of the
+        four distinct env keys must survive as its own field, bound (by name or
+        alias) to its exact original key. Built with escapes so the byte forms are
+        deterministic regardless of this file's own normalization.
+        """
+        nfc = "CAF\u00c9"  # precomposed E-acute (U+00C9)
+        nfd = "CAFE\u0301"  # E + combining acute (U+0301)
+        lig = "\ufb01le"  # FB01 ligature, NFKC-folds to "file"
+        env_file = tmp_path / ".env"
+        env_file.write_text(f"{nfc}=a\n{nfd}=b\n{lig}=c\nfile=d\n", encoding="utf-8")
+        out = tmp_path / "settings.py"
+
+        result = runner.invoke(
+            app, ["init", str(env_file), "--output", str(out), "--class-name", "Cfg"]
+        )
+        assert result.exit_code == 0, result.output
+
+        spec = importlib.util.spec_from_file_location("gen_nfkc_settings", out)
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        fields = module.Cfg.model_fields
+        # No collapse: all four distinct keys survive as four distinct fields.
+        assert len(fields) == 4
+        # Each field binds (by alias, else attribute name) to an exact original key.
+        recovered = {(f.alias if f.alias else name) for name, f in fields.items()}
+        assert recovered == {nfc, nfd, lig, "file"}
+
     def test_init_then_validate_round_trip_with_non_identifier_keys(self, tmp_path: Path) -> None:
         """#443: the documented init→validate workflow PASSES for non-identifier keys.
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1411,25 +1411,63 @@ class TestInitCommand:
         assert "invalid class name" in result.output.lower()
         assert not out.exists()
 
-    def test_init_warns_on_non_identifier_keys(self, tmp_path: Path) -> None:
-        """#413: .env keys the parser cannot read are warned about, not dropped.
+    def test_init_aliases_non_identifier_keys(self, tmp_path: Path) -> None:
+        """#443: .env keys the parser cannot read are aliased in, not dropped.
 
         `2FA_ENABLED` (leading digit) and `MY-DASH-VAR` (dash) never enter the
-        parsed variable set, so init previously omitted them with no warning.
+        strict parser's variable set, so init used to omit them and warn. They are
+        now emitted with a sanitized attribute name plus a Pydantic ``alias`` so the
+        schema stays complete and the module still imports.
         """
         env_file = tmp_path / ".env"
-        env_file.write_text("2FA_ENABLED=true\nMY-DASH-VAR=x\nVALID=keep\n")
+        env_file.write_text("2FA_ENABLED=true\nMY-DASH-VAR=x\nVALID=keep\n", encoding="utf-8")
         out = tmp_path / "settings.py"
 
         result = runner.invoke(
             app, ["init", str(env_file), "--output", str(out), "--class-name", "Cfg"]
         )
         assert result.exit_code == 0, result.output
-        # Both un-parseable keys are named in the warning output.
-        assert "2FA_ENABLED" in result.output
-        assert "MY-DASH-VAR" in result.output
-        # The parseable variable is still emitted.
-        assert "VALID" in out.read_text()
+        content = out.read_text(encoding="utf-8")
+        # Both keys are aliased into the schema rather than dropped/warned.
+        assert "alias='2FA_ENABLED'" in content
+        assert "alias='MY-DASH-VAR'" in content
+        assert "VALID" in content
+
+        # The generated module must still import (no SyntaxError from raw names).
+        spec = importlib.util.spec_from_file_location("gen_alias_settings", out)
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        aliases = {f.alias for f in module.Cfg.model_fields.values() if f.alias}
+        assert {"2FA_ENABLED", "MY-DASH-VAR"} <= aliases
+
+    def test_init_unicode_identifier_keys_become_bare_fields(self, tmp_path: Path) -> None:
+        """#443: valid non-ASCII identifiers are real fields; only true non-identifiers alias.
+
+        ``CAFÉ`` / ``ΑΛΦΑ`` pass ``str.isidentifier()`` and must become bare
+        attributes (no alias); an emoji key ``KEY🔑`` is not an identifier and is
+        sanitized + aliased like any other non-identifier key.
+        """
+        env_file = tmp_path / ".env"
+        # Greek capital letters are intentional (testing non-ASCII identifiers).
+        env_file.write_text("CAFÉ=a\nΑΛΦΑ=b\nKEY🔑=c\n", encoding="utf-8")  # noqa: RUF001
+        out = tmp_path / "settings.py"
+
+        result = runner.invoke(
+            app, ["init", str(env_file), "--output", str(out), "--class-name", "Cfg"]
+        )
+        assert result.exit_code == 0, result.output
+
+        spec = importlib.util.spec_from_file_location("gen_unicode_settings", out)
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        fields = module.Cfg.model_fields
+        # Unicode-letter identifiers are kept verbatim (no alias).
+        assert "CAFÉ" in fields and fields["CAFÉ"].alias is None
+        assert "ΑΛΦΑ" in fields and fields["ΑΛΦΑ"].alias is None
+        # The emoji key is aliased back to its original name.
+        assert {f.alias for f in fields.values() if f.alias == "KEY🔑"} == {"KEY🔑"}
 
     def test_sanitize_identifier_produces_valid_non_keyword_names(self) -> None:
         """#413: the sanitizer always yields a valid, non-keyword identifier."""

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -372,3 +372,25 @@ BAR=plaintext
         assert env_var.value == payload
         assert env_var.encryption_status == EncryptionStatus.ENCRYPTED
         assert env_var.encryption_backend == "dotenvx"
+
+
+class TestLenientParsing:
+    """#443: parse(lenient=True) recovers non-identifier / non-ASCII keys the
+    strict pattern rejects; the default parse stays strict."""
+
+    CONTENT = "OK_KEY=1\n2FA_ENABLED=x\nX-API-KEY=y\nCAFÉ=z\n"
+
+    def test_strict_default_drops_non_identifier_keys(self, tmp_path):
+        env_file = tmp_path / ".env"
+        env_file.write_text(self.CONTENT, encoding="utf-8")
+        env = EnvParser().parse(env_file)
+        assert set(env.variables) == {"OK_KEY"}
+
+    def test_lenient_recovers_non_identifier_and_unicode_keys(self, tmp_path):
+        env_file = tmp_path / ".env"
+        env_file.write_text(self.CONTENT, encoding="utf-8")
+        env = EnvParser().parse(env_file, lenient=True)
+        assert set(env.variables) == {"OK_KEY", "2FA_ENABLED", "X-API-KEY", "CAFÉ"}
+        # Values are unquoted exactly as strict parsing would.
+        assert env.variables["X-API-KEY"].value == "y"
+        assert env.variables["CAFÉ"].value == "z"

--- a/tests/unit/test_validator.py
+++ b/tests/unit/test_validator.py
@@ -416,3 +416,47 @@ EXTRA=extra
         assert result.has_errors is True
         assert result.error_count > 0
         assert result.warning_count >= 0
+
+
+class TestValidatorAliasMatching:
+    """#443: a field with a Pydantic alias is matched against the .env by its
+    alias (the real env-var name), so init's non-identifier-key fields validate
+    instead of false-reporting MISSING (the init→validate round-trip)."""
+
+    @staticmethod
+    def _schema():
+        class Settings(BaseSettings):
+            model_config = SettingsConfigDict(extra="forbid")
+
+            X_API_KEY: str = Field(alias="X-API-KEY")
+            DATABASE_URL: str
+
+        return SchemaLoader().extract_metadata(Settings)
+
+    def test_extract_metadata_captures_alias(self):
+        schema = self._schema()
+        assert schema.fields["X_API_KEY"].alias == "X-API-KEY"
+        assert schema.fields["DATABASE_URL"].alias is None
+
+    def test_aliased_field_present_under_its_alias_validates(self, tmp_path):
+        """The non-identifier key in the .env matches the aliased field."""
+        env_file = tmp_path / ".env"
+        env_file.write_text("DATABASE_URL=postgres://x\nX-API-KEY=secret\n", encoding="utf-8")
+        env = EnvParser().parse(env_file, lenient=True)
+
+        result = Validator().validate(env, self._schema(), check_encryption=False)
+
+        assert result.valid is True, result.missing_required | result.extra_vars
+        assert not result.missing_required
+        # The alias key is the field, not an unknown extra under extra="forbid".
+        assert not result.extra_vars
+
+    def test_aliased_field_absent_is_reported_missing(self, tmp_path):
+        env_file = tmp_path / ".env"
+        env_file.write_text("DATABASE_URL=postgres://x\n", encoding="utf-8")
+        env = EnvParser().parse(env_file, lenient=True)
+
+        result = Validator().validate(env, self._schema(), check_encryption=False)
+
+        assert result.valid is False
+        assert "X_API_KEY" in result.missing_required


### PR DESCRIPTION
Supersedes #446. Closes the init→validate round-trip for keys the strict parser rejects, so the documented workflow is correct end-to-end. (#446 fixed only the init side; CodeRabbit correctly flagged that aliasing keys into the schema without teaching `validate` to match them makes init→validate fail.)

## The problem (verified)

The adversarial sweep (#443) found `init` silently **drops** every `.env` key the strict `EnvParser` rejects (dash/digit/dot/emoji + non-ASCII like `CAFÉ`). Fixing init to **alias** them in surfaced a second bug: `validate` parsed the .env strictly (dropping those keys) and matched by attribute name, so:

```
$ envdrift init .env -o settings.py -c Cfg   # X-API-KEY -> Field(alias='X-API-KEY')
$ envdrift validate .env --schema settings:Cfg
Validation FAILED — MISSING REQUIRED VARIABLES: X_API_KEY   # but X-API-KEY IS in the file
```

## The fix (init + validate, one theme)

| Layer | Change |
|---|---|
| `EnvParser` | opt-in **`lenient=True`** (`LENIENT_LINE_PATTERN`) recovers non-identifier / non-ASCII keys. Every other caller keeps the strict pattern. |
| `init` | parses `lenient=True` and aliases the recovered keys; drops its private `_unparsed_assignments` (now redundant — single-source). |
| `FieldMetadata` | carries the field **`alias`** (from `validation_alias`/`alias`). |
| `validate` | parses `lenient=True`; the validator matches each field against the .env **by alias** (when present) for the missing / extra / encryption / type checks — mirroring pydantic-settings. |

Result:

```
$ envdrift validate .env --schema settings:Cfg
Validation PASSED
```

## Tests / docs

- parser: strict drops vs `lenient=True` recovers non-identifier + Unicode keys
- schema: `extract_metadata` captures the alias
- validator: an aliased field present under its alias validates (and is reported missing when absent)
- **end-to-end `init`→`validate` round-trip** over `X-API-KEY` / `2FA_ENABLED` / `CAFÉ` that **PASSES** (failed before this change)

Full non-integration suite green (2479); ruff/format/pyrefly/bandit/markdownlint clean. Docs synced.

Scope note: this is the alias/round-trip slice of validate-fidelity. The remaining `validate` findings — constraint enforcement (#443 #12), broken-schema-module traceback (#34), multiline values (#33) — stay as follow-ups.

Refs #443

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Lenient `.env` parsing retains non-standard keys (non-identifiers, non-ASCII) and emits fields with sanitized attribute names plus Pydantic aliases so every env var is captured and generated modules remain importable.

* **Bug Fixes**
  * Removed warnings about skipped/unparsed keys; aliasing now preserves those variables.
  * Generated settings files are written using explicit UTF-8 encoding.

* **Documentation**
  * Updated examples and docs to show aliased field handling for non-identifier environment variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the `init`→`validate` round-trip for non-identifier and Unicode `.env` keys by adding a `lenient=True` parsing mode to `EnvParser` and threading alias awareness through `FieldMetadata` and the `Validator`. Keys that were previously dropped (e.g. `X-API-KEY`, `2FA_ENABLED`, `CAFÉ`) are now aliased into the generated schema and matched back by alias during validation.

- **Parser**: adds `LENIENT_LINE_PATTERN` and a `lenient` keyword arg to `parse`/`parse_string`; `value_from_raw` is extracted as a public helper for consistent value normalization.
- **`init`**: switches to `lenient=True`, replaces the dropped-key warning path with NFKC-aware collision tracking in `_resolve_field_name`, and writes output as UTF-8.
- **`validate`**: parses leniently; the validator now resolves each field's lookup key via `field_meta.alias or field_meta.name`, mirroring how pydantic-settings binds env vars to aliased fields.

<h3>Confidence Score: 4/5</h3>

Safe to merge for the init→validate round-trip fix; one remaining defect in `generate_fix_template` means `--fix` output writes the wrong key name for aliased fields.

The core alias matching in `validate` and the lenient parser are correct and well-tested. However, `generate_fix_template` in `validator.py` (lines 325–346) still emits `var_name` (the attribute name like `X_API_KEY`) as the `.env` key rather than `field_meta.alias or var_name` (`X-API-KEY`). A user who runs `envdrift validate --fix` on a file with a missing aliased field will receive a template that instructs them to add the wrong key, and validation will still fail after they follow the advice. The `alias` field added to `FieldMetadata` in this PR is everything needed to fix it — only the two emission lines in `generate_fix_template` were not updated.

src/envdrift/core/validator.py — the `generate_fix_template` method needs its key-emission lines updated to use the alias.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/envdrift/core/validator.py | Validation matching updated to use alias for field lookup — correct. `generate_fix_template` still emits the attribute name instead of the alias as the .env key, so `--fix` output is wrong for aliased fields. |
| src/envdrift/core/parser.py | Adds `lenient=True` opt-in mode via `LENIENT_LINE_PATTERN` and exposes `value_from_raw` as a public helper; default strict behavior is unchanged. |
| src/envdrift/core/schema.py | Adds `alias` field to `FieldMetadata`, populated from `validation_alias` (with precedence) or `alias` during `extract_metadata`; clean and correct. |
| src/envdrift/cli_commands/init_cmd.py | Switches to `lenient=True` parsing, drops `_unparsed_keys`/`_raw_assignment_keys`, adds NFKC collision tracking in `_resolve_field_name`, and writes output as UTF-8; logic is solid. |
| src/envdrift/api.py | Removes the `UserWarning` emission for non-identifier keys and adds `encoding="utf-8"` to `write_text`; clean. |
| tests/unit/test_validator.py | New `TestValidatorAliasMatching` class covers alias extraction, aliased-present, and aliased-absent cases; good coverage of the new logic. |
| tests/unit/test_cli.py | Adds five new test cases including NFKC collision, unicode identifier, and end-to-end init→validate round-trip; comprehensive coverage of the new behavior. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant init_cmd
    participant EnvParser
    participant FieldResolver
    participant validate_cmd
    participant Validator

    User->>init_cmd: envdrift init .env -o settings.py
    init_cmd->>EnvParser: "parse(.env, lenient=True)"
    EnvParser-->>init_cmd: "EnvFile {X-API-KEY, 2FA_ENABLED, CAFÉ, ...}"
    init_cmd->>FieldResolver: _resolve_field_name(X-API-KEY, used_folded)
    FieldResolver-->>init_cmd: "(X_API_KEY, alias=X-API-KEY)"
    init_cmd->>FieldResolver: _resolve_field_name(2FA_ENABLED, used_folded)
    FieldResolver-->>init_cmd: "(field_2FA_ENABLED, alias=2FA_ENABLED)"
    init_cmd-->>User: settings.py written (UTF-8)

    User->>validate_cmd: envdrift validate .env --schema settings:Cfg
    validate_cmd->>EnvParser: "parse(.env, lenient=True)"
    EnvParser-->>validate_cmd: "EnvFile {X-API-KEY, 2FA_ENABLED, CAFÉ, ...}"
    validate_cmd->>Validator: validate(env, schema_meta)
    Note over Validator: _lookup_key(fm) = fm.alias or fm.name
    Validator-->>validate_cmd: "ValidationResult(valid=True)"
    validate_cmd-->>User: Validation PASSED
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `src/envdrift/core/validator.py`, line 322-333 ([link](https://github.com/jainal09/envdrift/blob/3884d31a6259d2a67414f090c70ceb4550e315be/src/envdrift/core/validator.py#L322-L333)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`generate_fix_template` emits the attribute name, not the real env-var name**

   `var_name` here is the Pydantic attribute name (e.g., `X_API_KEY`). For a field carrying `alias='X-API-KEY'` — exactly the kind of field this PR now adds to the schema — the template outputs `X_API_KEY=`, but the `.env` file expects `X-API-KEY=`. A user running `envdrift validate --fix` on a file missing that key would be told to add the wrong key and validation would still fail.

   The `alias` field added to `FieldMetadata` in this PR should be used here: replace `var_name` with `field_meta.alias or var_name` (or `var_name` when `field_meta` is None) as the key written to the template.

2. `src/envdrift/core/validator.py`, line 323-346 ([link](https://github.com/jainal09/envdrift/blob/0821ff0385b580e63c1d3822882af3b91ab03a81/src/envdrift/core/validator.py#L323-L346)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`generate_fix_template` emits attribute name, not the real env-var key**

   `var_name` here is the Pydantic attribute name (e.g. `X_API_KEY`). For a field carrying `alias='X-API-KEY'` — exactly the kind of field this PR adds — the template writes `X_API_KEY=` in both the required and optional sections, but the `.env` file must use `X-API-KEY=`. A user running `envdrift validate --fix` on a file that's missing that key would be instructed to add the wrong key name, and validation would still fail after they follow the advice.

   Both loops should replace the bare `var_name` with `field_meta.alias or var_name` (falling back to `var_name` when `field_meta` is `None` or the alias is unset).

3. `src/envdrift/core/validator.py`, line 323-348 ([link](https://github.com/jainal09/envdrift/blob/5214c631a56a49990f755c7360cdcf518f4705a6/src/envdrift/core/validator.py#L323-L348)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`generate_fix_template` emits the attribute name instead of the real env-var key**

   `var_name` here is the Pydantic attribute name (e.g. `X_API_KEY`). For a field carrying `alias='X-API-KEY'` — exactly what this PR now generates from `init` — the template writes `X_API_KEY=` in both the required and optional sections. A user running `envdrift validate --fix` on a file missing that key would be told to add `X_API_KEY=secret`, but validation would still fail because the `.env` file must contain `X-API-KEY=secret`. The `alias` field added to `FieldMetadata` in this PR is the fix: replace `var_name` in the key-emission lines with `(field_meta.alias or var_name) if field_meta else var_name`.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into feat/init-valid..."](https://github.com/jainal09/envdrift/commit/5214c631a56a49990f755c7360cdcf518f4705a6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36471993)</sub>

<!-- /greptile_comment -->