### PR TITLE
fix(validate): enforce Pydantic field constraints so a rejected config can't pass

### DIFF
--- a/src/envdrift/core/schema.py
+++ b/src/envdrift/core/schema.py
@@ -15,6 +15,11 @@ from pydantic_settings import BaseSettings
 # Environment variable to signal schema extraction mode
 ENVDRIFT_SCHEMA_EXTRACTION = "ENVDRIFT_SCHEMA_EXTRACTION"
 
+# Field types whose validation is fully covered by the name-based type check, so
+# a schema using only these (with no constraints/validators) needs no real
+# model_validate pass.
+_PLAIN_SCALARS = (str, int, float, bool)
+
 
 @dataclass
 class FieldMetadata:
@@ -55,6 +60,11 @@ class SchemaMetadata:
     # Pydantic field-constraint checks (ge/le, Literal, min_length, pattern, ...)
     # rather than only the name-based type heuristics derived from the metadata.
     model_class: type[BaseSettings] | None = None
+    # True when at least one field carries validation beyond a plain scalar type
+    # (a constraint, a Literal/special/nested type, or a custom validator). Lets
+    # the validator skip the (relatively expensive) real model_validate pass for
+    # trivially-typed schemas, where the name-based type check already suffices.
+    has_constraints: bool = False
 
     @property
     def required_fields(self) -> list[str]:
@@ -230,6 +240,13 @@ class SchemaLoader:
 
         schema.extra_policy = extra if extra else "ignore"
 
+        # Track whether any field needs real Pydantic validation (a constraint, a
+        # non-plain-scalar type such as Literal/EmailStr/a nested model, or a
+        # custom validator). A model with only plain str/int/float/bool fields is
+        # fully covered by the name-based type check, so the validator can skip
+        # the expensive model_validate pass for it.
+        has_constraints = False
+
         # Extract field metadata
         for field_name, field_info in settings_cls.model_fields.items():
             # Check if field is required
@@ -250,6 +267,14 @@ class SchemaLoader:
 
             # Get type annotation as string
             annotation = field_info.annotation
+
+            # Does this field carry validation beyond a plain scalar type?
+            # field_info.metadata holds constraint markers (Ge/Le/MinLen/Pattern/
+            # ...); a non-plain annotation (Literal, Optional, a special pydantic
+            # type, a nested model) also needs the real validator.
+            if field_info.metadata or annotation not in _PLAIN_SCALARS:
+                has_constraints = True
+
             if annotation is not None:
                 if hasattr(annotation, "__name__"):
                     type_str = annotation.__name__
@@ -274,6 +299,17 @@ class SchemaLoader:
                 alias=field_alias,
             )
 
