### PR TITLE
fix(guard,init): clean errors for invalid --fail-on (json) and an unwritable init output

### DIFF
--- a/src/envdrift/cli_commands/guard.py
+++ b/src/envdrift/cli_commands/guard.py
@@ -498,9 +498,12 @@ def guard(
     try:
         fail_severity = FindingSeverity(fail_on_value.lower())
     except ValueError as e:
-        console.print(
-            f"[red]Error:[/red] Invalid severity '{fail_on_value}'. "
-            f"Valid options: critical, high, medium, low"
+        # Route through _emit_error so --json/--sarif get a clean error document
+        # instead of Rich-markup human prose contaminating machine stdout (#28).
+        _emit_error(
+            json_output,
+            sarif,
+            f"Invalid severity '{fail_on_value}'. Valid options: critical, high, medium, low",
         )
         raise typer.Exit(code=1) from e
 

--- a/src/envdrift/cli_commands/init_cmd.py
+++ b/src/envdrift/cli_commands/init_cmd.py
@@ -376,6 +376,12 @@ def _write_init_output(result: SettingsGeneration, output: Path, *, force: bool)
 
     # encoding="utf-8" so a non-ASCII field name/value (e.g. a unicode-identifier
     # key) round-trips on platforms whose default text encoding is not UTF-8.
-    output.write_text(result.source, encoding="utf-8")
+    try:
+        output.write_text(result.source, encoding="utf-8")
+    except OSError as exc:
+        # A read-only / unwritable output path used to dump a raw PermissionError
+        # traceback; surface it as a clean error instead (#443 #26).
+        print_error(f"Could not write {output}: {exc}")
+        raise typer.Exit(code=1) from exc
     print_success(f"Generated {output}")
     _print_generation_summary(result)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -5395,3 +5395,31 @@ class TestDetectEnvFile:
         assert detection.path is not None
         assert detection.path.name == ".env"
         assert detection.environment == "production"
+
+
+class TestErrorPathHardening:
+    """#26/#28: an unwritable init output and an invalid guard --fail-on are clean
+    errors, not a PermissionError traceback / machine-output contamination."""
+
+    def test_init_unwritable_output_is_clean_error(self, tmp_path: Path) -> None:
+        env = tmp_path / ".env"
+        env.write_text("API_KEY=abc\n")
+        # A directory as the output path makes write_text raise OSError — the same
+        # branch a read-only file hits, reliably and regardless of euid/platform.
+        out_dir = tmp_path / "outdir"
+        out_dir.mkdir()
+        result = runner.invoke(app, ["init", str(env), "-o", str(out_dir), "--force"])
+        assert result.exit_code != 0
+        assert "Could not write" in result.output
+        assert "Traceback" not in result.output
+
+    def test_guard_invalid_fail_on_json_is_clean_error_doc(self, tmp_path: Path) -> None:
+        env = tmp_path / ".env"
+        env.write_text("API_KEY=sk-test\n")
+        result = runner.invoke(
+            app, ["guard", str(env), "--native-only", "--json", "--fail-on", "bogus"]
+        )
+        assert result.exit_code != 0
+        # stdout must be a clean JSON error doc, not Rich/human prose (#28).
+        doc = json.loads(result.output)
+        assert "error" in doc and "bogus" in doc["error"]

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -5461,7 +5461,7 @@ class TestErrorPathHardening:
         out_dir = tmp_path / "outdir"
         out_dir.mkdir()
         result = runner.invoke(app, ["init", str(env), "-o", str(out_dir), "--force"])
-        assert result.exit_code != 0
+        assert result.exit_code == 1
         assert "Could not write" in result.output
         assert "Traceback" not in result.output
 
@@ -5471,7 +5471,7 @@ class TestErrorPathHardening:
         result = runner.invoke(
             app, ["guard", str(env), "--native-only", "--json", "--fail-on", "bogus"]
         )
-        assert result.exit_code != 0
+        assert result.exit_code == 1
         # stdout must be a clean JSON error doc, not Rich/human prose (#28).
         doc = json.loads(result.output)
         assert "error" in doc and "bogus" in doc["error"]


### PR DESCRIPTION
## What

P7 of the #443 re-audit — two unguarded error paths:

- **#28** `guard`: an invalid `--fail-on` severity printed Rich-markup human prose to stdout via `console.print`, **contaminating `--json`/`--sarif`** machine output. Now routed through `_emit_error` → clean `{"error": ...}` / SARIF doc.
- **#26** `init`: writing the generated module to a **read-only / unwritable path** raised an uncaught `PermissionError` traceback. Now catches `OSError` → clean `[ERROR] Could not write …`, exit 1.

## Reproduction

```
envdrift guard .env --json --fail-on bogus
# BEFORE: stdout = "Error: Invalid severity 'bogus'..." (breaks JSON consumers)
# AFTER:  stdout = {"error": "Invalid severity 'bogus'. ..."}

envdrift init .env -o <read-only> --force
# BEFORE: PermissionError traceback / AFTER: [ERROR] Could not write ...: [Errno 13] ...
```

## Tests (dogfood, test-first)

`test_guard_invalid_fail_on_json_is_clean_error_doc` (stdout parses as a JSON error doc) and `test_init_unwritable_output_is_clean_error` (clean error, no traceback). Both red before the fix.

Part of the #443 backlog (P7 of 9). See the [re-audit](https://github.com/jainal09/envdrift/issues/443#issuecomment-4663943129).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error message handling in `guard` command—invalid severity values now produce clean, structured output (JSON/SARIF when requested) instead of unformatted errors
  * Enhanced error handling for file write failures in `init` command with clearer user-friendly messages

* **Tests**
  * Added test coverage for CLI error scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

PR #463 fixes two unguarded error paths in `guard` and `init` commands. The `guard` command now routes invalid `--fail-on` errors through `_emit_error` for clean JSON/SARIF output, and `init` catches `OSError` on write to surface a clean error message instead of a raw traceback. Both fixes are covered by new regression tests.

<h3>Confidence Score: 5/5</h3>

Two small, focused fixes with accompanying tests — safe to merge.

Both changes are minimal and surgical: a one-function call swap in guard.py and a try/except wrapper in init_cmd.py. Each fix is covered by a new test that was red before the change, and the error-routing function _emit_error is already proven in production for other error paths. No shared state, no new dependencies, and no behaviour changes on the happy path.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/envdrift/cli_commands/guard.py | Routes invalid --fail-on error through _emit_error, eliminating Rich-markup stdout contamination in JSON/SARIF mode. |
| src/envdrift/cli_commands/init_cmd.py | Wraps output.write_text in an OSError catch to surface permission/write failures as a clean [ERROR] message instead of a raw traceback. |
| tests/unit/test_cli.py | Adds two regression tests covering the new error paths; uses a directory as the output path to trigger OSError portably across platforms and euid. |

</details>

<sub>Reviews (5): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/guard-init-..."](https://github.com/jainal09/envdrift/commit/34061375eb692cc249e1168a84dee0e1710d4393) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36600975)</sub>

<!-- /greptile_comment -->