### PR TITLE
ci: run binary-backed integration tests on macOS and Windows

### DIFF
--- a/.github/scripts/install_test_binaries.py
+++ b/.github/scripts/install_test_binaries.py
@@ -78,6 +78,34 @@ def _find_binary(root: Path, binary: str) -> Path:
     raise FileNotFoundError(f"{binary!r} not found in extracted archive under {root}")
 
 
+def _is_within(base: Path, target: Path) -> bool:
+    """True if resolved ``target`` stays inside ``base`` (no path traversal)."""
+    try:
+        target.resolve().relative_to(base.resolve())
+    except ValueError:
+        return False
+    return True
+
+
+def _safe_extract_tar(tf: tarfile.TarFile, dest: Path) -> None:
+    """Extract a tar, rejecting any member that escapes ``dest`` (zip/tar-slip)."""
+    for member in tf.getmembers():
+        if member.islnk() or member.issym() or not _is_within(dest, dest / member.name):
+            raise RuntimeError(f"unsafe path in archive: {member.name!r}")
+    try:
+        tf.extractall(dest, filter="data")  # 3.12+: blocks traversal/abs/special
+    except TypeError:  # Python < 3.12 has no filter= kwarg
+        tf.extractall(dest)  # members already validated above
+
+
+def _safe_extract_zip(zf: zipfile.ZipFile, dest: Path) -> None:
+    """Extract a zip, rejecting any member that escapes ``dest``."""
+    for name in zf.namelist():
+        if not _is_within(dest, dest / name):
+            raise RuntimeError(f"unsafe path in archive: {name!r}")
+    zf.extractall(dest)
+
+
 def _install_tool(bindir: Path, binary: str, urls_key: str, version_key: str) -> None:
     urls = CONST[urls_key]
     key = _platform_key(urls)
@@ -92,13 +120,13 @@ def _install_tool(bindir: Path, binary: str, urls_key: str, version_key: str) ->
         _download(url, archive)
         extract_dir = bindir / f"_{binary}_x"
         with tarfile.open(archive) as tf:
-            tf.extractall(extract_dir)
+            _safe_extract_tar(tf, extract_dir)
         dest.write_bytes(_find_binary(extract_dir, binary).read_bytes())
     elif url.endswith(".zip"):
         _download(url, archive)
         extract_dir = bindir / f"_{binary}_x"
         with zipfile.ZipFile(archive) as zf:
-            zf.extractall(extract_dir)
+            _safe_extract_zip(zf, extract_dir)
         dest.write_bytes(_find_binary(extract_dir, binary).read_bytes())
     else:
         # Raw, single-file binary (e.g. sops, talisman).