+        # A custom @field_validator / @model_validator can reject otherwise
+        # plainly-typed values, so it too requires the real validator.
+        decorators = getattr(settings_cls, "__pydantic_decorators__", None)
+        if decorators is not None and (
+            getattr(decorators, "field_validators", None)
+            or getattr(decorators, "model_validators", None)
+            or getattr(decorators, "validators", None)
+        ):
+            has_constraints = True
+
+        schema.has_constraints = has_constraints
         return schema
 
     def get_schema_metadata_func(

--- a/src/envdrift/core/schema.py
+++ b/src/envdrift/core/schema.py
@@ -51,6 +51,10 @@ class SchemaMetadata:
     module_path: str
     fields: dict[str, FieldMetadata] = field(default_factory=dict)
     extra_policy: str = "ignore"  # "forbid", "ignore", "allow"
+    # The live Settings class, when available, so validation can run the real
+    # Pydantic field-constraint checks (ge/le, Literal, min_length, pattern, ...)
+    # rather than only the name-based type heuristics derived from the metadata.
+    model_class: type[BaseSettings] | None = None
 
     @property
     def required_fields(self) -> list[str]:
@@ -213,6 +217,7 @@ class SchemaLoader:
         schema = SchemaMetadata(
             class_name=settings_cls.__name__,
             module_path=settings_cls.__module__,
+            model_class=settings_cls,
         )
 
         # Determine extra policy from model_config

--- a/src/envdrift/core/validator.py
+++ b/src/envdrift/core/validator.py
@@ -4,9 +4,31 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass, field
+from typing import Literal, Union, get_args, get_origin
 
 from envdrift.core.parser import EncryptionStatus, EnvFile
 from envdrift.core.schema import FieldMetadata, SchemaMetadata
+
+_COERCIBLE_SCALARS = (str, int, float, bool)
+
+
+def _is_string_coercible(tp: object) -> bool:
+    """True if model_validate can validate a *raw env string* against ``tp``.
+
+    Pydantic-settings parses complex types (``list``/``dict``/nested models) from
+    their env string via JSON in its env source; ``model_validate`` of the raw
+    string does not, so feeding it such a field would wrongly reject a config the
+    real schema accepts. Only scalars, ``Literal``, and Optionals of those accept
+    a string directly, so only those are checked via model_validate.
+    """
+    if tp in _COERCIBLE_SCALARS:
+        return True
+    origin = get_origin(tp)
+    if origin is Literal:
+        return True
+    if origin is Union:  # Optional[X] / X | None
+        return all(arg is type(None) or _is_string_coercible(arg) for arg in get_args(tp))
+    return False
 
 
 @dataclass
@@ -239,6 +261,12 @@ class Validator:
                 # Mirror _check_type's skips: ciphertext and empty (= unset).
                 if value == "" or value.startswith(("encrypted:", "ENC[")):
                     continue
+                # Only feed fields whose raw env string model_validate can check.
+                # Complex types (list/dict/nested) are JSON-parsed by the env source
+                # at runtime, which model_validate of the raw string does not do, so
+                # including them would wrongly reject a valid config (#443 review).
+                if not _is_string_coercible(field_meta.field_type):
+                    continue
                 values[field_meta.alias or field_name] = value
 
             try:
@@ -255,6 +283,11 @@ class Validator:
                     field_name = alias_to_field.get(key, key)
                     if field_name in schema.fields and field_name not in result.type_errors:
                         result.type_errors[field_name] = err.get("msg", "invalid value")
+            except Exception:
+                # A model-level @model_validator / model_post_init can raise a
+                # non-ValidationError; the base-type check already ran, so a
+                # constraint-pass failure must not crash validate (#443 review).
+                pass
 
         # Determine overall validity
         # Note: unencrypted_secrets are warnings, not errors

--- a/src/envdrift/core/validator.py
+++ b/src/envdrift/core/validator.py
@@ -225,8 +225,9 @@ class Validator:
         # The heuristic above only parses base types, so a config the real schema
         # rejects on a *constraint* used to pass as valid (#443). Instantiate the
         # live Settings class with the type-valid, non-encrypted, non-empty values
-        # and surface the constraint errors the heuristic cannot see.
-        if schema.model_class is not None:
+        # and surface the constraint errors the heuristic cannot see. Skipped for
+        # trivially-typed schemas (no constraints), where it would only add cost.
+        if schema.model_class is not None and schema.has_constraints:
             from pydantic import ValidationError
 
             values: dict[str, str] = {}

--- a/src/envdrift/core/validator.py
+++ b/src/envdrift/core/validator.py
@@ -210,7 +210,8 @@ class Validator:
                                 "but is not marked sensitive in schema"
                             )
 
-        # Basic type validation
+        # Basic type validation (name-based). Produces envdrift's own messages and
+        # skips encrypted/empty values; kept as the source of base-type errors.
         for field_name, field_meta in schema.fields.items():
             env_var = env_by_lower.get(_lookup_key(field_meta))
             if env_var is None:
