### PR TITLE
fix(parser): guard the shared read seam against directory and non-UTF-8 inputs

### DIFF
--- a/src/envdrift/cli_commands/diff.py
+++ b/src/envdrift/cli_commands/diff.py
@@ -67,7 +67,9 @@ def _read_env(path: Path, format_: str) -> EnvFile:
         _emit_error(f"Not a file: {path}", format_)
     try:
         return EnvParser().parse(path)
-    except UnicodeDecodeError:
+    except (UnicodeDecodeError, ValueError):
+        # EnvParser now converts a non-UTF-8 read into a clean ValueError; keep
+        # catching the raw UnicodeDecodeError too for belt-and-suspenders.
         _emit_error(f"Could not read {path} as UTF-8 text (not a valid .env file)", format_)
 
 

--- a/src/envdrift/cli_commands/diff.py
+++ b/src/envdrift/cli_commands/diff.py
@@ -67,9 +67,9 @@ def _read_env(path: Path, format_: str) -> EnvFile:
         _emit_error(f"Not a file: {path}", format_)
     try:
         return EnvParser().parse(path)
-    except (UnicodeDecodeError, ValueError):
-        # EnvParser now converts a non-UTF-8 read into a clean ValueError; keep
-        # catching the raw UnicodeDecodeError too for belt-and-suspenders.
+    except ValueError:
+        # EnvParser converts a non-UTF-8 read into a ValueError (UnicodeDecodeError
+        # is itself a ValueError subclass), so this one arm covers both.
         _emit_error(f"Could not read {path} as UTF-8 text (not a valid .env file)", format_)
 
 