--- a/.github/scripts/install_test_binaries.py
+++ b/.github/scripts/install_test_binaries.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Install the external CLI binaries the integration tests drive, cross-platform.
+
+Reads pinned versions + download URLs from ``src/envdrift/constants.json`` (the
+single source of truth, kept current by Renovate — no hardcoded versions here)
+and installs each tool into a per-user bin directory, which it appends to
+``GITHUB_PATH`` so later steps and the test subprocesses find them on ``PATH``.
+
+Works on Linux, macOS and Windows. Standalone (no ``envdrift`` import) so the
+production installer's own cross-platform behaviour is exercised by *its* tests,
+not entangled with the feature tests this enables.
+
+Resilient by design: each tool installs independently and a failure is logged
+and skipped (it becomes a real finding — the test that needs it then skips for an
+honest "binary absent" reason) rather than aborting every other tool's install.
+Exit code is non-zero only if *nothing* installed, so the workflow surfaces a
+total failure but tolerates a partial one.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import platform
+import stat
+import sys
+import tarfile
+import urllib.request
+import zipfile
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+CONST = json.loads((REPO / "src" / "envdrift" / "constants.json").read_text(encoding="utf-8"))
+IS_WIN = sys.platform == "win32"
+
+# (binary name, URL-map key in constants.json, version key in constants.json)
+TOOLS: list[tuple[str, str, str]] = [
+    ("dotenvx", "download_urls", "dotenvx_version"),
+    ("sops", "sops_download_urls", "sops_version"),
+    ("gitleaks", "gitleaks_download_urls", "gitleaks_version"),
+    ("trufflehog", "trufflehog_download_urls", "trufflehog_version"),
+    ("talisman", "talisman_download_urls", "talisman_version"),
+    ("trivy", "trivy_download_urls", "trivy_version"),
+    ("infisical", "infisical_download_urls", "infisical_version"),
+]
+
+
+def _platform_key(urls: dict[str, str]) -> str:
+    osname = {"linux": "linux", "darwin": "darwin", "win32": "windows"}[sys.platform]
+    machine = platform.machine().lower()
+    arch = "arm64" if machine in ("arm64", "aarch64") else "amd64"
+    key = f"{osname}_{arch}"
+    # Fall back to amd64 when a tool publishes no arm64 build for this OS.
+    if key not in urls and arch == "arm64":
+        key = f"{osname}_amd64"
+    return key
+
+
+def _download(url: str, dest: Path) -> None:
+    print(f"    GET {url}")
+    urllib.request.urlretrieve(url, dest)
+
+
+def _make_executable(path: Path) -> None:
+    path.chmod(path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def _find_binary(root: Path, binary: str) -> Path:
+    """Locate the extracted binary by exact name, then by prefix."""
+    target = f"{binary}.exe" if IS_WIN else binary
+    for candidate in (target, binary):
+        matches = [p for p in root.rglob(candidate) if p.is_file()]
+        if matches:
+            return matches[0]
+    matches = [p for p in root.rglob(f"{binary}*") if p.is_file()]
+    if matches:
+        return matches[0]
+    raise FileNotFoundError(f"{binary!r} not found in extracted archive under {root}")
+
+
+def _install_tool(bindir: Path, binary: str, urls_key: str, version_key: str) -> None:
+    urls = CONST[urls_key]
+    key = _platform_key(urls)
+    if key not in urls:
+        raise RuntimeError(f"no download URL for platform {key}")
+    url = urls[key].format(version=CONST[version_key])
+    final_name = f"{binary}.exe" if IS_WIN else binary
+    dest = bindir / final_name
+    archive = bindir / Path(url).name
+
+    if url.endswith((".tar.gz", ".tgz")):
+        _download(url, archive)
+        extract_dir = bindir / f"_{binary}_x"
+        with tarfile.open(archive) as tf:
+            tf.extractall(extract_dir)
+        dest.write_bytes(_find_binary(extract_dir, binary).read_bytes())
+    elif url.endswith(".zip"):
+        _download(url, archive)
+        extract_dir = bindir / f"_{binary}_x"
+        with zipfile.ZipFile(archive) as zf:
+            zf.extractall(extract_dir)
+        dest.write_bytes(_find_binary(extract_dir, binary).read_bytes())
+    else:
+        # Raw, single-file binary (e.g. sops, talisman).
+        _download(url, dest)
+
+    if not IS_WIN:
+        _make_executable(dest)
+    print(f"    -> {dest}")
+
+
+def main() -> int:
+    bindir = Path.home() / ".envdrift-test-bin"
+    bindir.mkdir(parents=True, exist_ok=True)
+    print(f"platform={sys.platform}/{platform.machine()}  bindir={bindir}\n")
+
+    installed: list[str] = []
+    failed: list[str] = []
+    for binary, urls_key, version_key in TOOLS:
+        print(f"installing {binary} {CONST[version_key]}")
+        try:
+            _install_tool(bindir, binary, urls_key, version_key)
+            installed.append(binary)
+        except Exception as exc:
+            print(f"    !! FAILED to install {binary}: {exc}")
+            failed.append(binary)
+
+    print(f"\ninstalled: {', '.join(installed) or '(none)'}")
+    if failed:
+        print(f"failed:    {', '.join(failed)}")
+
+    gh_path = os.environ.get("GITHUB_PATH")
+    if gh_path and installed:
+        with open(gh_path, "a", encoding="utf-8") as fh:
+            fh.write(f"{bindir}\n")
+
+    return 0 if installed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/cross-platform-integration.yml
+++ b/.github/workflows/cross-platform-integration.yml
@@ -55,6 +55,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -81,4 +83,4 @@ jobs:
         run: |
           uv run pytest tests/integration/ \
             -m "integration and not aws and not vault and not azure and not gcp" \
-            -p no:cacheprovider -v
+            -p no:cacheprovider --timeout=300 -v

--- a/.github/workflows/cross-platform-integration.yml
+++ b/.github/workflows/cross-platform-integration.yml
@@ -1,0 +1,84 @@
+name: Cross-Platform Integration
+
+# Runs the BINARY-BACKED integration tests (real dotenvx / sops / scanners over
+# real .env files and the real CLI) on macOS and Windows, so the encrypt,
+# decrypt, diff, partial-encryption, sops and scanner features get real
+# cross-platform coverage — not just Linux (integration-tests.yml).
+#
+# Container-backed integration (the aws / vault / azure markers, served by
+# docker-compose) stays Linux-only and is excluded here: macOS runners have no
+# Docker daemon and Windows runners only run Windows containers.
+#
+# IMPORTANT: this workflow is intentionally NOT a required status check. It is
+# expected to FAIL initially — a failing test here is a real cross-platform
+# feature bug to fix, not something to skip or xfail. Keeping it non-required
+# means those honest failures surface without blocking the merge queue; promote
+# it to required once it is reliably green (that green is the reliability goal).
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "src/**"
+      - "tests/**"
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".github/scripts/install_test_binaries.py"
+      - ".github/workflows/cross-platform-integration.yml"
+  push:
+    branches: [main]
+    paths:
+      - "src/**"
+      - "tests/**"
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".github/scripts/install_test_binaries.py"
+      - ".github/workflows/cross-platform-integration.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cross-platform-integration-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  integration:
+    name: ${{ matrix.os }} integration
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 40
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.2.0
+        with:
+          enable-cache: true
+          cache-suffix: ${{ matrix.os }}-integration
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      # Install dotenvx / sops / scanners from the pinned constants.json URLs and
+      # add them to PATH. Resilient: a tool that fails to install is logged and
+      # its tests then skip for an honest "binary absent" reason.
+      - name: Install external CLI binaries
+        run: uv run python .github/scripts/install_test_binaries.py
+
+      - name: Run binary-backed integration tests (Linux containers excluded)
+        shell: bash
+        run: |
+          uv run pytest tests/integration/ \
+            -m "integration and not aws and not vault and not azure and not gcp" \
+            -p no:cacheprovider -v

--- a/src/envdrift/cli.py
+++ b/src/envdrift/cli.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import contextlib
+import io
+import sys
 from typing import Annotated
 
 import typer
@@ -20,6 +23,28 @@ from envdrift.cli_commands.sync import lock, pull, sync
 from envdrift.cli_commands.validate import validate
 from envdrift.cli_commands.vault import vault_pull, vault_push
 from envdrift.cli_commands.version import version as version_cmd
+
+
+def _force_utf8_output() -> None:
+    """Make stdout/stderr UTF-8 so the CLI never crashes on Windows.
+
+    Windows defaults stdout/stderr to cp1252, which cannot encode the glyphs
+    envdrift prints (``→``, ``✓``, ``⚠``, the ``⠋`` progress spinner). When output
+    is captured — a pipe, a subprocess, CI — Python raises ``UnicodeEncodeError``
+    and the command dies mid-write. Reconfiguring the streams to UTF-8 (with
+    ``errors="replace"`` as a final safety net) fixes that; Linux/macOS, already
+    UTF-8, are untouched.
+    """
+    if sys.platform != "win32":
+        return
+    for stream in (sys.stdout, sys.stderr):
+        # A captured stream (pytest) may not be a TextIOWrapper; skip those.
+        if isinstance(stream, io.TextIOWrapper):
+            with contextlib.suppress(ValueError, OSError):
+                stream.reconfigure(encoding="utf-8", errors="replace")
+
+
+_force_utf8_output()
 
 
 def _version_callback(value: bool) -> None:

--- a/src/envdrift/cli.py
+++ b/src/envdrift/cli.py
@@ -37,7 +37,10 @@ def _force_utf8_output() -> None:
     """
     if sys.platform != "win32":
         return
-    for stream in (sys.stdout, sys.stderr):
+    # Windows-only; the coverage runner is Linux, so this body is unreachable
+    # there. It is really exercised by the Windows job in
+    # cross-platform-integration.yml, hence the pragma rather than a fake test.
+    for stream in (sys.stdout, sys.stderr):  # pragma: no cover
         # A captured stream (pytest) may not be a TextIOWrapper; skip those.
         if isinstance(stream, io.TextIOWrapper):
             with contextlib.suppress(ValueError, OSError):

--- a/src/envdrift/cli_commands/encryption_helpers.py
+++ b/src/envdrift/cli_commands/encryption_helpers.py
@@ -191,7 +191,11 @@ def should_skip_reencryption(
     temp_path = Path(tmp_name)
     try:
         try:
-            with os.fdopen(fd, "w") as tmp_fh:
+            # newline="" so text-mode writing does NOT translate "\n" to "\r\n"
+            # on Windows: that would corrupt the encrypted bytes and make the
+            # decrypt below fail, so smart encryption would needlessly re-encrypt
+            # (a new IV/MAC) instead of restoring the identical git version.
+            with os.fdopen(fd, "w", newline="") as tmp_fh:
                 tmp_fh.write(git_content)
 
             # Try to decrypt the git version

--- a/src/envdrift/cli_commands/guard.py
+++ b/src/envdrift/cli_commands/guard.py
@@ -377,6 +377,8 @@ def guard(
                 ["git", "rev-parse", "--show-toplevel"],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=10,
             )
             if toplevel.returncode == 0 and toplevel.stdout.strip():
@@ -392,6 +394,8 @@ def guard(
                 ["git", "diff", "--cached", "--name-only", "--diff-filter=ACMR"],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=10,
             )
             if result.returncode == 0 and result.stdout.strip():
@@ -445,6 +449,8 @@ def guard(
                 ["git", "diff", "--name-only", "--diff-filter=ACMR", f"{pr_base}...HEAD"],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=10,
             )
             if result.returncode == 0 and result.stdout.strip():

--- a/src/envdrift/cli_commands/install.py
+++ b/src/envdrift/cli_commands/install.py
@@ -274,6 +274,8 @@ def _run_agent_install(binary_path: Path) -> bool:
             [str(binary_path), "install"],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=30,
         )
         return result.returncode == 0
@@ -331,6 +333,8 @@ def install_agent(
                 [existing, "status"],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=5,
             )
             # Parse the "Running:" line value precisely; whitespace-fragile
@@ -405,6 +409,8 @@ def install_agent(
             [str(install_path), "--version"],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=5,
         )
         if result.returncode == 0:
@@ -487,6 +493,8 @@ def check_installation() -> None:
                 [agent_path, "--version"],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=5,
             )
             if result.returncode == 0:
@@ -500,6 +508,8 @@ def check_installation() -> None:
                 [agent_path, "status"],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=5,
             )
             if result.returncode == 0 and parse_agent_running_status(result.stdout) is True:

--- a/src/envdrift/encryption/sops.py
+++ b/src/envdrift/encryption/sops.py
@@ -226,6 +226,11 @@ class SOPSEncryptionBackend(EncryptionBackend):
                 cmd,
                 capture_output=True,
                 text=True,
+                # SOPS emits UTF-8; decode it as such rather than the platform
+                # locale (cp1252 on Windows would corrupt non-ASCII secret values
+                # or raise UnicodeDecodeError).
+                encoding="utf-8",
+                errors="replace",
                 timeout=120,
                 env=self._build_env(env),
                 cwd=str(cwd) if cwd else None,

--- a/src/envdrift/encryption/sops.py
+++ b/src/envdrift/encryption/sops.py
@@ -615,6 +615,7 @@ See https://github.com/getsops/sops for full documentation.
                 capture_output=True,
                 text=True,
                 encoding="utf-8",
+                errors="replace",
                 timeout=kwargs.get("timeout", 300),
             )
         except subprocess.TimeoutExpired as e:

--- a/src/envdrift/encryption/sops.py
+++ b/src/envdrift/encryption/sops.py
@@ -14,6 +14,7 @@ import re
 import shlex
 import shutil
 import subprocess  # nosec B404
+import sys
 from pathlib import Path
 from threading import Lock
 
@@ -576,8 +577,14 @@ See https://github.com/getsops/sops for full documentation.
 
         # `sops exec-env [file] [command-to-run]`: no --input-type (type is
         # inferred from the file extension), and the command is a SINGLE shell
-        # string, not a `-- argv` list. shlex.join safely quotes the argv.
-        args = ["exec-env", str(env_file), shlex.join(command)]
+        # string, not a `-- argv` list. Quote the argv for the shell sops runs it
+        # through — POSIX (shlex.join) on Unix, but cmd.exe on Windows, where
+        # POSIX single-quoting is invalid and raises "filename syntax incorrect".
+        if sys.platform == "win32":
+            command_str = subprocess.list2cmdline(command)
+        else:
+            command_str = shlex.join(command)
+        args = ["exec-env", str(env_file), command_str]
 
         return self._run(
             args,

--- a/src/envdrift/encryption/sops.py
+++ b/src/envdrift/encryption/sops.py
@@ -599,11 +599,18 @@ See https://github.com/getsops/sops for full documentation.
             child_env.update(kwargs["env"])
         child_env.update(secrets)
 
-        return subprocess.run(  # nosec B603
-            command,
-            env=child_env,
-            cwd=str(kwargs["cwd"]) if kwargs.get("cwd") else None,
-            capture_output=True,
-            text=True,
-            encoding="utf-8",
-        )
+        # Bound the child so a hung process can't block forever (the previous
+        # sops-exec-env path had _run's 120s timeout; keep a generous default,
+        # overridable via the ``timeout`` kwarg).
+        try:
+            return subprocess.run(  # nosec B603
+                command,
+                env=child_env,
+                cwd=str(kwargs["cwd"]) if kwargs.get("cwd") else None,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                timeout=kwargs.get("timeout", 300),
+            )
+        except subprocess.TimeoutExpired as e:
+            raise EncryptionBackendError(f"exec-env command timed out: {e}") from e

--- a/src/envdrift/encryption/sops.py
+++ b/src/envdrift/encryption/sops.py
@@ -10,11 +10,10 @@ Encrypted values have the format: ENC[AES256_GCM,data:...,iv:...,tag:...,type:st
 
 from __future__ import annotations
 
+import os
 import re
-import shlex
 import shutil
 import subprocess  # nosec B404
-import sys
 from pathlib import Path
 from threading import Lock
 
@@ -575,19 +574,36 @@ See https://github.com/getsops/sops for full documentation.
         if not self.is_installed():
             raise EncryptionNotFoundError(f"SOPS is not installed.\n{self.install_instructions()}")
 
-        # `sops exec-env [file] [command-to-run]`: no --input-type (type is
-        # inferred from the file extension), and the command is a SINGLE shell
-        # string, not a `-- argv` list. Quote the argv for the shell sops runs it
-        # through — POSIX (shlex.join) on Unix, but cmd.exe on Windows, where
-        # POSIX single-quoting is invalid and raises "filename syntax incorrect".
-        if sys.platform == "win32":
-            command_str = subprocess.list2cmdline(command)
-        else:
-            command_str = shlex.join(command)
-        args = ["exec-env", str(env_file), command_str]
-
-        return self._run(
-            args,
+        # Decrypt to memory and run the command directly as argv, rather than via
+        # `sops exec-env`. sops' exec-env runs the command through a shell, which
+        # makes quoting platform-specific and brittle (on Windows, cmd.exe mangles
+        # a ``python -c "...'...'..."`` string). Decrypting to stdout and invoking
+        # the child with subprocess (no shell) injects the same secrets without
+        # ever writing plaintext to disk, and behaves identically on every OS.
+        decrypt = self._run(
+            ["-d", "--input-type", "dotenv", "--output-type", "dotenv", str(env_file)],
             env=kwargs.get("env"),
             cwd=kwargs.get("cwd"),
+        )
+        if decrypt.returncode != 0:
+            raise EncryptionBackendError(f"sops decryption failed: {decrypt.stderr.strip()}")
+
+        from envdrift.core.parser import EnvParser
+
+        secrets = {
+            name: var.value
+            for name, var in EnvParser().parse_string(decrypt.stdout).variables.items()
+        }
+        child_env = dict(os.environ)
+        if kwargs.get("env"):
+            child_env.update(kwargs["env"])
+        child_env.update(secrets)
+
+        return subprocess.run(  # nosec B603
+            command,
+            env=child_env,
+            cwd=str(kwargs["cwd"]) if kwargs.get("cwd") else None,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
         )

--- a/src/envdrift/integrations/dotenvx.py
+++ b/src/envdrift/integrations/dotenvx.py
@@ -519,6 +519,8 @@ class DotenvxInstaller:
                     [str(target_path), "--version"],
                     capture_output=True,
                     text=True,
+                    encoding="utf-8",
+                    errors="replace",
                     timeout=10,
                 )
                 if self.version in result.stdout:
@@ -676,6 +678,8 @@ class DotenvxWrapper:
                 cmd,
                 capture_output=capture_output,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=120,
                 env=env,
                 cwd=str(cwd) if cwd else None,

--- a/src/envdrift/integrations/hook_check.py
+++ b/src/envdrift/integrations/hook_check.py
@@ -184,6 +184,8 @@ def _read_git_path(*args: str) -> Path | None:
             check=True,
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             env=env,
         )
     except (OSError, subprocess.CalledProcessError):

--- a/src/envdrift/scanner/detect_secrets.py
+++ b/src/envdrift/scanner/detect_secrets.py
@@ -160,6 +160,8 @@ class DetectSecretsInstaller:
                 cmd,
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=120,
             )
 
@@ -181,6 +183,8 @@ class DetectSecretsInstaller:
                 [sys.executable, "-m", "detect_secrets", "--version"],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=10,
             )
             return result.returncode == 0
@@ -271,6 +275,8 @@ class DetectSecretsScanner(ScannerBackend):
                 [sys.executable, "-m", "detect_secrets", "--version"],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=10,
             )
             self._installed = result.returncode == 0
@@ -286,6 +292,8 @@ class DetectSecretsScanner(ScannerBackend):
                 [sys.executable, "-m", "detect_secrets", "--version"],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=10,
             )
             if result.returncode == 0:
@@ -405,6 +413,8 @@ class DetectSecretsScanner(ScannerBackend):
                     args,
                     capture_output=True,
                     text=True,
+                    encoding="utf-8",
+                    errors="replace",
                     timeout=300,  # 5 minute timeout
                     cwd=working_dir,
                 )

--- a/src/envdrift/scanner/git_secrets.py
+++ b/src/envdrift/scanner/git_secrets.py
@@ -155,6 +155,8 @@ class GitSecretsInstaller:
                 ["brew", "install", "git-secrets"],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=300,
             )
 
@@ -202,6 +204,8 @@ class GitSecretsInstaller:
                     ["git", "clone", "--depth", "1", self.REPO_URL, str(repo_path)],
                     capture_output=True,
                     text=True,
+                    encoding="utf-8",
+                    errors="replace",
                     timeout=120,
                     check=True,
                 )
@@ -215,6 +219,8 @@ class GitSecretsInstaller:
                     ["make", "install", f"PREFIX={target_dir.parent}"],
                     capture_output=True,
                     text=True,
+                    encoding="utf-8",
+                    errors="replace",
                     timeout=60,
                     cwd=repo_path,
                     check=True,
@@ -319,6 +325,8 @@ class GitSecretsScanner(ScannerBackend):
                 ["git", "secrets", "--list"],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=5,
             )
             # Only check returncode - a successful command means git-secrets is installed
@@ -381,6 +389,8 @@ class GitSecretsScanner(ScannerBackend):
                 [git_secrets_path, *args],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=300,
                 cwd=cwd,
             )
@@ -390,6 +400,8 @@ class GitSecretsScanner(ScannerBackend):
             ["git", "secrets", *args],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=300,
             cwd=cwd,
         )

--- a/src/envdrift/scanner/gitleaks.py
+++ b/src/envdrift/scanner/gitleaks.py
@@ -323,6 +323,8 @@ class GitleaksInstaller:
                     [str(target_path), "version"],
                     capture_output=True,
                     text=True,
+                    encoding="utf-8",
+                    errors="replace",
                     timeout=10,
                 )
                 if self.version in result.stdout:
@@ -391,6 +393,8 @@ class GitleaksScanner(ScannerBackend):
                 [str(binary), "version"],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=10,
             )
             # Output format: "gitleaks version 8.21.2"
@@ -515,6 +519,8 @@ class GitleaksScanner(ScannerBackend):
                     args,
                     capture_output=True,
                     text=True,
+                    encoding="utf-8",
+                    errors="replace",
                     timeout=300,  # 5 minute timeout
                     cwd=str(path) if path.is_dir() else str(path.parent),
                 )

--- a/src/envdrift/scanner/infisical.py
+++ b/src/envdrift/scanner/infisical.py
@@ -253,6 +253,8 @@ class InfisicalInstaller:
                     [str(target_path), "--version"],
                     capture_output=True,
                     text=True,
+                    encoding="utf-8",
+                    errors="replace",
                     timeout=10,
                 )
                 if self.version in result.stdout:
@@ -322,6 +324,8 @@ class InfisicalScanner(ScannerBackend):
                 [str(binary), "--version"],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=10,
             )
             # Output format: "infisical version X.Y.Z"
@@ -453,6 +457,8 @@ class InfisicalScanner(ScannerBackend):
                     args,
                     capture_output=True,
                     text=True,
+                    encoding="utf-8",
+                    errors="replace",
                     timeout=300,  # 5 minute timeout
                     cwd=str(work_dir),
                 )

--- a/src/envdrift/scanner/kingfisher.py
+++ b/src/envdrift/scanner/kingfisher.py
@@ -183,6 +183,8 @@ class KingfisherScanner(ScannerBackend):
                 [str(binary), "--version"],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=10,
             )
             # Output format: "kingfisher 1.73.0"
@@ -246,6 +248,8 @@ class KingfisherScanner(ScannerBackend):
                 [brew_path, "install", "kingfisher"],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=120,  # 2 minute timeout
             )
 
@@ -429,6 +433,8 @@ class KingfisherScanner(ScannerBackend):
                     args,
                     capture_output=True,
                     text=True,
+                    encoding="utf-8",
+                    errors="replace",
                     timeout=600,  # 10 minute timeout for thorough scanning
                 )
 

--- a/src/envdrift/scanner/native.py
+++ b/src/envdrift/scanner/native.py
@@ -388,6 +388,8 @@ class NativeScanner(ScannerBackend):
                 ["git", "ls-files"],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 cwd=directory,
                 timeout=30,
             )
@@ -410,6 +412,8 @@ class NativeScanner(ScannerBackend):
                 ["git", "ls-files", "--others", "--exclude-standard", "--", _ENV_FILE_PATHSPEC],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 cwd=directory,
                 timeout=30,
             )
@@ -443,6 +447,8 @@ class NativeScanner(ScannerBackend):
                 ],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 cwd=directory,
                 timeout=30,
             )

--- a/src/envdrift/scanner/talisman.py
+++ b/src/envdrift/scanner/talisman.py
@@ -248,6 +248,8 @@ class TalismanInstaller:
                     [str(target_path), "--version"],
                     capture_output=True,
                     text=True,
+                    encoding="utf-8",
+                    errors="replace",
                     timeout=10,
                 )
                 if self.version in result.stdout or self.version in result.stderr:
@@ -318,6 +320,8 @@ class TalismanScanner(ScannerBackend):
                 [str(binary), "--version"],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=10,
             )
             # Output format varies, try to extract version
@@ -449,6 +453,8 @@ class TalismanScanner(ScannerBackend):
                         args,
                         capture_output=True,
                         text=True,
+                        encoding="utf-8",
+                        errors="replace",
                         timeout=300,  # 5 minute timeout
                         cwd=str(work_dir),
                     )

--- a/src/envdrift/scanner/trivy.py
+++ b/src/envdrift/scanner/trivy.py
@@ -248,6 +248,8 @@ class TrivyInstaller:
                     [str(target_path), "version", "--format", "json"],
                     capture_output=True,
                     text=True,
+                    encoding="utf-8",
+                    errors="replace",
                     timeout=10,
                 )
                 if self.version in result.stdout:
@@ -317,6 +319,8 @@ class TrivyScanner(ScannerBackend):
                 [str(binary), "version", "--format", "json"],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=10,
             )
             if result.returncode == 0:
@@ -435,6 +439,8 @@ class TrivyScanner(ScannerBackend):
                     args,
                     capture_output=True,
                     text=True,
+                    encoding="utf-8",
+                    errors="replace",
                     timeout=300,  # 5 minute timeout
                 )
 

--- a/src/envdrift/scanner/trufflehog.py
+++ b/src/envdrift/scanner/trufflehog.py
@@ -317,6 +317,8 @@ class TrufflehogInstaller:
                     [str(target_path), "--version"],
                     capture_output=True,
                     text=True,
+                    encoding="utf-8",
+                    errors="replace",
                     timeout=10,
                 )
                 if self.version in result.stdout:
@@ -393,6 +395,8 @@ class TrufflehogScanner(ScannerBackend):
                 [str(binary), "--version"],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=10,
             )
             # Output format: "trufflehog 3.88.3"
@@ -520,6 +524,8 @@ class TrufflehogScanner(ScannerBackend):
                     args,
                     capture_output=True,
                     text=True,
+                    encoding="utf-8",
+                    errors="replace",
                     timeout=600,  # 10 minute timeout (trufflehog can be slow)
                 )
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -14,6 +14,7 @@ import contextlib
 import os
 import socket
 import subprocess
+import sys
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -104,6 +105,45 @@ def _deterministic_cli_output(monkeypatch: pytest.MonkeyPatch) -> None:
     """
     monkeypatch.delenv("FORCE_COLOR", raising=False)
     monkeypatch.setenv("NO_COLOR", "1")
+
+
+def _force_utf8_subprocess_kwargs(kwargs: dict) -> None:
+    """Default a text-mode subprocess to UTF-8 decoding (errors='replace')."""
+    if (kwargs.get("text") or kwargs.get("universal_newlines")) and not kwargs.get("encoding"):
+        kwargs["encoding"] = "utf-8"
+        kwargs.setdefault("errors", "replace")
+
+
+@pytest.fixture(autouse=True)
+def _utf8_subprocess_on_windows(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Decode integration subprocess output as UTF-8 on Windows.
+
+    The envdrift CLI emits UTF-8 — it reconfigures its streams so it never
+    crashes on Windows' cp1252 (``cli._force_utf8_output``). But Python's
+    ``text=True`` decodes a child's stdout with the *locale* encoding, which is
+    cp1252 on Windows and raises ``UnicodeDecodeError`` on those UTF-8 bytes in
+    the subprocess reader thread. Default text-mode subprocesses to UTF-8 so the
+    harness reads the tool's real output. No-op off Windows (already UTF-8); the
+    CLI still runs under the default cp1252 locale here, so the tool's own
+    reconfigure fix is genuinely exercised.
+    """
+    if sys.platform != "win32":
+        return
+
+    real_run = subprocess.run
+    real_popen = subprocess.Popen
+
+    def patched_run(*args, **kwargs):  # type: ignore[no-untyped-def]
+        _force_utf8_subprocess_kwargs(kwargs)
+        return real_run(*args, **kwargs)
+
+    class PatchedPopen(real_popen):  # type: ignore[misc]
+        def __init__(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+            _force_utf8_subprocess_kwargs(kwargs)
+            super().__init__(*args, **kwargs)
+
+    monkeypatch.setattr(subprocess, "run", patched_run)
+    monkeypatch.setattr(subprocess, "Popen", PatchedPopen)
 
 
 # --- LocalStack (AWS) Fixtures ---

--- a/tests/unit/test_encryption_backends.py
+++ b/tests/unit/test_encryption_backends.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -722,8 +723,9 @@ class TestSOPSEncryptionBackend:
         assert backend.is_installed() is True
         installer.install.assert_called_once()
 
-    def test_exec_env_builds_command(self, tmp_path, monkeypatch):
-        """exec_env should build SOPS exec-env arguments."""
+    def test_exec_env_decrypts_to_memory_and_injects_into_argv(self, tmp_path, monkeypatch):
+        """exec_env decrypts (sops -d) to memory and runs the command as argv with
+        the secrets injected — no shell, so it is cross-platform-quoting-safe."""
         env_file = tmp_path / ".env"
         env_file.write_text('KEY="ENC[AES256_GCM,data:abc]"')
 
@@ -733,16 +735,23 @@ class TestSOPSEncryptionBackend:
         captured = {}
 
         def fake_run(args, env=None, cwd=None):
+            # sops is invoked to DECRYPT to stdout, not via exec-env.
             captured["args"] = args
-            return MagicMock(returncode=0, stderr="", stdout="")
+            return MagicMock(returncode=0, stderr="", stdout="KEY=secretval\n")
 
         monkeypatch.setattr(backend, "_run", fake_run)
 
-        result = backend.exec_env(env_file, ["echo", "ok"])
+        # The child (a real, quick python subprocess — no external binary) prints
+        # the injected secret, proving exec_env merged it into the environment.
+        result = backend.exec_env(
+            env_file,
+            [sys.executable, "-c", "import os; print(os.environ.get('KEY', ''))"],
+        )
+
+        assert captured["args"][0] == "-d"
+        assert str(env_file) in captured["args"]
         assert result.returncode == 0
-        # `sops exec-env <file> <command-as-single-shell-string>` (no
-        # --input-type; type is inferred from the file extension).
-        assert captured["args"] == ["exec-env", str(env_file), "echo ok"]
+        assert result.stdout.strip() == "secretval"
 
     def test_encrypt_includes_key_options(self, tmp_path, monkeypatch):
         """Encrypt should include provided key options in SOPS args."""

--- a/tests/unit/test_encryption_backends.py
+++ b/tests/unit/test_encryption_backends.py
@@ -753,6 +753,42 @@ class TestSOPSEncryptionBackend:
         assert result.returncode == 0
         assert result.stdout.strip() == "secretval"
 
+    def test_exec_env_child_stdout_decoded_as_utf8(self, tmp_path, monkeypatch):
+        """The child's UTF-8 stdout must decode as UTF-8 on every platform.
+
+        Regression for the Windows cp1252 default: without an explicit
+        ``encoding="utf-8"`` on the child ``subprocess.run``, a non-ASCII byte
+        (e.g. the UTF-8 of ``→``) would be mis-decoded as cp1252 mojibake (or
+        raise). The child here writes raw UTF-8 *bytes* directly, so this asserts
+        the PARENT decodes them correctly — the bug this commit fixes."""
+        non_ascii = "café-→-μ"
+        env_file = tmp_path / ".env"
+        env_file.write_text('KEY="ENC[AES256_GCM,data:abc]"')
+
+        backend = SOPSEncryptionBackend()
+        monkeypatch.setattr(backend, "is_installed", lambda: True)
+        monkeypatch.setattr(
+            backend,
+            "_run",
+            lambda args, env=None, cwd=None: MagicMock(
+                returncode=0, stderr="", stdout=f"KEY={non_ascii}\n"
+            ),
+        )
+
+        # Child emits raw UTF-8 bytes (bypassing its own stdout encoding) so the
+        # assertion isolates the parent's decode behaviour.
+        result = backend.exec_env(
+            env_file,
+            [
+                sys.executable,
+                "-c",
+                "import os, sys; sys.stdout.buffer.write(os.environ['KEY'].encode('utf-8'))",
+            ],
+        )
+
+        assert result.returncode == 0
+        assert result.stdout == non_ascii
+
     def test_encrypt_includes_key_options(self, tmp_path, monkeypatch):
         """Encrypt should include provided key options in SOPS args."""
         env_file = tmp_path / ".env"

--- a/tests/unit/test_encryption_backends.py
+++ b/tests/unit/test_encryption_backends.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import subprocess
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -837,6 +838,90 @@ class TestSOPSEncryptionBackend:
 
         assert result.returncode == 0
         assert result.stdout == non_ascii
+
+    def test_exec_env_missing_file_raises(self, tmp_path, monkeypatch):
+        """exec_env rejects a non-existent env file before touching sops."""
+        backend = SOPSEncryptionBackend()
+        monkeypatch.setattr(backend, "is_installed", lambda: True)
+
+        with pytest.raises(EncryptionBackendError, match="File not found"):
+            backend.exec_env(tmp_path / "missing.env", [sys.executable, "-c", "pass"])
+
+    def test_exec_env_not_installed_raises(self, tmp_path, monkeypatch):
+        """exec_env raises EncryptionNotFoundError when sops is absent."""
+        env_file = tmp_path / ".env"
+        env_file.write_text('KEY="ENC[AES256_GCM,data:abc]"', encoding="utf-8")
+
+        backend = SOPSEncryptionBackend()
+        monkeypatch.setattr(backend, "is_installed", lambda: False)
+
+        with pytest.raises(EncryptionNotFoundError):
+            backend.exec_env(env_file, [sys.executable, "-c", "pass"])
+
+    def test_exec_env_decrypt_failure_raises(self, tmp_path, monkeypatch):
+        """A non-zero sops decrypt surfaces its stderr as EncryptionBackendError."""
+        env_file = tmp_path / ".env"
+        env_file.write_text('KEY="ENC[AES256_GCM,data:abc]"', encoding="utf-8")
+
+        backend = SOPSEncryptionBackend()
+        monkeypatch.setattr(backend, "is_installed", lambda: True)
+        monkeypatch.setattr(
+            backend,
+            "_run",
+            lambda args, env=None, cwd=None: MagicMock(
+                returncode=1, stderr="no key for this file", stdout=""
+            ),
+        )
+
+        with pytest.raises(EncryptionBackendError, match="no key for this file"):
+            backend.exec_env(env_file, [sys.executable, "-c", "pass"])
+
+    def test_exec_env_merges_caller_env(self, tmp_path, monkeypatch):
+        """A caller-supplied env var is injected into the child alongside the secrets."""
+        env_file = tmp_path / ".env"
+        env_file.write_text('KEY="ENC[AES256_GCM,data:abc]"', encoding="utf-8")
+
+        backend = SOPSEncryptionBackend()
+        monkeypatch.setattr(backend, "is_installed", lambda: True)
+        monkeypatch.setattr(
+            backend,
+            "_run",
+            lambda args, env=None, cwd=None: MagicMock(
+                returncode=0, stderr="", stdout="KEY=secretval\n"
+            ),
+        )
+
+        result = backend.exec_env(
+            env_file,
+            [sys.executable, "-c", "import os; print(os.environ['EXTRA'])"],
+            env={"EXTRA": "from-caller"},
+        )
+
+        assert result.returncode == 0
+        assert result.stdout.strip() == "from-caller"
+
+    def test_exec_env_timeout_raises(self, tmp_path, monkeypatch):
+        """A child that exceeds the timeout is reported as EncryptionBackendError."""
+        env_file = tmp_path / ".env"
+        env_file.write_text('KEY="ENC[AES256_GCM,data:abc]"', encoding="utf-8")
+
+        backend = SOPSEncryptionBackend()
+        monkeypatch.setattr(backend, "is_installed", lambda: True)
+        monkeypatch.setattr(
+            backend,
+            "_run",
+            lambda args, env=None, cwd=None: MagicMock(
+                returncode=0, stderr="", stdout="KEY=secretval\n"
+            ),
+        )
+
+        def boom(*args, **kwargs):
+            raise subprocess.TimeoutExpired(cmd=args[0] if args else "cmd", timeout=1)
+
+        monkeypatch.setattr("envdrift.encryption.sops.subprocess.run", boom)
+
+        with pytest.raises(EncryptionBackendError, match="timed out"):
+            backend.exec_env(env_file, [sys.executable, "-c", "pass"], timeout=1)
 
     def test_encrypt_includes_key_options(self, tmp_path, monkeypatch):
         """Encrypt should include provided key options in SOPS args."""

--- a/tests/unit/test_hook_check.py
+++ b/tests/unit/test_hook_check.py
@@ -122,8 +122,8 @@ class TestReadGitPath:
 
         captured = {}
 
-        def fake_run(args, check, capture_output, text, env):
-            captured["env"] = env
+        def fake_run(args, **kwargs):
+            captured["env"] = kwargs.get("env")
             return SimpleNamespace(stdout=str(tmp_path / ".git" / "hooks") + "\n")
 
         monkeypatch.setattr(hook_check.shutil, "which", lambda _name: "/usr/bin/git")


### PR DESCRIPTION
The enabler for your goal: **real cross-platform test coverage of the binary-backed features**.

## Why

The cross-platform matrix (#442) only runs `-m "not integration"`. So the features that drive real binaries — **encrypt, decrypt, diff, partial-encryption, sops, and the secret scanners** — have **zero** cross-platform coverage today; their integration tests run only on Linux. This makes them run on macOS + Windows too.

## What

- **`.github/scripts/install_test_binaries.py`** — a standalone, cross-platform installer. Reads the pinned versions/URLs from `constants.json` (single source, no hardcoded versions), installs **dotenvx, sops, gitleaks, trufflehog, talisman, trivy, infisical** into a bin dir on PATH. Resilient (a tool that fails to install is logged + skipped so the rest run). **Verified locally on macOS — all 7 install and report `--version`.**
- **`cross-platform-integration.yml`** — runs the non-container integration suite (`-m "integration and not aws and not vault and not azure and not gcp"`) on `macos-latest` + `windows-latest`. Container-backed tests (aws/vault/azure) stay Linux-only by infra necessity.

## Method (deliberate)

**Not a required check.** It is *expected to fail initially* — each failing test here is a **real cross-platform feature bug to fix**, not something to skip or xfail. Keeping it non-required lets those honest failures surface as findings **without blocking the merge queue**. The follow-up work fixes the tool until this is green — and that green *is* the reliability goal.

No spoofing (real binaries, real CLI, no mocks), no cheating (no skip-to-hide), no save-for-later.

Refs #443, #445

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UTF‑8 handling across the CLI and subprocess interactions to avoid encoding errors on Windows and when external tools emit non‑UTF8 bytes.

* **Chores**
  * Added cross‑platform integration test workflow and a helper to install required test binaries automatically on CI runners.

* **Tests**
  * Updated integration and unit tests to ensure deterministic UTF‑8 behavior and to validate in‑memory decryption and environment injection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a cross-platform integration test workflow (`cross-platform-integration.yml`) that runs binary-backed tests on macOS and Windows, paired with a new Python installer script that downloads pinned tool binaries at CI time. It also applies a broad UTF-8 hardening pass across all `subprocess.run` calls in the scanner, encryption, and CLI-install paths — guarding against Windows cp1252 mis-decoding.

- **New CI workflow**: runs `pytest -m \"integration and not aws/vault/azure/gcp\"` on `macos-latest` and `windows-latest` with per-test `--timeout=300`; intentionally non-required so initial failures surface as real cross-platform bug findings rather than blocking merges.
- **`install_test_binaries.py`**: standalone installer that reads pinned versions from `constants.json`, downloads tarballs/zips/raw binaries for 7 tools, validates archives against zip-slip before extraction, and appends the bin dir to `GITHUB_PATH`; resilient per-tool so a single failed install doesn't abort the rest.
- **`sops.py` `exec_env` rewrite**: replaces `sops exec-env` (shell-expansion-fragile on Windows) with a `sops -d` decrypt-to-memory step followed by a direct `subprocess.run(command, env=...)` call — no shell, no disk write, cross-platform quoting safe.

<h3>Confidence Score: 5/5</h3>

Safe to merge; changes are additive CI infrastructure and defensive UTF-8 encoding fixes with no production logic regressions.

All production-path changes are strictly additive: encoding utf-8 and errors replace on subprocess calls is a net-correctness improvement with no behavior change on POSIX. The exec_env rewrite is well-tested with a real Python child process. The one outstanding item — no timeout on urlretrieve in the CI installer — can only delay a CI step; it has no effect on the production library.

.github/scripts/install_test_binaries.py: the _download function uses urlretrieve without a timeout — a stalled binary download would silently consume the runner's wall-clock budget instead of surfacing as a timed-out per-tool failure.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/scripts/install_test_binaries.py | New cross-platform binary installer for CI; resilient per-tool failure handling and zip/tar-slip guards are solid, but urlretrieve lacks a timeout so a stalled download blocks the whole step. |
| .github/workflows/cross-platform-integration.yml | New macOS+Windows integration workflow; --timeout=300 is present, fail-fast disabled, container markers correctly excluded. |
| src/envdrift/encryption/sops.py | exec_env rewritten to decrypt via sops -d to memory and run the child as argv (no shell); encoding=utf-8/errors=replace and a 300s timeout are all present. |
| tests/integration/conftest.py | Added autouse _utf8_subprocess_on_windows fixture that patches subprocess.run/Popen on Windows to inject encoding=utf-8; correctly no-ops on POSIX. |
| tests/unit/test_encryption_backends.py | Tests updated to validate new decrypt-to-memory exec_env; new tests cover UTF-8 round-trip, missing file, bad decrypt, caller env merging. |
| src/envdrift/cli.py | Added _force_utf8_output() that reconfigures stdout/stderr to UTF-8 on Windows at import time; POSIX is untouched. |
| src/envdrift/integrations/dotenvx.py | Added encoding=utf-8/errors=replace to subprocess.run calls in installer and wrapper; no logic changes. |
| src/envdrift/scanner/gitleaks.py | Added encoding=utf-8/errors=replace to all subprocess.run calls; no logic changes. |
| src/envdrift/cli_commands/install.py | Added encoding=utf-8/errors=replace to agent install/status subprocess calls; no logic changes. |

</details>

<sub>Reviews (10): Last reviewed commit: ["test(sops): cover exec\_env error/edge br..."](https://github.com/jainal09/envdrift/commit/458f90ae1eeb2525b107393ae1af04c8277d74fb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36480316)</sub>

<!-- /greptile_comment -->