@@ -219,6 +220,40 @@ class Validator:
             type_error = self._check_type(env_var.value, field_meta.field_type)
             if type_error:
                 result.type_errors[field_name] = type_error
+
+        # Field-constraint validation (ge/le, Literal, min_length, pattern, ...).
+        # The heuristic above only parses base types, so a config the real schema
+        # rejects on a *constraint* used to pass as valid (#443). Instantiate the
+        # live Settings class with the type-valid, non-encrypted, non-empty values
+        # and surface the constraint errors the heuristic cannot see.
+        if schema.model_class is not None:
+            from pydantic import ValidationError
+
+            values: dict[str, str] = {}
+            for field_name, field_meta in schema.fields.items():
+                env_var = env_by_lower.get(_lookup_key(field_meta))
+                if env_var is None:
+                    continue
+                value = env_var.value
+                # Mirror _check_type's skips: ciphertext and empty (= unset).
+                if value == "" or value.startswith(("encrypted:", "ENC[")):
+                    continue
+                values[field_meta.alias or field_name] = value
+
+            try:
+                schema.model_class.model_validate(values)
+            except ValidationError as exc:
+                alias_to_field = {(fm.alias or name): name for name, fm in schema.fields.items()}
+                for err in exc.errors():
+                    # missing/extra are reported via missing_required / extra_vars;
+                    # don't override a base-type message the heuristic already set.
+                    if err.get("type") in ("missing", "extra_forbidden"):
+                        continue
+                    loc = err.get("loc") or ()
+                    key = str(loc[0]) if loc else ""
+                    field_name = alias_to_field.get(key, key)
+                    if field_name in schema.fields and field_name not in result.type_errors:
+                        result.type_errors[field_name] = err.get("msg", "invalid value")
 
         # Determine overall validity
         # Note: unencrypted_secrets are warnings, not errors

--- a/tests/unit/test_validator.py
+++ b/tests/unit/test_validator.py
@@ -312,6 +312,35 @@ NEW_FEATURE_FLAG=enabled
         assert result.valid is False
         assert "PORT" in result.type_errors
 
+    def test_validate_enforces_pydantic_field_constraints(self, tmp_path):
+        """#18: field constraints (ge/le/Literal/min_length/pattern) must be enforced.
+
+        validate previously did only name-based type checks and never instantiated
+        the Settings class, so a config the real Pydantic schema REJECTS sailed
+        through as 'Validation PASSED' (exit 0) — a false pass on the CI gate.
+        """
+        from typing import Literal
+
+        from pydantic import Field
+        from pydantic_settings import BaseSettings
+
+        class ConstrainedSettings(BaseSettings):
+            PORT: int = Field(ge=1, le=65535)
+            LOG_LEVEL: Literal["debug", "info", "warning", "error"]
+            APP_NAME: str = Field(min_length=3)
+            VERSION: str = Field(pattern=r"^v\d+\.\d+\.\d+$")
+
+        # Type-correct values that every constraint nonetheless rejects.
+        env_file = tmp_path / ".env"
+        env_file.write_text("PORT=99999\nLOG_LEVEL=trace\nAPP_NAME=ab\nVERSION=not-a-version\n")
+
+        env = EnvParser().parse(env_file)
+        schema = SchemaLoader().extract_metadata(ConstrainedSettings)
+        result = Validator().validate(env, schema, check_encryption=False)
+
+        assert result.valid is False
+        assert set(result.type_errors) >= {"PORT", "LOG_LEVEL", "APP_NAME", "VERSION"}
+
     def test_validate_suspicious_plaintext(self, tmp_path, permissive_settings_class):
         """Warn about plaintext values matching secret patterns."""
         content = """

--- a/tests/unit/test_validator.py
+++ b/tests/unit/test_validator.py
@@ -341,6 +341,37 @@ NEW_FEATURE_FLAG=enabled
         assert result.valid is False
         assert set(result.type_errors) >= {"PORT", "LOG_LEVEL", "APP_NAME", "VERSION"}
 
+    def test_validate_runs_custom_validator_on_plain_field(self, tmp_path):
+        """A custom @field_validator on a plain-typed field is still enforced.
+
+        The field is a bare ``str`` (no constraint metadata), so the only
+        validation is the custom validator — has_constraints must flag it so the
+        real model_validate pass runs and surfaces the rejection.
+        """
+        from pydantic import field_validator
+        from pydantic_settings import BaseSettings
+
+        class Settings(BaseSettings):
+            NAME: str
+
+            @field_validator("NAME")
+            @classmethod
+            def _no_spaces(cls, v: str) -> str:
+                if " " in v:
+                    raise ValueError("must not contain spaces")
+                return v
+
+        env_file = tmp_path / ".env"
+        env_file.write_text("NAME=has spaces\n")
+
+        env = EnvParser().parse(env_file)
+        schema = SchemaLoader().extract_metadata(Settings)
+        assert schema.has_constraints is True  # custom validator detected
+
+        result = Validator().validate(env, schema, check_encryption=False)
+        assert result.valid is False
+        assert "NAME" in result.type_errors
+
     def test_validate_suspicious_plaintext(self, tmp_path, permissive_settings_class):
         """Warn about plaintext values matching secret patterns."""
         content = """

