### PR TITLE
feat(guard): warn when --json and --sarif are both passed

### DIFF
--- a/src/envdrift/cli_commands/guard.py
+++ b/src/envdrift/cli_commands/guard.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import json
 import os
+import sys
 import time as time_module
 import tomllib
 from pathlib import Path
@@ -363,6 +364,15 @@ def guard(
       envdrift guard ./src ./config      # Scan specific directories
     """
     import subprocess  # nosec B404
+
+    if sarif and json_output:
+        # SARIF takes precedence over JSON; warn on stderr so the choice is not
+        # silent, without contaminating the (SARIF) stdout (#443 #31).
+        print(
+            "[WARN] --json is ignored because --sarif was also passed "
+            "(SARIF output takes precedence).",
+            file=sys.stderr,
+        )
 
     def _git_toplevel() -> Path:
         """Return the git repository root, falling back to cwd if unavailable.

--- a/tests/unit/test_guard_cli.py
+++ b/tests/unit/test_guard_cli.py
@@ -1103,8 +1103,10 @@ def test_guard_json_and_sarif_warns_about_precedence(tmp_path: Path):
 
     result = runner.invoke(app, ["guard", str(env), "--native-only", "--json", "--sarif"])
 
-    # The warning goes to stderr; CliRunner may merge it into output (older Click)
-    # or keep it separate (newer) — check both so the test is version-robust.
+    # The warning is written to stderr. Depending on the CliRunner configuration,
+    # stderr is either merged into result.output or exposed separately via
+    # result.stderr (which can raise if it was not captured separately); check
+    # both so the assertion holds regardless.
     combined = result.output
     try:
         combined += result.stderr or ""

--- a/tests/unit/test_guard_cli.py
+++ b/tests/unit/test_guard_cli.py
@@ -1090,3 +1090,24 @@ def test_guard_skip_gitignored_default_is_false(tmp_path: Path, monkeypatch):
     assert result.exit_code == 0
     assert created_configs
     assert created_configs[0].skip_gitignored is False
+
+
+def test_guard_json_and_sarif_warns_about_precedence(tmp_path: Path):
+    """#31: passing --json and --sarif together is no longer silent.
+
+    SARIF takes precedence; guard now warns on stderr that --json is ignored,
+    while keeping the SARIF stdout clean.
+    """
+    env = tmp_path / ".env"
+    env.write_text("API_KEY=sk-test123\n")
+
+    result = runner.invoke(app, ["guard", str(env), "--native-only", "--json", "--sarif"])
+
+    # The warning goes to stderr; CliRunner may merge it into output (older Click)
+    # or keep it separate (newer) — check both so the test is version-robust.
+    combined = result.output
+    try:
+        combined += result.stderr or ""
+    except (ValueError, AttributeError):
+        pass
+    assert "--json is ignored" in combined

--- a/tests/unit/test_guard_cli.py
+++ b/tests/unit/test_guard_cli.py
@@ -1095,21 +1095,22 @@ def test_guard_skip_gitignored_default_is_false(tmp_path: Path, monkeypatch):
 def test_guard_json_and_sarif_warns_about_precedence(tmp_path: Path):
     """#31: passing --json and --sarif together is no longer silent.
 
-    SARIF takes precedence; guard now warns on stderr that --json is ignored,
-    while keeping the SARIF stdout clean.
+    SARIF takes precedence; the precedence warning goes to stderr ONLY, so a
+    --json/--sarif consumer still gets a clean, parseable document on stdout —
+    that separation is the whole point of the fix.
     """
+    import json
+
     env = tmp_path / ".env"
     env.write_text("API_KEY=sk-test123\n")
 
     result = runner.invoke(app, ["guard", str(env), "--native-only", "--json", "--sarif"])
 
-    # The warning is written to stderr. Depending on the CliRunner configuration,
-    # stderr is either merged into result.output or exposed separately via
-    # result.stderr (which can raise if it was not captured separately); check
-    # both so the assertion holds regardless.
-    combined = result.output
-    try:
-        combined += result.stderr or ""
-    except (ValueError, AttributeError):
-        pass
-    assert "--json is ignored" in combined
+    # The precedence warning lands on stderr.
+    assert "--json is ignored" in result.stderr
+    # stdout (the captured output with the stderr portion removed) is a clean,
+    # parseable SARIF document — the warning must NOT leak into it.
+    stdout = result.output.replace(result.stderr, "")
+    assert "--json is ignored" not in stdout
+    sarif = json.loads(stdout)
+    assert "runs" in sarif


### PR DESCRIPTION
P9 (final) of the #443 re-audit (#31, LOW). SARIF silently overrode `--json` with no warning, so a caller expecting JSON got SARIF and no signal.

`guard` now prints a warning to **stderr** (`--json is ignored because --sarif was also passed (SARIF output takes precedence)`) so the choice is explicit, while keeping the SARIF **stdout** clean.

Test: `guard --json --sarif` emits the warning; verified end-to-end that stdout stays a valid SARIF document.

Completes the #443 backlog (P9 of 9). See the [re-audit](https://github.com/jainal09/envdrift/issues/443#issuecomment-4663943129).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * The `guard` command now displays a warning when both `--json` and `--sarif` output formats are specified, clarifying that SARIF output takes precedence and JSON output is ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a warning to stderr when `--json` and `--sarif` are both passed to `guard`, making the flag-precedence behaviour explicit rather than silent. The SARIF output on stdout remains untouched; the warning (`[WARN] --json is ignored because --sarif was also passed`) is printed to `sys.stderr` before any scan work begins.

- **`guard.py`**: A nine-line block inserted at the top of the `guard` function emits the warning to `sys.stderr` when both flags are set; no changes to the existing JSON/SARIF output or exit-code logic.
- **`test_guard_cli.py`**: A new end-to-end test invokes `guard --json --sarif` on a real `.env` file and asserts the warning appears in `result.stderr` while `result.output` still parses as a valid SARIF document.

<h3>Confidence Score: 4/5</h3>

The production change in guard.py is correct and safe; the only concern is test reliability across the declared typer>=0.9 version range.

The guard.py implementation is a clean, minimal addition — the warning correctly targets sys.stderr before any scan logic runs, and the existing SARIF/JSON output path is untouched. The test accesses result.stderr directly from the module-level CliRunner (mix_stderr=True by default), which raises ValueError on Typer < 0.16.0; the project declares typer>=0.9, so the affected version range is real.

tests/unit/test_guard_cli.py — the new test should use a local CliRunner(mix_stderr=False) to be reliable across all declared-supported Typer versions.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/envdrift/cli_commands/guard.py | Minimal, correct addition: warns to sys.stderr before any scan logic runs when both --json and --sarif are passed; existing output routing at line 726 is unchanged. |
| tests/unit/test_guard_cli.py | New test asserts the precedence warning; accesses result.stderr directly without a local CliRunner(mix_stderr=False), which may silently break on Typer < 0.16.0 where the default runner does not expose stderr separately. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant guard as guard()
    participant stderr as sys.stderr
    participant stdout as stdout

    Caller->>guard: --json --sarif
    guard->>stderr: [WARN] --json is ignored because --sarif was also passed
    guard->>guard: run scan
    guard->>stdout: SARIF JSON document
    guard-->>Caller: exit code (0/1/2/3/4)
```

<sub>Reviews (7): Last reviewed commit: ["Merge branch &#39;main&#39; into feat/guard-json..."](https://github.com/jainal09/envdrift/commit/abe4e429ac07ec2f54991b27270a60b2fdba0b61) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36601608)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->