### PR TITLE
fix(encrypt): refuse a filename dotenvx can't turn into a valid key (prevents secret lockout)

### DIFF
--- a/src/envdrift/encryption/dotenvx.py
+++ b/src/envdrift/encryption/dotenvx.py
@@ -135,6 +135,27 @@ class DotenvxEncryptionBackend(EncryptionBackend):
                 file_path=env_file,
             )
 
+        # Refuse a filename dotenvx would turn into an invalid private-key
+        # variable name. dotenvx derives the DOTENV_PRIVATE_KEY_<SLUG> env-var
+        # name from the filename; a space or non-ASCII character produces an
+        # invalid name (e.g. "DOTENV_PRIVATE_KEY_MY SECRETS..."), so the value
+        # encrypts and dotenvx exits 0 — but the file is then permanently
+        # undecryptable: the original plaintext is destroyed and the secret is
+        # locked out for good, and the plaintext-survival check below cannot
+        # catch it (the value *is* encrypted, only the key name is unusable).
+        # Only [A-Za-z0-9._-] filenames round-trip safely (#443).
+        if not re.fullmatch(r"[A-Za-z0-9._-]+", env_file.name):
+            return EncryptionResult(
+                success=False,
+                message=(
+                    f"Refusing to encrypt {env_file}: its filename contains "
+                    "characters dotenvx cannot turn into a valid key name, which "
+                    "would leave the file permanently undecryptable. Rename it to "
+                    "use only letters, digits, '.', '-' and '_'."
+                ),
+                file_path=env_file,
+            )
+
         if not self.is_installed():
             raise EncryptionNotFoundError(
                 f"dotenvx is not installed.\n{self.install_instructions()}"

--- a/tests/unit/test_encryption_backends.py
+++ b/tests/unit/test_encryption_backends.py
@@ -299,6 +299,8 @@ class TestDotenvxEncryptionBackend:
         result = backend.encrypt(env_file)
 
         assert result.success is False
+        # Pin the failure to the filename guard, not e.g. the empty-file guard.
+        assert "undecryptable" in result.message.lower()
         # Original plaintext preserved — not encrypted into an unrecoverable file.
         assert env_file.read_text() == "SECRET=keepme\n"
 
@@ -311,6 +313,7 @@ class TestDotenvxEncryptionBackend:
         result = backend.encrypt(env_file)
 
         assert result.success is False
+        assert "undecryptable" in result.message.lower()
         assert env_file.read_text() == "SECRET=keepme\n"
 
     @patch("envdrift.integrations.dotenvx.DotenvxWrapper")

--- a/tests/unit/test_encryption_backends.py
+++ b/tests/unit/test_encryption_backends.py
@@ -283,6 +283,36 @@ class TestDotenvxEncryptionBackend:
         assert result.success is False
         assert "not found" in result.message
 
+    def test_encrypt_filename_with_space_refused_preserves_plaintext(self, tmp_path):
+        """#23: a filename dotenvx can't turn into a valid key name must be refused.
+
+        ``my secrets.env`` makes dotenvx derive a private-key variable name with a
+        space (``DOTENV_PRIVATE_KEY_MY SECRETS...``): the value encrypts and exits
+        0, but the file is then permanently undecryptable and the original
+        plaintext is destroyed — silent secret lockout. The backend must refuse
+        pre-flight and leave the file byte-for-byte untouched.
+        """
+        env_file = tmp_path / "my secrets.env"
+        env_file.write_text("SECRET=keepme\n")
+
+        backend = DotenvxEncryptionBackend()
+        result = backend.encrypt(env_file)
+
+        assert result.success is False
+        # Original plaintext preserved — not encrypted into an unrecoverable file.
+        assert env_file.read_text() == "SECRET=keepme\n"
+
+    def test_encrypt_unicode_filename_refused(self, tmp_path):
+        """#23: a non-ASCII filename also yields an invalid dotenvx key name."""
+        env_file = tmp_path / "café.env"
+        env_file.write_text("SECRET=keepme\n")
+
+        backend = DotenvxEncryptionBackend()
+        result = backend.encrypt(env_file)
+
+        assert result.success is False
+        assert env_file.read_text() == "SECRET=keepme\n"
+
     @patch("envdrift.integrations.dotenvx.DotenvxWrapper")
     def test_decrypt_success(self, mock_wrapper_class, tmp_path):
         """Test successful decryption."""


### PR DESCRIPTION
## What

P2 of the #443 re-audit (#23): `encrypt` on a filename with a space or non-ASCII char reports `[OK]` / exit 0 but leaves the file **permanently undecryptable** — the original plaintext is destroyed and the secret is locked out for good.

## Why

dotenvx derives the `DOTENV_PRIVATE_KEY_<SLUG>` variable name from the **filename**. `'my secrets.env'` → `DOTENV_PRIVATE_KEY_MY SECRETS…` — a space in an env-var name is invalid, so decrypt can never find the key. The existing plaintext-survival guard can't catch it (the value *is* encrypted; only the key name is unusable), and `encrypt --check` even reports "100% encrypted".

## Reproduction (real CLI)

```
printf 'SECRET=keepme\n' > 'my secrets.env'
envdrift encrypt 'my secrets.env'   # BEFORE: [OK]/exit 0, plaintext DESTROYED
envdrift decrypt 'my secrets.env'   # BEFORE: [ERROR] MISSING_PRIVATE_KEY, exit 1 — locked out
# AFTER: encrypt -> [ERROR] Refusing to encrypt … (exit 1), file untouched
```

## Fix

A pre-flight guard in the dotenvx backend (before the destructive call, and before `is_installed`) refuses to encrypt when the filename is not `[A-Za-z0-9._-]+`. Those are the names that round-trip safely (`postgresql.env`, `svc.env.docker`, `app-local.env` still encrypt); a space/unicode name now gets a clear `[ERROR]` to rename it. The original file is left byte-for-byte untouched.

## Tests (dogfood, test-first)

- **New** `test_encrypt_filename_with_space_refused_preserves_plaintext` — **red** before the fix (encrypt succeeded and destroyed the file), green after (refused, plaintext byte-identical).
- **New** `test_encrypt_unicode_filename_refused` — same for `café.env`.
- Existing custom-filename round-trip + the full 89-test encryption-backends module still pass.

Part of the #443 backlog (P2 of 9). See the [re-audit](https://github.com/jainal09/envdrift/issues/443#issuecomment-4663943129).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a pre-flight filename-validity guard to `DotenvxEncryptionBackend.encrypt` that refuses to proceed when the filename contains characters dotenvx cannot slugify into a valid env-var key name. Without this guard, encrypting `my secrets.env` exits 0 but leaves the file permanently undecryptable.

- **`src/envdrift/encryption/dotenvx.py`**: Inserts a `re.fullmatch(r"[A-Za-z0-9._-]+", env_file.name)` check after the empty-file guard; returns a descriptive `EncryptionResult(success=False, …)` and leaves the file byte-for-byte untouched when the filename fails.
- **`tests/unit/test_encryption_backends.py`**: Adds two regression tests (space in filename, non-ASCII filename) that assert `success is False`, pin the failure to the filename guard via `"undecryptable" in result.message.lower()`, and verify the original plaintext is preserved.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a pre-flight guard that only adds a new early-return path; existing filenames that already round-trip correctly are unaffected.

The fix is a narrow, well-tested addition: a single `re.fullmatch` check returns a descriptive failure before any destructive I/O. The regex is correct, `re` is already imported, the character class is well-formed, and the two new tests pin the guard to the right code path via message-substring assertion and byte-exact file verification. No existing behaviour is altered.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/envdrift/encryption/dotenvx.py | Adds a correctly-anchored filename guard using `re.fullmatch`; `re` is already imported, the regex character class is well-formed, and the return path leaves the file untouched. |
| tests/unit/test_encryption_backends.py | Two new regression tests cover space and unicode filenames; both assert on `success`, message substring, and byte-exact file content, adequately pinning the new guard. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[encrypt called] --> B{File exists?}
    B -- No --> C[Return failure: file not found]
    B -- Yes --> D{file_has_assignment?}
    D -- No --> E[Return failure: nothing to encrypt]
    D -- Yes --> F{re.fullmatch\nA-Za-z0-9._- filename?}
    F -- No --> G[Return failure: invalid filename\nfile left untouched]
    F -- Yes --> H{is_installed?}
    H -- No --> I[Raise EncryptionNotFoundError]
    H -- Yes --> J[dotenvx encrypt]
    J --> K{has_plaintext_secret_value?}
    K -- Yes --> L[Return failure: encryption didn't take effect]
    K -- No --> M[Return success]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/envdrift/encryption/dotenvx.py`, line 107-114 ([link](https://github.com/jainal09/envdrift/blob/b0f733b0eb44c953cc5ad71dffb829f67f611805/src/envdrift/encryption/dotenvx.py#L107-L114)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Filename validity is a pure string check but runs after disk I/O**

   `file_has_assignment` opens and reads the file before the filename is even inspected. Since the filename check is zero-cost, moving it immediately after `env_file = Path(env_file)` (before the exists check or any I/O) makes the common bad-name path faster and removes any accidental dependency on file content. The ordering doesn't cause a correctness bug today, but the current placement is surprising given the comment says "before the destructive call, and before `is_installed`".
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["test(encrypt): assert the filename-guard..."](https://github.com/jainal09/envdrift/commit/cc825ad1cb1638f4182109de5b59ce9bf1370cfe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36586669)</sub>

<!-- /greptile_comment -->