--- a/tests/unit/test_validator.py
+++ b/tests/unit/test_validator.py
@@ -419,6 +419,28 @@ NEW_FEATURE_FLAG=enabled
         assert "PORT" in result.type_errors
         assert "Expected integer" in result.type_errors["PORT"]
 
+    def test_validate_does_not_false_fail_on_complex_typed_field(self, tmp_path):
+        """#443 review: a valid config with a complex (list) field must not be
+        rejected. pydantic-settings parses such fields from JSON in its env source;
+        the constraint pass skips them rather than reject the raw string.
+        """
+        from pydantic import Field
+        from pydantic_settings import BaseSettings
+
+        class Settings(BaseSettings):
+            TAGS: list[str]
+            PORT: int = Field(ge=1, le=65535)  # a constraint -> has_constraints True
+
+        env_file = tmp_path / ".env"
+        env_file.write_text('TAGS=["a","b","c"]\nPORT=8080\n')
+
+        env = EnvParser().parse(env_file)
+        schema = SchemaLoader().extract_metadata(Settings)
+        result = Validator().validate(env, schema, check_encryption=False)
+
+        assert result.valid is True
+        assert "TAGS" not in result.type_errors
+
     def test_validate_suspicious_plaintext(self, tmp_path, permissive_settings_class):
         """Warn about plaintext values matching secret patterns."""
         content = """

--- a/tests/unit/test_validator.py
+++ b/tests/unit/test_validator.py
@@ -372,6 +372,53 @@ NEW_FEATURE_FLAG=enabled
         assert result.valid is False
         assert "NAME" in result.type_errors
 
+    def test_validate_constraint_pass_skips_missing_encrypted_and_empty(self, tmp_path):
+        """The constraint pass skips fields the env omits, encrypts, or leaves
+        empty, and never double-reports a missing required field as a type error.
+        """
+        from pydantic import Field
+        from pydantic_settings import BaseSettings
+
+        class Settings(BaseSettings):
+            PORT: int = Field(ge=1, le=65535)  # present + valid
+            SECRET: str = Field(min_length=10)  # encrypted -> can't constraint-check
+            NOTES: str = Field(min_length=5)  # empty -> unset
+            REQUIRED_MISSING: str = Field(min_length=3)  # absent from env
+
+        env_file = tmp_path / ".env"
+        env_file.write_text("PORT=8080\nSECRET=encrypted:abc\nNOTES=\n")
+
+        env = EnvParser().parse(env_file)
+        schema = SchemaLoader().extract_metadata(Settings)
+        result = Validator().validate(env, schema, check_encryption=False)
+
+        # Absent required field is reported as missing, not a min_length type error.
+        assert "REQUIRED_MISSING" in result.missing_required
+        assert "REQUIRED_MISSING" not in result.type_errors
+        # Encrypted + empty values are not flagged by the constraint pass.
+        assert "SECRET" not in result.type_errors
+        assert "NOTES" not in result.type_errors
+
+    def test_validate_constraint_pass_keeps_base_type_message(self, tmp_path):
+        """A field failing both the base-type check and Pydantic keeps the
+        base-type message — the constraint pass must not override it.
+        """
+        from pydantic import Field
+        from pydantic_settings import BaseSettings
+
+        class Settings(BaseSettings):
+            PORT: int = Field(ge=1, le=65535)
+
+        env_file = tmp_path / ".env"
+        env_file.write_text("PORT=not_a_number\n")
+
+        env = EnvParser().parse(env_file)
+        schema = SchemaLoader().extract_metadata(Settings)
+        result = Validator().validate(env, schema, check_encryption=False)
+
+        assert "PORT" in result.type_errors
+        assert "Expected integer" in result.type_errors["PORT"]
+
     def test_validate_suspicious_plaintext(self, tmp_path, permissive_settings_class):
         """Warn about plaintext values matching secret patterns."""
         content = """


