### PR TITLE
test(decrypt): cover the sops binary-blob stderr-decode path (#443 #14)

### DIFF
--- a/tests/integration/test_decrypt_outcome_bench.py
+++ b/tests/integration/test_decrypt_outcome_bench.py
@@ -51,7 +51,11 @@ def test_decrypt_sops_binary_blob_does_not_crash(tmp_path: Path, sops_on_path: N
     the blob; the point is it fails *cleanly* and leaves the file intact.
     """
     env_file = tmp_path / ".env"
-    blob = bytes(range(256)) * 4  # NUL + non-UTF-8 bytes
+    # The *invalid* first line (no '=') must carry non-UTF-8 bytes so sops echoes
+    # them back on stderr ("invalid dotenv input line: \xff\xfe..."). That is the
+    # exact path the #14 fix guards: sops._run decoding that non-UTF-8 stderr. An
+    # all-valid-UTF-8 blob (e.g. bytes(range(256))) would NOT exercise it.
+    blob = b"\xff\xfe\x80\x81\xc0\xc1notavalidline\n"
     env_file.write_bytes(blob)
 
     backend = SOPSEncryptionBackend()

--- a/tests/integration/test_decrypt_outcome_bench.py
+++ b/tests/integration/test_decrypt_outcome_bench.py
@@ -22,6 +22,7 @@ import pytest
 
 from envdrift.encryption.base import EncryptionBackendError
 from envdrift.encryption.dotenvx import DotenvxEncryptionBackend
+from envdrift.encryption.sops import SOPSEncryptionBackend
 
 # Mark all tests in this module
 pytestmark = [pytest.mark.integration]
@@ -32,6 +33,35 @@ def dotenvx_on_path() -> None:
     """Skip the test if the real ``dotenvx`` binary is not installed."""
     if shutil.which("dotenvx") is None:
         pytest.skip("dotenvx binary not found on PATH")
+
+
+@pytest.fixture
+def sops_on_path() -> None:
+    """Skip the test if the real ``sops`` binary is not installed."""
+    if shutil.which("sops") is None:
+        pytest.skip("sops binary not found on PATH")
+
+
+def test_decrypt_sops_binary_blob_does_not_crash(tmp_path: Path, sops_on_path: None) -> None:
+    """#14: decrypting a binary blob with the SOPS backend must not raise an
+    uncaught UnicodeDecodeError while decoding sops' (non-UTF-8) stderr.
+
+    sops._run reads the subprocess with encoding='utf-8', errors='replace', so a
+    non-UTF-8 stderr byte degrades to U+FFFD instead of crashing. sops rejects
+    the blob; the point is it fails *cleanly* and leaves the file intact.
+    """
+    env_file = tmp_path / ".env"
+    blob = bytes(range(256)) * 4  # NUL + non-UTF-8 bytes
+    env_file.write_bytes(blob)
+
+    backend = SOPSEncryptionBackend()
+    try:
+        result = backend.decrypt(env_file, cwd=tmp_path)
+        assert result.success is False
+    except EncryptionBackendError:
+        pass  # a clean, typed failure is the acceptable outcome
+    # No silent corruption: the blob is byte-for-byte intact.
+    assert env_file.read_bytes() == blob
 
 
 # --- A non-encrypted file is an honest no-op, never mutated --------------------

--- a/tests/integration/test_decrypt_outcome_bench.py
+++ b/tests/integration/test_decrypt_outcome_bench.py
@@ -55,11 +55,11 @@ def test_decrypt_sops_binary_blob_does_not_crash(tmp_path: Path, sops_on_path: N
     env_file.write_bytes(blob)
 
     backend = SOPSEncryptionBackend()
-    try:
-        result = backend.decrypt(env_file, cwd=tmp_path)
-        assert result.success is False
-    except EncryptionBackendError:
-        pass  # a clean, typed failure is the acceptable outcome
+    # sops rejects the blob; the point is it surfaces a clean, typed
+    # EncryptionBackendError — not a UnicodeDecodeError from decoding sops'
+    # non-UTF-8 stderr (which would fail this pytest.raises and flag the bug).
+    with pytest.raises(EncryptionBackendError):
+        backend.decrypt(env_file, cwd=tmp_path)
     # No silent corruption: the blob is byte-for-byte intact.
     assert env_file.read_bytes() == blob
 


### PR DESCRIPTION
P8 of the #443 re-audit. #14 was classified **fixed-but-untested**: the sops backend's binary-blob decrypt used to raise an uncaught `UnicodeDecodeError` decoding sops' non-UTF-8 stderr; #451 fixed it (`sops._run` reads with `encoding="utf-8", errors="replace"`) but left no regression test.

Adds a real-`sops` integration test (skip-gated on the binary): decrypting a 1KB binary blob must fail **cleanly** (a failure result or a typed `EncryptionBackendError`), never an uncaught `UnicodeDecodeError`, and leave the file byte-for-byte intact.

Part of the #443 backlog (P8 of 9). See the [re-audit](https://github.com/jainal09/envdrift/issues/443#issuecomment-4663943129).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a skip-gated integration test (`test_decrypt_sops_binary_blob_does_not_crash`) that exercises the SOPS backend's non-UTF-8 stderr-decode path (issue #14), previously fixed in `sops._run` via `encoding="utf-8", errors="replace"` but left untested.

- Writes a binary blob carrying non-UTF-8 bytes (`\xff\xfe\x80\x81…`), calls `backend.decrypt()`, and asserts it raises `EncryptionBackendError` (not an uncaught `UnicodeDecodeError`); a `UnicodeDecodeError` propagating out of `_run` would miss `pytest.raises` and fail the test.
- Follows the `pytest.raises` context with a byte-level file-integrity assertion to confirm sops did not silently corrupt the blob on failure.

<h3>Confidence Score: 5/5</h3>

Test-only change that adds a regression guard for a previously fixed but untested bug; no production code is modified.

The added test is correctly structured: pytest.raises(EncryptionBackendError) tightly covers the failure path so a reintroduced UnicodeDecodeError (which _run does not catch) would propagate past the context manager and fail the test. The sops_on_path skip gate is consistent with the existing dotenvx_on_path fixture. The post-raise file-integrity assertion runs in the right place. No logic touches production code.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| tests/integration/test_decrypt_outcome_bench.py | Adds sops_on_path fixture and test_decrypt_sops_binary_blob_does_not_crash; regression guard for issue #14, using pytest.raises(EncryptionBackendError) correctly after the previous dead-code assertion was removed. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant T as Test
    participant B as SOPSEncryptionBackend
    participant R as _run()
    participant S as sops binary

    T->>B: "decrypt(env_file, cwd=tmp_path)"
    B->>R: _run(["--decrypt", "--in-place", "--input-type", "dotenv", ...])
    R->>S: "subprocess.run(..., encoding="utf-8", errors="replace")"
    S-->>R: "returncode=1, stderr=<non-UTF-8 bytes replaced with U+FFFD>"
    R-->>B: "CompletedProcess(returncode=1)"
    B-->>T: raises EncryptionBackendError
    Note over T: pytest.raises catches EncryptionBackendError ✓
    T->>T: "assert env_file.read_bytes() == blob ✓"
```

<sub>Reviews (6): Last reviewed commit: ["test(decrypt): drive sops to emit non-UT..."](https://github.com/jainal09/envdrift/commit/1d9a684d20e0e9cf3b0f22eaa8bba34fd37ab498) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36601212)</sub>

<!-- /greptile_comment -->