--- a/src/envdrift/cli_commands/encryption.py
+++ b/src/envdrift/cli_commands/encryption.py
@@ -243,7 +243,13 @@ def encrypt_cmd(
 
     # Parse env file
     parser = EnvParser()
-    env = parser.parse(env_file)
+    try:
+        env = parser.parse(env_file)
+    except (IsADirectoryError, ValueError) as e:
+        # A directory passed instead of a file, or a non-UTF-8 / binary file —
+        # surface cleanly instead of an uncaught traceback (#24, #25).
+        print_error(str(e))
+        raise typer.Exit(code=1) from None
 
     # Analyze encryption
     detector = EncryptionDetector()

--- a/src/envdrift/cli_commands/init_cmd.py
+++ b/src/envdrift/cli_commands/init_cmd.py
@@ -322,7 +322,9 @@ def _generate_or_exit(
         raise typer.Exit(code=1)
     try:
         return generate_settings_module(env_file, class_name, detect_sensitive)
-    except ValueError as exc:
+    except (IsADirectoryError, ValueError) as exc:
+        # IsADirectoryError: a directory passed instead of a file; ValueError: an
+        # invalid class name or a non-UTF-8 / binary env file (#24, #25).
         print_error(str(exc))
         raise typer.Exit(code=1) from exc
 

--- a/src/envdrift/cli_commands/validate.py
+++ b/src/envdrift/cli_commands/validate.py
@@ -121,7 +121,9 @@ def validate(
     parser = EnvParser()
     try:
         env = parser.parse(env_file, lenient=True)
-    except FileNotFoundError as e:
+    except (FileNotFoundError, IsADirectoryError, ValueError) as e:
+        # IsADirectoryError: a directory passed where a file is expected;
+        # ValueError: a non-UTF-8 / binary file. Surface both cleanly (#24, #25).
         print_error(str(e))
         raise typer.Exit(code=1) from None
 

--- a/src/envdrift/core/encryption.py
+++ b/src/envdrift/core/encryption.py
@@ -302,7 +302,14 @@ class EncryptionDetector:
         if not path.exists():
             return None
 
-        content = path.read_text(encoding="utf-8")
+        try:
+            content = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            # Not readable as UTF-8 text (binary blob, directory, ...): it is not a
+            # dotenvx/sops-encrypted file, so no backend is detected. Returning
+            # None (rather than crashing) lets decrypt auto-detect fall back to a
+            # clean per-backend message instead of a raw traceback (#13).
+            return None
         return self.detect_backend(content)
 
     def is_file_encrypted(self, path: Path) -> bool:
@@ -318,7 +325,11 @@ class EncryptionDetector:
         if not path.exists():
             return False
 
-        content = path.read_text(encoding="utf-8")
+        try:
+            content = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            # A non-UTF-8/binary file or a directory holds no encryption markers.
+            return False
         return self.has_encrypted_header(content)
 
     def is_value_encrypted(self, value: str) -> bool:

--- a/src/envdrift/core/parser.py
+++ b/src/envdrift/core/parser.py
@@ -175,7 +175,20 @@ class EnvParser:
         if not path.exists():
             raise FileNotFoundError(f"ENV file not found: {path}")
 
-        content = path.read_text(encoding="utf-8")
+        # A directory passed where a file is expected used to fall through to
+        # read_text and surface an uncaught IsADirectoryError traceback across
+        # init/encrypt/decrypt/validate; raise a clean, typed error instead (#25).
+        if not path.is_file():
+            raise IsADirectoryError(f"Not a file: {path}")
+
+        # A binary / non-UTF-8 file raised a raw UnicodeDecodeError traceback;
+        # convert it to a clean ValueError with an actionable message (#24).
+        try:
+            content = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError as exc:
+            raise ValueError(
+                f"Could not read {path} as UTF-8 text (not a valid .env file)"
+            ) from exc
         env_file = self.parse_string(content, lenient=lenient)
         env_file.path = path
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -5395,3 +5395,47 @@ class TestDetectEnvFile:
         assert detection.path is not None
         assert detection.path.name == ".env"
         assert detection.environment == "production"
+
+
+class TestReadSeamGuards:
+    """#24/#25: init/encrypt/validate surface a directory or a non-UTF-8 file as a
+    clean error, not an uncaught IsADirectoryError / UnicodeDecodeError traceback."""
+
+    def test_init_on_directory_is_clean_error(self, tmp_path: Path) -> None:
+        a_dir = tmp_path / "adir"
+        a_dir.mkdir()
+        result = runner.invoke(app, ["init", str(a_dir), "-o", str(tmp_path / "o.py")])
+        assert result.exit_code != 0
+        assert "Not a file" in result.output
+        assert result.exc_info is None or not isinstance(result.exception, IsADirectoryError)
+
+    def test_init_on_non_utf8_is_clean_error(self, tmp_path: Path) -> None:
+        bad = tmp_path / ".env.bad"
+        bad.write_bytes(b"API_KEY=secret\nPASSWORD=p\xff\xc3ss\n")
+        result = runner.invoke(app, ["init", str(bad), "-o", str(tmp_path / "o.py")])
+        assert result.exit_code != 0
+        assert "UTF-8" in result.output
+
+    def test_validate_on_directory_is_clean_error(self, tmp_path: Path) -> None:
+        env = tmp_path / ".env"
+        env.write_text("FOO=bar\n")
+        runner.invoke(app, ["init", str(env), "-o", str(tmp_path / "s.py"), "--class-name", "Cfg"])
+        a_dir = tmp_path / "adir"
+        a_dir.mkdir()
+        result = runner.invoke(
+            app, ["validate", str(a_dir), "--schema", "s:Cfg", "-d", str(tmp_path)]
+        )
+        assert result.exit_code != 0
+        assert "Not a file" in result.output
+
+    def test_validate_on_non_utf8_is_clean_error(self, tmp_path: Path) -> None:
+        env = tmp_path / ".env"
+        env.write_text("FOO=bar\n")
+        runner.invoke(app, ["init", str(env), "-o", str(tmp_path / "s.py"), "--class-name", "Cfg"])
+        bad = tmp_path / ".env.bad"
+        bad.write_bytes(b"FOO=p\xff\xc3ss\n")
+        result = runner.invoke(
+            app, ["validate", str(bad), "--schema", "s:Cfg", "-d", str(tmp_path)]
+        )
+        assert result.exit_code != 0
+        assert "UTF-8" in result.output

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -5439,3 +5439,17 @@ class TestReadSeamGuards:
         )
         assert result.exit_code != 0
         assert "UTF-8" in result.output
+
+    def test_encrypt_check_on_directory_is_clean_error(self, tmp_path: Path) -> None:
+        a_dir = tmp_path / "adir"
+        a_dir.mkdir()
+        result = runner.invoke(app, ["encrypt", "--check", str(a_dir)])
+        assert result.exit_code != 0
+        assert "Not a file" in result.output
+
+    def test_encrypt_check_on_non_utf8_is_clean_error(self, tmp_path: Path) -> None:
+        bad = tmp_path / ".env.bad"
+        bad.write_bytes(b"FOO=p\xff\xc3ss\n")
+        result = runner.invoke(app, ["encrypt", "--check", str(bad)])
+        assert result.exit_code != 0
+        assert "UTF-8" in result.output

--- a/tests/unit/test_encryption.py
+++ b/tests/unit/test_encryption.py
@@ -144,6 +144,26 @@ BAZ=qux
         nonexistent = tmp_path / ".env.nonexistent"
         assert detector.is_file_encrypted(nonexistent) is False
 
+    def test_detection_on_non_utf8_and_directory_does_not_crash(self, tmp_path):
+        """#13: a binary/non-UTF-8 file or a directory has no encryption markers.
+
+        ``detect_backend_for_file`` used to read the file as UTF-8 with no guard,
+        so decrypt's auto-detect crashed with an uncaught UnicodeDecodeError on a
+        binary blob. It (and ``is_file_encrypted``) must return None/False
+        gracefully instead.
+        """
+        detector = EncryptionDetector()
+
+        blob = tmp_path / "blob.env"
+        blob.write_bytes(b"\x00\x01\x02\xff\xfe\xfd\x80\x81\x82\xc0\xc1")
+        assert detector.detect_backend_for_file(blob) is None
+        assert detector.is_file_encrypted(blob) is False
+
+        a_dir = tmp_path / "adir"
+        a_dir.mkdir()
+        assert detector.detect_backend_for_file(a_dir) is None
+        assert detector.is_file_encrypted(a_dir) is False
+
     def test_encryption_ratio(self, tmp_path):
         """Test encryption ratio calculation."""
         # 2 encrypted, 2 plaintext = 50%

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -138,6 +138,29 @@ BAZ=qux
         with pytest.raises(FileNotFoundError):
             parser.parse(tmp_path / "nonexistent.env")
 
+    def test_parse_directory_raises_clean_error(self, tmp_path):
+        """#25: a directory where a file is expected raises a clean, typed error.
+
+        It used to fall through to read_text and surface an uncaught
+        IsADirectoryError traceback from init/encrypt/decrypt/validate.
+        """
+        a_dir = tmp_path / "adir"
+        a_dir.mkdir()
+        parser = EnvParser()
+
+        with pytest.raises(IsADirectoryError, match="Not a file"):
+            parser.parse(a_dir)
+
+    def test_parse_non_utf8_raises_value_error_not_traceback(self, tmp_path):
+        """#24: a non-UTF-8 file raises a clean ValueError, not a raw
+        UnicodeDecodeError traceback."""
+        bad = tmp_path / ".env.bad"
+        bad.write_bytes(b"API_KEY=secret\nPASSWORD=p\xff\xc3ss\n")
+        parser = EnvParser()
+
+        with pytest.raises(ValueError, match="UTF-8"):
+            parser.parse(bad)
+
     def test_env_file_is_encrypted_property(self, tmp_path):
         """Test EnvFile.is_encrypted property."""
         encrypted_content = 'FOO="encrypted:BDQE123..."'


### PR DESCRIPTION
## What

P5 of the #443 re-audit (#24, #25, #13): a directory passed where a file is expected, or a binary / non-UTF-8 file, surfaced an uncaught `IsADirectoryError` / `UnicodeDecodeError` **traceback** across `init`, `encrypt --check`, `validate`, and `decrypt`'s auto-detect. `diff` was already hardened; this fixes the two shared seams the rest of the commands use.

## Fix

- **`EnvParser.parse()`**: reject a non-file with a clean `IsADirectoryError` ("Not a file: …") and convert a non-UTF-8 read into a clean `ValueError` ("Could not read … as UTF-8 text").
- **`EncryptionDetector.detect_backend_for_file()` / `is_file_encrypted()`**: return `None`/`False` on an unreadable (binary/dir) file instead of crashing, so `decrypt`'s auto-detect falls back to a clean per-backend message (the binary blob now reports `[WARN] Nothing to decrypt`).
- **`validate` / `init` / `encrypt`** catch `(IsADirectoryError, ValueError)` → clean `[ERROR]`; `diff._read_env` catches the converted `ValueError` too.

## Reproduction (all were tracebacks before)

```
envdrift validate adir   ...   # BEFORE: IsADirectoryError traceback / AFTER: [ERROR] Not a file: adir
envdrift validate bad.env ...  # BEFORE: UnicodeDecodeError traceback / AFTER: [ERROR] Could not read ... as UTF-8 text
envdrift decrypt blob.env      # BEFORE: UnicodeDecodeError traceback / AFTER: [WARN] Nothing to decrypt
```

## Tests (dogfood, test-first)

- `test_parse_directory_raises_clean_error`, `test_parse_non_utf8_raises_value_error_not_traceback` (parser seam).
- `test_detection_on_non_utf8_and_directory_does_not_crash` (detector seam).
- `TestReadSeamGuards` — CliRunner tests asserting `init`/`validate` emit a clean error (no traceback) on a directory and a non-UTF-8 file.

Each is red before the fix (uncaught traceback). Full non-integration suite (**2500**) passes.

Part of the #443 backlog (P5 of 9). See the [re-audit](https://github.com/jainal09/envdrift/issues/443#issuecomment-4663943129).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens two shared input-reading seams against directory and non-UTF-8 inputs that were previously surfacing as uncaught tracebacks across `init`, `encrypt`, `validate`, and `decrypt`'s auto-detect path.

- **`EnvParser.parse()`** now raises a clean `IsADirectoryError` for non-file paths and wraps `UnicodeDecodeError` into an actionable `ValueError`, so all callers automatically inherit the guard.
- **`EncryptionDetector.detect_backend_for_file()` and `is_file_encrypted()`** silently return `None`/`False` on unreadable inputs, letting `decrypt`'s auto-detect fall through to a clean per-backend message.
- CLI commands (`init`, `encrypt`, `validate`) extend their `except` clauses to catch both new exception types, and `diff._read_env` is simplified to a single `except ValueError` arm (since `UnicodeDecodeError` is a `ValueError` subclass and the parser already wraps it). New unit and CLI tests confirm each path is red before the fix.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are narrowly scoped error-handling guards with no effect on the happy path.

The fix centralises the guard at the parser seam so every command inherits it automatically, and the CLI commands extend their existing except clauses consistently. The `_emit_error` function in `diff.py` is typed `NoReturn`, confirming the pre-existing `is_file()` guard always terminates before reaching the parser, so the simplified `except ValueError` arm is complete. Six new CLI tests and two new unit tests cover every added code path and were written to be red before the fix.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/envdrift/core/parser.py | Adds `is_file()` guard that raises `IsADirectoryError` and wraps `UnicodeDecodeError` → `ValueError` before propagation; clean and correct. |
| src/envdrift/core/encryption.py | Both `detect_backend_for_file` and `is_file_encrypted` now catch `(OSError, UnicodeDecodeError)` and return `None`/`False`; the broad `OSError` catch is appropriate here since unreadable inputs are treated as 'no encryption'. |
| src/envdrift/cli_commands/validate.py | Extends `except FileNotFoundError` to `(FileNotFoundError, IsADirectoryError, ValueError)` to cleanly surface the two new parser error types. |
| src/envdrift/cli_commands/init_cmd.py | Extends the except clause to include `IsADirectoryError`, consistent with the other CLI command guards. |
| src/envdrift/cli_commands/encryption.py | Wraps `parser.parse()` in a new try/except catching `(IsADirectoryError, ValueError)`, consistent with `init` and `validate`. |
| src/envdrift/cli_commands/diff.py | Simplifies `except (UnicodeDecodeError, ...)` to `except ValueError`; `_emit_error` is typed `NoReturn`, so the pre-existing `is_file()` guard prevents `IsADirectoryError` from ever reaching the except clause. |
| tests/unit/test_parser.py | Two new unit tests verify the clean `IsADirectoryError` and `ValueError` raises at the parser seam; straightforward and correct. |
| tests/unit/test_encryption.py | New test covers both `detect_backend_for_file` and `is_file_encrypted` on a binary blob and a directory, confirming graceful `None`/`False` returns. |
| tests/unit/test_cli.py | New `TestReadSeamGuards` class adds six CLI-level tests covering directory and non-UTF-8 inputs for `init`, `validate`, and `encrypt --check`. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[CLI Command: init / encrypt / validate / diff] --> B[EnvParser.parse]
    B --> C{path.exists?}
    C -- No --> D[raise FileNotFoundError]
    C -- Yes --> E{path.is_file?}
    E -- No --> F[raise IsADirectoryError\nNot a file]
    E -- Yes --> G[path.read_text utf-8]
    G -- UnicodeDecodeError --> H[raise ValueError\nCould not read as UTF-8]
    G -- OK --> I[parse_string EnvFile]
    D --> J[CLI: catch FileNotFoundError\nprint_error + Exit 1]
    F --> K[CLI: catch IsADirectoryError\nprint_error + Exit 1]
    H --> L[CLI: catch ValueError\nprint_error + Exit 1]
    I --> M[Continue command logic]
    N[decrypt auto-detect\nEncryptionDetector] --> O[detect_backend_for_file\nis_file_encrypted]
    O --> P{path.exists?}
    P -- No --> Q[return None or False]
    P -- Yes --> R[path.read_text utf-8]
    R -- OSError or UnicodeDecodeError --> S[return None or False\nNothing to decrypt]
    R -- OK --> T[detect_backend / has_encrypted_header]
```

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/parser-read..."](https://github.com/jainal09/envdrift/commit/2fda07062afa5dd1f014c62a09c871708279cb98) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36596571)</sub>

<!-- /greptile_comment -->