### PR TITLE
fix(init): prefix leading-underscore sanitized keys so the generated schema imports

### DIFF
--- a/src/envdrift/cli_commands/init_cmd.py
+++ b/src/envdrift/cli_commands/init_cmd.py
@@ -83,12 +83,19 @@ def _sanitize_identifier(name: str) -> str:
 def _needs_sanitizing(name: str) -> bool:
     """True when ``name`` cannot be used as a bare Settings attribute name.
 
-    Flags non-identifiers, Python keywords, and names colliding with pydantic's
-    reserved attribute namespace (``model_`` prefix or a BaseSettings/BaseModel
-    member) — all of which produce a broken or non-importable module if emitted
-    as a bare field annotation.
+    Flags non-identifiers, a leading underscore (a valid Python identifier but
+    one Pydantic rejects — "Fields must not use names with leading underscores"),
+    Python keywords, and names colliding with pydantic's reserved attribute
+    namespace (``model_`` prefix or a BaseSettings/BaseModel member) — all of
+    which produce a broken or non-importable module if emitted as a bare field
+    annotation.
     """
-    return not name.isidentifier() or keyword.iskeyword(name) or _is_pydantic_reserved(name)
+    return (
+        not name.isidentifier()
+        or name.startswith("_")
+        or keyword.iskeyword(name)
+        or _is_pydantic_reserved(name)
+    )
 
 
 def _nfkc(name: str) -> str:

--- a/src/envdrift/cli_commands/init_cmd.py
+++ b/src/envdrift/cli_commands/init_cmd.py
@@ -58,16 +58,20 @@ class SettingsGeneration:
 def _sanitize_identifier(name: str) -> str:
     """Turn an arbitrary .env key into a valid, non-keyword, non-reserved identifier.
 
-    Non-identifier characters become ``_``; a leading digit (or empty result)
-    gets a ``field_`` prefix; a Python keyword/soft-keyword gets a ``_`` suffix.
-    A name colliding with pydantic's reserved attribute namespace (``model_``
-    prefix, or a BaseSettings/BaseModel attribute such as ``schema``/``dict``) is
-    given a ``field_`` prefix so it cannot raise at import or shadow model
-    internals. The original name is preserved separately as a Pydantic alias so
-    the schema still round-trips against the real environment variable.
+    Non-identifier characters become ``_``; a leading digit, a leading underscore,
+    or an empty result gets a ``field_`` prefix; a Python keyword/soft-keyword
+    gets a ``_`` suffix. A leading underscore arises when a key starts with a
+    non-word character (e.g. ``.dotstart`` -> ``_dotstart``, ``🔑EMOJI`` ->
+    ``_EMOJI``); Pydantic rejects such field names ("Fields must not use names
+    with leading underscores"), so they need the prefix too. A name colliding
+    with pydantic's reserved attribute namespace (``model_`` prefix, or a
+    BaseSettings/BaseModel attribute such as ``schema``/``dict``) is given a
+    ``field_`` prefix so it cannot raise at import or shadow model internals. The
+    original name is preserved separately as a Pydantic alias so the schema still
+    round-trips against the real environment variable.
     """
     sanitized = re.sub(r"\W", "_", name)