### PR DESCRIPTION
## What

P3 of the #443 re-audit (#18): `validate` reports **"Validation PASSED" / exit 0** on a config the real Pydantic Settings class **rejects** — field constraints (`ge`/`le`, `Literal`, `min_length`, `pattern`, …) were never enforced. A false pass on the CI gate.

(The companion finding #20 — multiline quoted values misparsed — is split out to #458 because it changes the core `EnvParser`.)

## Why

The validator only did name-based base-type checks (`int`/`float`/`bool`/`list`) and **never instantiated the Settings class**, so constraints were invisible.

## Reproduction (real CLI)

```
# schema: PORT:int=Field(ge=1,le=65535); LOG_LEVEL:Literal[...]; APP_NAME:str=Field(min_length=3); VERSION:str=Field(pattern=...)
printf 'PORT=99999\nLOG_LEVEL=trace\nAPP_NAME=ab\nVERSION=not-a-version\n' > .env
envdrift validate .env --schema config:Settings --no-check-encryption --ci
# BEFORE: Validation PASSED, exit 0   (real pydantic raises 4 ValidationErrors)
# AFTER:  Validation FAILED, exit 1   (PORT le, LOG_LEVEL literal, APP_NAME min_length, VERSION pattern)
```

## Fix

`SchemaMetadata` now carries the live `model_class` (set by `extract_metadata`). The validator keeps the heuristic base-type pass (preserving its messages and the encrypted/empty skips), then validates the type-valid, non-encrypted, non-empty values against the real class via `model_validate` and surfaces the constraint errors the heuristic can't see. `missing`/`extra` pydantic errors are ignored (already reported as `missing_required`/`extra_vars`), and a base-type message is never overridden. `model_validate` applies real constraints, coerces string env values, and does not read `os.environ`.

## Tests (dogfood, test-first)

- **New** `test_validate_enforces_pydantic_field_constraints` — **red** before the fix (PASSED), green after (all four constraints flagged).
- The three edge-case tests for float/bool messages and encrypted/empty skipping still pass (caught + fixed during the change).
- Full non-integration suite (**2492**) green; verified end-to-end with the real CLI.

Part of the #443 backlog (P3 of 9). See the [re-audit](https://github.com/jainal09/envdrift/issues/443#issuecomment-4663943129).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes a false-pass gap in `envdrift validate`: field constraints (`ge`/`le`, `Literal`, `min_length`, `pattern`, custom validators) were invisible to the validator because it only ran name-based type checks and never instantiated the Settings class. A two-stage approach is now used — the existing heuristic runs first (preserving its messages and encrypted/empty skips), then the live class is validated with `model_validate` on a filtered subset of values.

- `SchemaMetadata` gains `model_class` (the live Settings class) and `has_constraints` (set when any field has constraint metadata, a non-plain-scalar type, or a custom validator); the expensive `model_validate` pass is skipped entirely for trivially-typed schemas.
- `_is_string_coercible` guards against false-positives by excluding complex types (list/dict/nested models) that pydantic-settings parses via its JSON env source rather than from a raw string.
- Five new unit tests cover the fixed path end-to-end: enforced constraints, custom field validators, skip-on-encrypted/empty/absent, base-type message priority, and no false-fail on list fields.

<h3>Confidence Score: 5/5</h3>

Safe to merge. The two-stage validation approach is well-guarded: complex types are explicitly skipped to avoid false-positives, `missing`/`extra_forbidden` pydantic errors are filtered to avoid double-reporting, the heuristic message takes priority over constraint messages, and a broad `Exception` guard prevents a user-defined after-validator from crashing the CLI.

The change is narrowly scoped: the existing heuristic path is untouched, and the new constraint pass only runs when `model_class` and `has_constraints` are both set. Every identified edge case (encrypted values, empty values, complex types, partial dicts raising missing errors, base-type message clobbering, non-ValidationError exceptions) has both handling code and a corresponding test. No new data paths are exposed externally.

No files require special attention. `validator.py` carries the most logic change but is thoroughly tested.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/envdrift/core/schema.py | Adds `model_class` and `has_constraints` to `SchemaMetadata`, and detects constraints/validators during `extract_metadata` to decide whether the deep-validate pass is needed. Logic is correct and the decorator sniffing via `__pydantic_decorators__` cleanly handles custom field/model validators. |
| src/envdrift/core/validator.py | Adds `_is_string_coercible` helper and the constraint-validation pass via `model_validate`. Correctly skips encrypted/empty values, complex types (list/dict/nested), and filters `missing`/`extra_forbidden` pydantic errors. Base-type message preservation and broad Exception guard for non-ValidationError model validators are both in place. |
| tests/unit/test_validator.py | Five new tests cover the fix comprehensively: enforcing constraints, custom field validators, skip-on-encrypted/empty/absent, base-type message preservation, and no false-fail on complex list fields. Edge cases are well-exercised. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CLI
    participant Validator
    participant BaseTypeCheck as _check_type (heuristic)
    participant Pydantic as model_validate (real Pydantic)

    CLI->>Validator: validate(env_file, schema)
    Validator->>Validator: build env_by_lower index
    Validator->>Validator: check missing required / extra vars / encryption

    loop for each field
        Validator->>BaseTypeCheck: _check_type(value, field_type)
        BaseTypeCheck-->>Validator: type_error or None
        Note over BaseTypeCheck: skips encrypted / empty values
    end

    alt schema.model_class is not None AND schema.has_constraints
        Validator->>Validator: build values dict (coercible, non-encrypted, non-empty fields only)
        Validator->>Pydantic: model_class.model_validate(values)
        alt ValidationError raised
            Pydantic-->>Validator: list of field errors
            loop for each pydantic error
                Note over Validator: skip missing / extra_forbidden
                Note over Validator: skip if base-type error already set
                Validator->>Validator: map alias to field_name
                Validator->>Validator: "result.type_errors[field_name] = msg"
            end
        else non-ValidationError raised
            Pydantic-->>Validator: Exception (caught, suppressed)
        else no error
            Pydantic-->>Validator: validated model (discarded)
        end
    end

    Validator-->>CLI: ValidationResult (valid / type_errors / missing / extras)
```

<sub>Reviews (6): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/validate-en..."](https://github.com/jainal09/envdrift/commit/793f658e06791ced135994636cd94b187609c2a1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36590216)</sub>

<!-- /greptile_comment -->