### PR TITLE
fix(config): surface config/schema-load failures as clean errors, not tracebacks

### DIFF
--- a/src/envdrift/cli_commands/sync.py
+++ b/src/envdrift/cli_commands/sync.py
@@ -125,6 +125,12 @@ def load_sync_config_and_client(
         except tomllib.TOMLDecodeError as e:
             print_error(f"TOML syntax error in {config_path}: {e}")
             raise typer.Exit(code=1) from None
+        except ValueError as e:
+            # A malformed section (e.g. a sync mapping missing secret_name) now
+            # raises a clean ValueError from load_config instead of a raw
+            # KeyError traceback (#443 #32).
+            print_error(f"Invalid config in {config_path}: {e}")
+            raise typer.Exit(code=1) from None
         except ConfigNotFoundError:
             pass
     elif config_file is None:

--- a/src/envdrift/config.py
+++ b/src/envdrift/config.py
@@ -267,6 +267,15 @@ class PartialEncryptionConfig:
 def _build_vault_config(vault_section: dict[str, Any]) -> VaultConfig:
     """Build the vault config, including its nested ``[vault.sync]`` section."""
     sync_section = vault_section.get("sync", {})
+    for m in sync_section.get("mappings", []):
+        missing = [k for k in ("secret_name", "folder_path") if k not in m]
+        if missing:
+            # Raw subscripts used to raise an uncaught KeyError traceback when a
+            # mapping omitted a required key (#443 #32).
+            raise ValueError(
+                f"[[vault.sync.mappings]] entry is missing required key(s) "
+                f"{', '.join(missing)}: {m!r}"
+            )
     sync_mappings = [
         SyncMappingConfig(
             secret_name=m["secret_name"],
@@ -351,6 +360,12 @@ def _build_guard_config(guard_section: dict[str, Any]) -> GuardConfig:
     scanners = guard_section.get("scanners", ["native", "gitleaks"])
     if isinstance(scanners, str):
         scanners = [scanners]
+    elif not isinstance(scanners, list) or not all(isinstance(s, str) for s in scanners):
+        # A non-iterable / non-string-list (e.g. ``scanners = 123``) used to crash
+        # guard with an uncaught TypeError when iterated (#443 #29).
+        raise ValueError(
+            f"[guard] scanners must be a string or a list of strings, got {scanners!r}"
+        )
     return GuardConfig(
         scanners=scanners,
         auto_install=guard_section.get("auto_install", True),
@@ -528,6 +543,10 @@ def load_config(path: Path | str | None = None) -> EnvdriftConfig:
         path = Path(path)
         if not path.exists():
             raise ConfigNotFoundError(f"Configuration file not found: {path}")
+        if not path.is_file():
+            # A directory (or other non-file) passed as --config used to reach
+            # open() and raise an uncaught IsADirectoryError traceback (#443 #30).
+            raise ConfigNotFoundError(f"Configuration path is not a file: {path}")
     else:
         path = find_config()
         if path is None:

--- a/src/envdrift/core/schema.py
+++ b/src/envdrift/core/schema.py
@@ -174,8 +174,15 @@ class SchemaLoader:
         try:
             with _isolated_import(module_path, service_dir) as module:
                 settings_cls = self._resolve_settings_class(module, module_path, class_name)
+        except SchemaLoadError:
+            raise  # already a clean error (missing class / not a BaseSettings)
         except ImportError as e:
             raise SchemaLoadError(f"Cannot import module '{module_path}': {e}") from e
+        except Exception as e:
+            # Any other error raised *while importing the schema module*
+            # (SyntaxError, NameError, RuntimeError, ...) used to escape as a raw
+            # traceback; surface it as a clean schema-load error (#443 #21).
+            raise SchemaLoadError(f"Error importing schema module '{module_path}': {e}") from e
         finally:
             os.environ.pop(ENVDRIFT_SCHEMA_EXTRACTION, None)
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -2171,6 +2171,21 @@ class TestSyncCommand:
         assert missing_provider.exit_code == 1
         assert "--provider" in missing_provider.output
 
+    def test_sync_mapping_missing_secret_name_is_clean_error(self, tmp_path: Path, monkeypatch):
+        """#32: a sync mapping missing secret_name surfaces a clean error, not a
+        raw KeyError traceback (covers sync's new except ValueError branch)."""
+        monkeypatch.chdir(tmp_path)
+        cfg = tmp_path / "envdrift.toml"
+        cfg.write_text(
+            '[vault]\nprovider = "azure"\n\n[[vault.sync.mappings]]\nfolder_path = "services/app"\n'
+        )
+
+        result = runner.invoke(app, ["sync", "--config", str(cfg)])
+
+        assert result.exit_code != 0
+        assert "secret_name" in result.output
+        assert "Traceback" not in result.output
+
     def test_sync_hook_check_errors_exit(self, monkeypatch, tmp_path: Path):
         """Sync should stop early when hook checks fail."""
         config_file = tmp_path / "envdrift.toml"

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -258,6 +258,32 @@ class TestLoadConfig:
             load_config(tmp_path / "nonexistent.toml")
         assert "not found" in str(exc_info.value)
 
+    def test_load_config_directory_raises_clean_error(self, tmp_path: Path):
+        """#30: a directory passed as --config raises ConfigNotFoundError, not a
+        raw IsADirectoryError traceback when open() is reached."""
+        a_dir = tmp_path / "somedir"
+        a_dir.mkdir()
+        with pytest.raises(ConfigNotFoundError, match="not a file"):
+            load_config(a_dir)
+
+    def test_load_config_non_iterable_scanners_raises_clean_error(self, tmp_path: Path):
+        """#29: a non-list/str [guard] scanners value raises a clean ValueError
+        instead of crashing later with a TypeError when iterated."""
+        cfg = tmp_path / "envdrift.toml"
+        cfg.write_text("[guard]\nscanners = 123\n")
+        with pytest.raises(ValueError, match="scanners"):
+            load_config(cfg)
+
+    def test_load_config_sync_mapping_missing_key_raises_clean_error(self, tmp_path: Path):
+        """#32: a sync mapping missing secret_name/folder_path raises a clean
+        ValueError instead of a raw KeyError traceback."""
+        cfg = tmp_path / "envdrift.toml"
+        cfg.write_text(
+            '[vault]\nprovider = "azure"\n\n[[vault.sync.mappings]]\nfolder_path = "services/app"\n'
+        )
+        with pytest.raises(ValueError, match="secret_name"):
+            load_config(cfg)
+
     def test_load_config_default_when_not_found(self, tmp_path: Path, monkeypatch):
         """Test load_config returns default config when no file found."""
         monkeypatch.chdir(tmp_path)

--- a/tests/unit/test_schema_loader.py
+++ b/tests/unit/test_schema_loader.py
@@ -106,6 +106,31 @@ def test_load_non_settings_class(tmp_path, monkeypatch):
         loader.load("not_settings:NotSettings")
 
 
+@pytest.mark.parametrize(
+    "body",
+    [
+        'raise RuntimeError("boom at import time")',
+        "undefined_name_at_module_level",  # NameError
+        "def broken(:\n    pass",  # SyntaxError
+    ],
+)
+def test_load_non_import_error_at_import_is_clean(tmp_path, monkeypatch, body):
+    """#21: a non-ImportError raised while importing the schema module
+    (RuntimeError / NameError / SyntaxError) is wrapped as SchemaLoadError, not
+    surfaced as a raw traceback."""
+    module_path = tmp_path / "bad_schema.py"
+    module_path.write_text(
+        "from pydantic_settings import BaseSettings\n"
+        f"{body}\n"
+        "class Settings(BaseSettings):\n    API_KEY: str\n"
+    )
+    monkeypatch.syspath_prepend(tmp_path)
+
+    loader = SchemaLoader()
+    with pytest.raises(SchemaLoadError):
+        loader.load("bad_schema:Settings")
+
+
 def test_extract_metadata_with_config_object_and_typing():
     """extract_metadata should handle config objects and typing annotations."""
 


### PR DESCRIPTION
## What

P6 of the #443 re-audit — four related cases where a config/schema-load failure escaped the caught exception set as a **raw traceback** (the #413 anti-pattern): **#30** (`guard --config <dir>`), **#29** (non-iterable `[guard] scanners`), **#32** (sync mapping missing a key), **#21** (non-ImportError at schema import).

## Fix (all at the source)

- **`load_config`** — `is_file()` guard → `ConfigNotFoundError` for a directory (was uncaught `IsADirectoryError`).
- **`_build_guard_config`** — reject a non-list/str `scanners` value with a clean `ValueError` (was `TypeError` when iterated).
- **`_build_vault_config`** — validate `secret_name`/`folder_path` before the raw subscript → clean `ValueError` (was `KeyError`); `sync` now catches `ValueError`.
- **`SchemaLoader.load`** — wrap any non-`ImportError` import-time error (`RuntimeError`/`NameError`/`SyntaxError`) as `SchemaLoadError`, re-raising an inner `SchemaLoadError` unchanged.

## Reproduction (all were tracebacks before)

```
envdrift guard --config somedir          # AFTER: [ERROR] Configuration path is not a file
envdrift guard .env  (scanners = 123)    # AFTER: [ERROR] [guard] scanners must be a string or a list of strings
envdrift sync --config sync.toml         # AFTER: [ERROR] [[vault.sync.mappings]] entry is missing required key(s) secret_name
envdrift validate --schema bad:Settings  # AFTER: [ERROR] Error importing schema module 'bad': boom
```

## Tests (dogfood, test-first)

`load_config` on a directory / non-iterable scanners / a mapping missing `secret_name` each raises a clean typed error; the schema loader wraps `RuntimeError`/`NameError`/`SyntaxError` at import (parametrized). Each is red before the fix. Full non-integration suite (**2497**) passes.

Part of the #443 backlog (P6 of 9). See the [re-audit](https://github.com/jainal09/envdrift/issues/443#issuecomment-4663943129).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR surfaces four config/schema-load failure cases that previously escaped as raw tracebacks, converting them into clean typed errors at the source.

- **`load_config`**: adds an `is_file()` guard so passing a directory raises `ConfigNotFoundError` instead of `IsADirectoryError`.
- **`_build_guard_config`**: rejects non-list/non-string `scanners` with a `ValueError` before iteration.
- **`_build_vault_config`**: validates `secret_name`/`folder_path` presence before subscript access, raising `ValueError` instead of `KeyError`.
- **`SchemaLoader.load`**: catches any non-`ImportError` import-time exception (`SyntaxError`, `NameError`, `RuntimeError`) and wraps it as `SchemaLoadError`, with a prior `except SchemaLoadError: raise` to avoid double-wrapping.

<h3>Confidence Score: 4/5</h3>

Safe to merge after addressing the unhandled ValueError in the auto-discovery branch of load_sync_config_and_client.

The explicit-config branch of load_sync_config_and_client now catches ValueError, but the auto-discovery branch (lines 136-145) does not. A user who runs envdrift sync without --config and whose auto-discovered envdrift.toml has a vault mapping with a missing key will still get a raw traceback - the exact regression this PR is meant to eliminate for that same config error.

src/envdrift/cli_commands/sync.py - the auto-discovery branch and the stale KeyError catch in _load_partial_encryption_paths both need attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/envdrift/cli_commands/sync.py | Adds except ValueError to the explicit-config branch of load_sync_config_and_client, but the parallel auto-discovery branch still lacks this handler, leaving the raw-traceback regression unaddressed for that code path. |
| src/envdrift/config.py | Adds is_file() guard in load_config, non-list/non-string-list rejection in _build_guard_config, and pre-flight key validation in _build_vault_config - all correct and well-tested. |
| src/envdrift/core/schema.py | Adds except SchemaLoadError: raise before except Exception so clean errors are not double-wrapped, then wraps any remaining non-ImportError import-time exception as SchemaLoadError - ordering is correct. |
| tests/unit/test_config.py | Adds three regression tests (directory path, non-iterable scanners, missing mapping key), all targeted and correctly written. |
| tests/unit/test_schema_loader.py | Adds a parametrized test covering RuntimeError, NameError, and SyntaxError at import time - good coverage of the three advertised cases. |
| tests/unit/test_cli.py | Adds a CLI-level integration test for the missing-secret_name case that exercises the new except ValueError path in sync - correctly asserts exit code, message content, and absence of traceback. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[load_config called] --> B{path is None?}
    B -- No --> C{path.exists?}
    C -- No --> D[ConfigNotFoundError file not found]
    C -- Yes --> E{path.is_file?}
    E -- No --> F[ConfigNotFoundError not a file NEW]
    E -- Yes --> G[Parse TOML]
    G --> H[_build_guard_config]
    H --> I{scanners is str?}
    I -- Yes --> J[wrap in list]
    I -- No --> K{scanners is list of str?}
    K -- No --> L[ValueError must be str or list NEW]
    K -- Yes --> M[_build_vault_config]
    M --> N{mapping keys present?}
    N -- No --> O[ValueError missing required key NEW]
    N -- Yes --> P[EnvdriftConfig returned]
    B -- Yes --> Q[find_config auto-discovery]
    Q --> G

    R[SchemaLoader.load] --> S[_isolated_import]
    S --> T{Exception type?}
    T -- SchemaLoadError --> U[re-raise unchanged NEW]
    T -- ImportError --> V[SchemaLoadError Cannot import]
    T -- Other Exception --> W[SchemaLoadError Error importing NEW]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `src/envdrift/cli_commands/sync.py`, line 136-145 ([link](https://github.com/jainal09/envdrift/blob/9d104fe17080cf99026004e01899703a62f286f5/src/envdrift/cli_commands/sync.py#L136-L145)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Auto-discovery path still exposes raw `ValueError` traceback**

   The new `ValueError` catch (lines 128–133) only covers the explicit `--config` branch. The auto-discovery branch (lines 136–145) catches `ConfigNotFoundError` and `tomllib.TOMLDecodeError` but leaves `ValueError` unhandled. If a user runs `envdrift sync` without `--config` and their auto-discovered `envdrift.toml` contains a mapping that omits `secret_name`, the newly-raised `ValueError` propagates as a raw traceback — identical to the regression that existed before this fix for `KeyError`.

2. `src/envdrift/cli_commands/sync.py`, line 139-145 ([link](https://github.com/jainal09/envdrift/blob/aedd5985db67394482de8f3d966d970dd652e913/src/envdrift/cli_commands/sync.py#L139-L145)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Auto-discover branch still exposes raw `ValueError` traceback**

   The new `except ValueError` handler only covers the explicit `--config` branch (lines 128-133). The auto-discovery branch below catches `ConfigNotFoundError` and `tomllib.TOMLDecodeError` but leaves `ValueError` unhandled. A user who runs `envdrift sync` without `--config` and whose auto-discovered `envdrift.toml` has a mapping missing `secret_name` will still see a raw traceback — the same regression this PR fixes for the explicit-config path.

3. `src/envdrift/cli_commands/sync.py`, line 136-145 ([link](https://github.com/jainal09/envdrift/blob/445d6b1c624c5eeb1db2108b59afec902cab6351/src/envdrift/cli_commands/sync.py#L136-L145)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Auto-discovery branch still exposes raw `ValueError` traceback**

   The new `except ValueError` handler was added only to the explicit `--config` branch (lines 128–133). The auto-discovery branch (`elif config_file is None:`) catches `ConfigNotFoundError` and `tomllib.TOMLDecodeError` but leaves `ValueError` unhandled. A user who runs `envdrift sync` without `--config` and whose auto-discovered `envdrift.toml` contains a vault mapping missing `secret_name` (or an invalid `scanners` value) will see a raw traceback — the same regression this PR is fixing for the explicit-config path.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/config-load..."](https://github.com/jainal09/envdrift/commit/445d6b1c624c5eeb1db2108b59afec902cab6351) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36600125)</sub>

<!-- /greptile_comment -->