-    if not sanitized or sanitized[0].isdigit():
+    if not sanitized or sanitized[0].isdigit() or sanitized.startswith("_"):
         sanitized = f"field_{sanitized}"
     if _is_pydantic_reserved(sanitized):
         sanitized = f"field_{sanitized}"

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1739,7 +1739,11 @@ class TestInitCommand:
         must prefix these like leading-digit keys so the schema imports.
         """
         env_file = tmp_path / ".env"
-        env_file.write_text(".dotstart=x\n🔑EMOJI=emojivalue\nNORMAL=ok\n", encoding="utf-8")
+        # `.dotstart`/`🔑EMOJI` sanitize to a leading underscore; `_PRIVATE` already
+        # starts with one natively — both must be prefixed so the module imports.
+        env_file.write_text(
+            ".dotstart=x\n🔑EMOJI=emojivalue\n_PRIVATE=secret\nNORMAL=ok\n", encoding="utf-8"
+        )
         out = tmp_path / "settings.py"
 
         result = runner.invoke(
@@ -1750,9 +1754,10 @@ class TestInitCommand:
         content = out.read_text(encoding="utf-8")
         # No field annotation may start with an underscore.
         assert "\n    _" not in content
-        # The original keys survive as aliases.
+        # The original keys survive as aliases (sanitized-to- and natively-leading _).
         assert "alias='.dotstart'" in content
         assert "alias='🔑EMOJI'" in content
+        assert "alias='_PRIVATE'" in content
 
         # The generated module must import (raised NameError before the fix).
         spec = importlib.util.spec_from_file_location("gen_underscore_settings", out)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1729,6 +1729,38 @@ class TestInitCommand:
         assert cfg.field_model_config == "b"
         assert cfg.field_schema == "c"
 
+    def test_init_underscore_prefixed_key_produces_importable_module(self, tmp_path: Path) -> None:
+        """#16: keys whose sanitized name starts with '_' stay importable.
+
+        A dot/emoji-prefixed key (``.dotstart``, ``🔑EMOJI``) sanitizes to a
+        leading-underscore name (``_dotstart``, ``_EMOJI``), which Pydantic
+        rejects at import ("Fields must not use names with leading underscores").
+        init exited 0 / [OK] while emitting an unimportable module; the sanitizer
+        must prefix these like leading-digit keys so the schema imports.
+        """
+        env_file = tmp_path / ".env"
+        env_file.write_text(".dotstart=x\n🔑EMOJI=emojivalue\nNORMAL=ok\n", encoding="utf-8")
+        out = tmp_path / "settings.py"
+
+        result = runner.invoke(
+            app, ["init", str(env_file), "--output", str(out), "--class-name", "Cfg"]
+        )
+        assert result.exit_code == 0, result.output
+
+        content = out.read_text(encoding="utf-8")
+        # No field annotation may start with an underscore.
+        assert "\n    _" not in content
+        # The original keys survive as aliases.
+        assert "alias='.dotstart'" in content
+        assert "alias='🔑EMOJI'" in content
+
+        # The generated module must import (raised NameError before the fix).
+        spec = importlib.util.spec_from_file_location("gen_underscore_settings", out)
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        assert hasattr(module, "Cfg")
+
 
 class TestHookCommand:
     """Tests for the hook CLI command."""


### PR DESCRIPTION
## What

P4 of the #443 re-audit (#16, the last HIGH): a `.env` key starting with a non-word character (`.dotstart`, `🔑EMOJI`) sanitizes to a **leading-underscore** field name. Pydantic rejects those, so `init` exits 0 / `[OK]` while emitting a `settings.py` that raises `NameError` **on import** — the schema (and `validate` against it) is unusable.

## Reproduction

```
printf '🔑EMOJI=v\n.dotstart=x\nNORMAL=ok\n' > .env
envdrift init .env -o s.py --class-name Cfg   # [OK], exit 0
python -c "import s"
# BEFORE: NameError: Fields must not use names with leading underscores ...
# AFTER:  imports; fields field__dotstart, NORMAL, field__EMOJI (originals aliased)
```

## Fix

`_sanitize_identifier` gives a leading-underscore result the same `field_` prefix it already gives a leading digit. One-line condition extension; the original key round-trips via its Pydantic alias.

## Test (dogfood, test-first)

`test_init_underscore_prefixed_key_produces_importable_module` — **red** before (module raises `NameError` on `exec_module`), green after. All 35 init tests pass.

Part of the #443 backlog (P4 of 9). See the [re-audit](https://github.com/jainal09/envdrift/issues/443#issuecomment-4663943129).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `envdrift init` to properly handle `.env` keys with special characters that generate Python identifiers starting with underscores (e.g., `.dotstart`), ensuring the generated settings module remains importable.

* **Tests**
  * Added test coverage for environment keys with non-standard prefixes like dots and emojis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes `envdrift init` for `.env` keys whose sanitized form starts with a leading underscore (e.g. `.dotstart` → `_dotstart`, `🔑EMOJI` → `_EMOJI`) and for natively leading-underscore keys like `_PRIVATE`, all of which Pydantic rejects as field names. The fix extends both `_sanitize_identifier` (adds `field_` prefix when the sanitized name starts with `_`) and `_needs_sanitizing` (flags native leading-underscore keys), with a new test that covers all three cases and verifies the generated module imports.

- `_sanitize_identifier` now applies the same `field_` prefix logic to leading-underscore results that it already applied to leading-digit and empty results.
- `_needs_sanitizing` gains `name.startswith(\"_\")` so native `_PRIVATE`-style keys are routed through the sanitizer; however, this same function is also reused to validate `--class-name`, which causes valid leading-underscore class names (e.g. `_Settings`) to be incorrectly rejected.

<h3>Confidence Score: 4/5</h3>

Safe to merge for the common case; one edge-case regression needs a small follow-up fix before the release if underscore-prefixed class names are a realistic user scenario.

The field-name fix is correct and well-tested. The side-effect is that `_needs_sanitizing` now also gates class name validation, so `--class-name=_Settings` (a valid Python class name that Pydantic accepts) now exits with a misleading "not a valid Python identifier" error. The regression is narrow in scope and doesn't affect the generated output for any currently passing case, but it silently breaks a contract that worked before.

src/envdrift/cli_commands/init_cmd.py — the shared use of `_needs_sanitizing` for both field-name and class-name validation at line 269.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/envdrift/cli_commands/init_cmd.py | Fixes leading-underscore field names in both sanitizer and needs_sanitizing; inadvertently causes _needs_sanitizing to reject leading-underscore class names via the shared validation call at line 269. |
| tests/unit/test_cli.py | New test covers the three key cases (.dotstart, emoji-prefix, natively-leading-underscore) including importability; addresses the gap surfaced by the previous review thread. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[".env key (e.g. .dotstart, _PRIVATE, NORMAL)"] --> B["_needs_sanitizing(name)"]
    B -->|"not isidentifier OR starts with _ OR keyword OR pydantic-reserved"| C["_sanitize_identifier(name)"]
    B -->|"clean identifier"| D["use name as-is"]
    C --> E["re.sub non-word chars → '_'"]
    E --> F{empty OR starts with digit OR starts with '_'?}
    F -->|yes| G["prefix: field_{sanitized}"]
    F -->|no| H["keep sanitized"]
    G --> I{pydantic reserved?}
    H --> I
    I -->|yes| J["prefix: field_{name}"]
    I -->|no| K{Python keyword?}
    J --> K
    K -->|yes| L["suffix: name_"]
    K -->|no| M["final field name"]
    L --> M
    D --> N["_resolve_field_name returns (field_name, alias?)"]
    M --> N
    N --> O["_render_field_line → emitted in settings.py"]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `src/envdrift/cli_commands/init_cmd.py`, line 83-91 ([link](https://github.com/jainal09/envdrift/blob/5a2f7b2d6547ec821f74aacaaa72b2e4b2efd994/src/envdrift/cli_commands/init_cmd.py#L83-L91)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`_needs_sanitizing` misses native leading-underscore keys**

   `_needs_sanitizing` returns `False` for any key that is already a valid Python identifier — including keys like `_DEBUG` or `_SECRET` that start with `_`. When it returns `False`, `_resolve_field_name` short-circuits and uses the raw key as the field name, so `_sanitize_identifier` (where the fix lives) is never reached. A `.env` file containing `_DEBUG=1` still generates `    _DEBUG: str = ...` in the output, which Pydantic rejects at import with "Fields must not use names with leading underscores" — the exact same error the PR is fixing for `.dotstart`/`🔑EMOJI`. Adding `or name.startswith("_")` to `_needs_sanitizing` closes the gap.

2. `src/envdrift/cli_commands/init_cmd.py`, line 269-270 ([link](https://github.com/jainal09/envdrift/blob/b7df2e98208491a697b968f301a0e9101e03e590/src/envdrift/cli_commands/init_cmd.py#L269-L270)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`_needs_sanitizing` now incorrectly rejects valid class names**

   `generate_settings_module` uses `_needs_sanitizing` to gate class name validation. With the new `or name.startswith("_")` condition, any `--class-name` that begins with `_` (e.g. `_Settings`, `_PrivateConfig`) now raises `ValueError: ... is not a valid Python identifier` even though `_Settings` is a perfectly valid Python class name that Pydantic happily accepts as a `BaseSettings` subclass. The leading-underscore restriction is Pydantic-field-specific; it does not apply to class definitions. A user calling `envdrift init .env --class-name _PrivateSettings` gets a misleading error when the generated module would have imported fine.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/init-leadin..."](https://github.com/jainal09/envdrift/commit/b7df2e98208491a697b968f301a0e9101e03e590) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36594906)</sub>

<!-- /greptile_comment -->