### PR TITLE
fix(partial-encryption): refuse filenames dotenvx can't turn into a valid key (#467)

### DIFF
--- a/src/envdrift/core/partial_encryption.py
+++ b/src/envdrift/core/partial_encryption.py
@@ -15,7 +15,7 @@ from typing import NamedTuple
 
 from envdrift.config import PartialEncryptionEnvironmentConfig
 from envdrift.env_files import _is_excluded_env_file
-from envdrift.integrations.dotenvx import DotenvxError, DotenvxWrapper
+from envdrift.integrations.dotenvx import DotenvxError, DotenvxFilenameError, DotenvxWrapper
 
 logger = logging.getLogger(__name__)
 
@@ -517,7 +517,10 @@ def encrypt_secret_file(env_config: PartialEncryptionEnvironmentConfig) -> None:
     dotenvx = DotenvxWrapper()
     try:
         dotenvx.encrypt(secret_file)
-    except DotenvxError as e:
+    except (DotenvxError, DotenvxFilenameError) as e:
+        # DotenvxFilenameError: the wrapper refused a name dotenvx would turn
+        # into an invalid key (silent lockout) BEFORE encrypting, so the
+        # plaintext is intact — surface a clean error, not a raw traceback (#467).
         raise PartialEncryptionError.encrypt_failed(secret_file, e) from e
 
     # Re-enable git tracking now the file is encrypted again
@@ -702,7 +705,10 @@ def _encrypt_secrets_only_file(dotenvx: DotenvxWrapper, file: Path, *, check: bo
         return True
     try:
         dotenvx.encrypt(file)
-    except DotenvxError as e:
+    except (DotenvxError, DotenvxFilenameError) as e:
+        # DotenvxFilenameError: a secrets_dir file whose name dotenvx can't turn
+        # into a valid key slug (e.g. "my secret.env", "café.env") is refused
+        # pre-flight with the plaintext preserved — surface it cleanly (#467).
         raise PartialEncryptionError.encrypt_failed(file, e) from e
     # Re-enable git tracking now the file is encrypted again.
     _git_unskip_worktree(file)

--- a/src/envdrift/encryption/dotenvx.py
+++ b/src/envdrift/encryption/dotenvx.py
@@ -143,8 +143,12 @@ class DotenvxEncryptionBackend(EncryptionBackend):
         # undecryptable: the original plaintext is destroyed and the secret is
         # locked out for good, and the plaintext-survival check below cannot
         # catch it (the value *is* encrypted, only the key name is unusable).
-        # Only [A-Za-z0-9._-] filenames round-trip safely (#443).
-        if not re.fullmatch(r"[A-Za-z0-9._-]+", env_file.name):
+        # Only [A-Za-z0-9._-] filenames round-trip safely (#443). The same
+        # predicate guards DotenvxWrapper.encrypt so the partial-encryption paths
+        # that bypass this backend are covered too (#467).
+        from envdrift.integrations.dotenvx import is_dotenvx_safe_filename
+
+        if not is_dotenvx_safe_filename(env_file.name):
             return EncryptionResult(
                 success=False,
                 message=(

--- a/src/envdrift/encryption/dotenvx.py
+++ b/src/envdrift/encryption/dotenvx.py
@@ -14,6 +14,7 @@ from envdrift.encryption.base import (
     EncryptionResult,
     EncryptionStatus,
 )
+from envdrift.integrations.dotenvx import is_dotenvx_safe_filename
 
 
 class DotenvxEncryptionBackend(EncryptionBackend):
@@ -146,8 +147,6 @@ class DotenvxEncryptionBackend(EncryptionBackend):
         # Only [A-Za-z0-9._-] filenames round-trip safely (#443). The same
         # predicate guards DotenvxWrapper.encrypt so the partial-encryption paths
         # that bypass this backend are covered too (#467).
-        from envdrift.integrations.dotenvx import is_dotenvx_safe_filename
-
         if not is_dotenvx_safe_filename(env_file.name):
             return EncryptionResult(
                 success=False,

--- a/src/envdrift/integrations/dotenvx.py
+++ b/src/envdrift/integrations/dotenvx.py
@@ -115,6 +115,29 @@ PROBLEMATIC_FILENAME_PATTERNS = [
     r"^\.env\.local$",
 ]
 
+# Only filenames matching this round-trip through dotenvx's key-name derivation.
+# dotenvx builds the DOTENV_PRIVATE_KEY_<SLUG> env-var name from the filename, so
+# a space or non-ASCII character yields an invalid name and a file that encrypts
+# (exit 0) yet is permanently undecryptable — see is_dotenvx_safe_filename.
+_DOTENVX_SAFE_FILENAME_RE = re.compile(r"[A-Za-z0-9._-]+")
+
+
+def is_dotenvx_safe_filename(name: str) -> bool:
+    """Return True if ``name`` survives dotenvx's ``DOTENV_*_<SLUG>`` key derivation.
+
+    dotenvx derives the public/private-key env-var names from the filename, so
+    only ``[A-Za-z0-9._-]`` characters round-trip into a usable key name. A space
+    or non-ASCII character produces an invalid name (e.g.
+    ``DOTENV_PRIVATE_KEY_MY SECRET``): the value still encrypts and dotenvx exits
+    0, but the file is then permanently undecryptable and the original plaintext
+    is destroyed — a silent secret lockout (#443/#457, #467). Both the guarded
+    ``DotenvxEncryptionBackend`` and the ``DotenvxWrapper.encrypt`` seam used by
+    the partial-encryption push/lock paths share this single predicate so the two
+    cannot drift.
+    """
+    return bool(_DOTENVX_SAFE_FILENAME_RE.fullmatch(name))
+
+
 _PUBLIC_KEY_NAME_RE = re.compile(r"\bDOTENV_PUBLIC_KEY_[A-Za-z0-9_-]+=")
 _PRIVATE_KEY_LINE_RE = re.compile(r"^DOTENV_PRIVATE_KEY_[A-Za-z0-9_-]+=(.*)$")
 
@@ -783,6 +806,37 @@ class DotenvxWrapper:
                     f"before encryption. See: https://github.com/dotenvx/dotenvx/issues/724"
                 )
 
+    @staticmethod
+    def _validate_encryptable_filename(file_path: Path) -> None:
+        """Refuse a filename dotenvx would turn into an invalid private-key name.
+
+        dotenvx derives ``DOTENV_PRIVATE_KEY_<SLUG>`` from the filename; a space or
+        non-ASCII character yields an invalid name, so the value encrypts and
+        dotenvx exits 0 — but the file is then permanently undecryptable and the
+        original plaintext is destroyed (a silent secret lockout). This guard runs
+        on every platform (the lockout is not Windows-specific) and before dotenvx
+        is invoked, so the plaintext is preserved.
+
+        The guarded ``DotenvxEncryptionBackend`` already performs this check, but
+        the partial-encryption push/lock paths (``encrypt_secret_file`` /
+        ``_encrypt_secrets_only_file``) reach dotenvx through this wrapper directly,
+        so the guard must live here too or those paths silently lock the secret out
+        (#443/#457, #467). Both share the ``is_dotenvx_safe_filename`` predicate.
+
+        Parameters:
+            file_path (Path): Path to the file to validate.
+
+        Raises:
+            DotenvxFilenameError: If the filename is not a safe dotenvx key slug.
+        """
+        if not is_dotenvx_safe_filename(file_path.name):
+            raise DotenvxFilenameError(
+                f"Refusing to encrypt '{file_path.name}': its filename contains "
+                "characters dotenvx cannot turn into a valid key name, which would "
+                "leave the file permanently undecryptable. Rename it to use only "
+                "letters, digits, '.', '-' and '_'."
+            )
+
     # Regex pattern for dotenvx public key header blocks
     DOTENVX_HEADER_BLOCK_PATTERN: ClassVar[re.Pattern[str]] = re.compile(
         r"#/---+\[DOTENV_PUBLIC_KEY\]---+/\n"
@@ -898,6 +952,13 @@ class DotenvxWrapper:
         env_file = Path(env_file)
         if not env_file.exists():
             raise DotenvxError(f"File not found: {env_file}")
+
+        # Refuse a filename dotenvx can't turn into a valid key name BEFORE
+        # invoking it, on every platform, so the plaintext is preserved. dotenvx
+        # would otherwise encrypt the value, exit 0, and leave the file
+        # permanently undecryptable. The partial-encryption push/lock paths use
+        # this wrapper directly, not the guarded backend (#443/#457, #467).
+        self._validate_encryptable_filename(env_file)
 
         # Validate filename for known dotenvx bugs (Windows-specific)
         if platform.system() == "Windows":

--- a/tests/unit/test_partial_encryption.py
+++ b/tests/unit/test_partial_encryption.py
@@ -14,6 +14,7 @@ from envdrift.config import PartialEncryptionEnvironmentConfig
 from envdrift.core.partial_encryption import (
     PartialEncryptionError,
     combine_files,
+    encrypt_secret_file,
     file_has_assignment,
     has_plaintext_secret_value,
     is_file_encrypted,
@@ -180,8 +181,6 @@ def test_encrypt_secret_file_reencrypts_mixed_state(tmp_path: Path):
     encrypt_secret_file early-returned and never encrypted the newly-added
     plaintext value -> it leaked. This asserts dotenvx.encrypt IS invoked.
     """
-    from envdrift.core.partial_encryption import encrypt_secret_file
-
     secret_file = tmp_path / ".env.secret"
     secret_file.write_text('API_KEY="encrypted:abc..."\nNEW_LEAKED_SECRET=plaintext_leak_value\n')
     config = PartialEncryptionEnvironmentConfig(
@@ -717,50 +716,59 @@ def test_push_secrets_only_raises_on_encrypt_failure(secrets_only_config, secret
 # ---------------------------------------------------------------------------
 
 
-def test_push_secrets_only_refuses_space_named_file_preserves_plaintext(tmp_path: Path):
-    """#467: a space-named secret file is refused, not silently locked out."""
+@pytest.mark.parametrize(
+    ("entry_point", "filename"),
+    [
+        ("push_secrets_only", "my secret.env"),  # space -> invalid dotenvx key slug
+        ("encrypt_secret_file", "café.env.secret"),  # non-ASCII -> invalid key slug
+    ],
+)
+def test_partial_encryption_refuses_unsafe_filename_preserves_plaintext(
+    tmp_path: Path, entry_point: str, filename: str
+):
+    """#467: a space/non-ASCII secret filename is refused, not silently locked out.
+
+    Both partial-encryption entry points (``push_secrets_only`` for secrets-only,
+    ``encrypt_secret_file`` for combine mode) reach dotenvx through
+    ``DotenvxWrapper``, NOT the guarded backend. dotenvx derives
+    ``DOTENV_PRIVATE_KEY_<SLUG>`` from the filename; a space or non-ASCII char
+    yields an invalid key name, so the value encrypts (exit 0) but is then
+    permanently undecryptable and the plaintext is destroyed — silent secret
+    lockout. The wrapper guard must refuse pre-flight, leaving the file
+    byte-for-byte intact. No ``DotenvxWrapper`` mock: the real guard IS the
+    behavior under test, and it fires before the binary is invoked, so the test
+    needs no dotenvx binary. Both entry points fail RED on ``main`` (DID NOT
+    RAISE; the file is silently encrypted and the plaintext destroyed).
+    """
     secrets_dir = tmp_path / "secrets"
     secrets_dir.mkdir()
-    bad = secrets_dir / "my secret.env"  # space -> invalid dotenvx key slug
-    bad.write_text("PASSWORD=keepme123\n", encoding="utf-8")
-    before = bad.read_bytes()
+    target = secrets_dir / filename
+    target.write_text("PASSWORD=keepme123\n", encoding="utf-8")
+    before = target.read_bytes()
 
-    config = PartialEncryptionEnvironmentConfig(
-        name="prod",
-        secrets_only=True,
-        secrets_dir=str(secrets_dir),
-        pattern="*.env",
-    )
-
-    with pytest.raises(PartialEncryptionError, match="Failed to encrypt"):
-        push_secrets_only(config)
+    if entry_point == "push_secrets_only":
+        config = PartialEncryptionEnvironmentConfig(
+            name="prod",
+            secrets_only=True,
+            secrets_dir=str(secrets_dir),
+            pattern="*.env*",
+        )
+        with pytest.raises(PartialEncryptionError, match="Failed to encrypt"):
+            push_secrets_only(config)
+    else:
+        config = PartialEncryptionEnvironmentConfig(
+            name="prod",
+            clear_file="",
+            secret_file=str(target),
+            combined_file="",
+        )
+        with pytest.raises(PartialEncryptionError, match="Failed to encrypt"):
+            encrypt_secret_file(config)
 
     # The original plaintext survives byte-for-byte — never encrypted into an
     # unrecoverable file (pre-fix this destroyed it and raised nothing).
-    assert bad.read_bytes() == before
-    assert b"encrypted:" not in bad.read_bytes()
-
-
-def test_encrypt_secret_file_refuses_unicode_named_file_preserves_plaintext(tmp_path: Path):
-    """#467: a non-ASCII secret filename is refused too, with plaintext intact."""
-    from envdrift.core.partial_encryption import encrypt_secret_file
-
-    secret_file = tmp_path / "café.env.secret"  # non-ASCII -> invalid key slug
-    secret_file.write_text("API_KEY=keepme\n", encoding="utf-8")
-    before = secret_file.read_bytes()
-
-    config = PartialEncryptionEnvironmentConfig(
-        name="prod",
-        clear_file="",
-        secret_file=str(secret_file),
-        combined_file="",
-    )
-
-    with pytest.raises(PartialEncryptionError, match="Failed to encrypt"):
-        encrypt_secret_file(config)
-
-    assert secret_file.read_bytes() == before
-    assert b"encrypted:" not in secret_file.read_bytes()
+    assert target.read_bytes() == before
+    assert b"encrypted:" not in target.read_bytes()
 
 
 def test_pull_secrets_only_decrypts_encrypted_files(secrets_only_config, secrets_dir):

--- a/tests/unit/test_partial_encryption.py
+++ b/tests/unit/test_partial_encryption.py
@@ -700,6 +700,69 @@ def test_push_secrets_only_raises_on_encrypt_failure(secrets_only_config, secret
             push_secrets_only(secrets_only_config)
 
 
+# ---------------------------------------------------------------------------
+# Secret-lockout guard reaches the partial-encryption paths too (#467)
+#
+# #457 added the [A-Za-z0-9._-] filename guard to DotenvxEncryptionBackend, but
+# the partial-encryption push/lock paths (encrypt_secret_file /
+# push_secrets_only) reach dotenvx through DotenvxWrapper directly, NOT the
+# guarded backend. A space- or non-ASCII-named secret file therefore still hit
+# the exact permanent lockout #457 set out to fix: dotenvx derives an invalid
+# DOTENV_PRIVATE_KEY_<SLUG> from the filename, encrypts the value (exit 0), and
+# the file is then undecryptable while the plaintext is destroyed.
+#
+# These drive the REAL wrapper guard (no DotenvxWrapper mock — the guard IS the
+# behavior under test) and assert refusal with the plaintext preserved. The
+# guard fires before dotenvx is invoked, so the tests need no dotenvx binary.
+# ---------------------------------------------------------------------------
+
+
+def test_push_secrets_only_refuses_space_named_file_preserves_plaintext(tmp_path: Path):
+    """#467: a space-named secret file is refused, not silently locked out."""
+    secrets_dir = tmp_path / "secrets"
+    secrets_dir.mkdir()
+    bad = secrets_dir / "my secret.env"  # space -> invalid dotenvx key slug
+    bad.write_text("PASSWORD=keepme123\n", encoding="utf-8")
+    before = bad.read_bytes()
+
+    config = PartialEncryptionEnvironmentConfig(
+        name="prod",
+        secrets_only=True,
+        secrets_dir=str(secrets_dir),
+        pattern="*.env",
+    )
+
+    with pytest.raises(PartialEncryptionError, match="Failed to encrypt"):
+        push_secrets_only(config)
+
+    # The original plaintext survives byte-for-byte — never encrypted into an
+    # unrecoverable file (pre-fix this destroyed it and raised nothing).
+    assert bad.read_bytes() == before
+    assert b"encrypted:" not in bad.read_bytes()
+
+
+def test_encrypt_secret_file_refuses_unicode_named_file_preserves_plaintext(tmp_path: Path):
+    """#467: a non-ASCII secret filename is refused too, with plaintext intact."""
+    from envdrift.core.partial_encryption import encrypt_secret_file
+
+    secret_file = tmp_path / "café.env.secret"  # non-ASCII -> invalid key slug
+    secret_file.write_text("API_KEY=keepme\n", encoding="utf-8")
+    before = secret_file.read_bytes()
+
+    config = PartialEncryptionEnvironmentConfig(
+        name="prod",
+        clear_file="",
+        secret_file=str(secret_file),
+        combined_file="",
+    )
+
+    with pytest.raises(PartialEncryptionError, match="Failed to encrypt"):
+        encrypt_secret_file(config)
+
+    assert secret_file.read_bytes() == before
+    assert b"encrypted:" not in secret_file.read_bytes()
+
+
 def test_pull_secrets_only_decrypts_encrypted_files(secrets_only_config, secrets_dir):
     """pull_secrets_only decrypts every encrypted file in secrets_dir."""
     for f in secrets_dir.iterdir():


### PR DESCRIPTION
## Part 1 of #467 — partial-encryption still bypasses the secret-lockout guard

### The bug (medium · **data-loss**)
#457 added the `[A-Za-z0-9._-]` filename guard to **`DotenvxEncryptionBackend.encrypt`**, but the
partial-encryption push/lock paths reach dotenvx through **`DotenvxWrapper.encrypt`** directly, *not*
the guarded backend:

- `encrypt_secret_file` → `DotenvxWrapper().encrypt(secret_file)` (combine mode)
- `push_secrets_only` → `_encrypt_secrets_only_file` → `dotenvx.encrypt(file)`, where `file` comes
  from `secrets_dir.glob(pattern)` — arbitrary on-disk filenames.

`DotenvxWrapper._validate_filename` only rejects the Windows `.env.local` pattern — it has no slug
check. So a `my secret.env` / `café.env.secret` file pushed via `envdrift push`/`lock` still hit the
exact permanent lockout #457 set out to fix.

**Confirmed live** through the real `push_secrets_only`:
```
push_secrets_only → {'encrypted': 1}        # claimed success
on disk           → DOTENV_PRIVATE_KEY_MY SECRET... (invalid: space in key name)
plaintext         → DESTROYED
pull_secrets_only → MISSING_PRIVATE_KEY      # permanent lockout
```

### The fix
- Extract a single shared predicate **`is_dotenvx_safe_filename(name)`** in `integrations/dotenvx.py`.
- `DotenvxWrapper.encrypt` now calls `_validate_encryptable_filename` **on every platform** (the
  lockout is not Windows-specific) and **before invoking dotenvx**, so the plaintext is preserved.
- `DotenvxEncryptionBackend.encrypt` reuses the same predicate (no more inline regex) so the two
  guards cannot drift.
- The partial-encryption callers wrap the resulting `DotenvxFilenameError` into a clean
  `PartialEncryptionError` (no raw traceback).

### Tests (real, no mock of the seam under test)
Two regression tests drive the **real** wrapper guard through `push_secrets_only` (space name) and
`encrypt_secret_file` (non-ASCII name) and assert refusal with the plaintext **byte-for-byte intact**.
Both fail RED on `main` (`DID NOT RAISE`; the file is silently encrypted and destroyed). The guard
fires before dotenvx is invoked, so the tests need no dotenvx binary.

Full non-integration suite green (2521 passed); ruff / pyrefly / bandit clean.

> Finding #2 of #467 (the `docs/cli/init.md` `isidentifier()` claim) is docs-only and a different
> subsystem — it ships as a separate small docs PR so this stays themed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added filename validation system to prevent encryption of files with incompatible character sets for key derivation.

* **Bug Fixes**
  * Improved error handling for encryption failures related to invalid filenames while preserving original data.
  * Enhanced cross-platform filename safety checks to prevent undecryptable encryption results.

* **Tests**
  * Added test coverage for filename validation during encryption operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes a data-loss gap left by #457: the `[A-Za-z0-9._-]` filename guard existed only in `DotenvxEncryptionBackend`, but the partial-encryption push/lock paths (`push_secrets_only` → `_encrypt_secrets_only_file`, `encrypt_secret_file`) call `DotenvxWrapper.encrypt` directly, bypassing that backend entirely.

- Extracts `is_dotenvx_safe_filename(name)` into `integrations/dotenvx.py` as a single shared predicate; `DotenvxEncryptionBackend` replaces its inline `re.fullmatch` with it so the two guards cannot drift.
- Adds `_validate_encryptable_filename` to `DotenvxWrapper.encrypt`, called on every platform before dotenvx is invoked, so unsafe filenames are refused with the plaintext byte-for-byte intact.
- Both partial-encryption callers now catch `DotenvxFilenameError` alongside `DotenvxError` and wrap it into a clean `PartialEncryptionError` instead of a raw traceback.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the guard fires before any dotenvx invocation, no file mutation can occur on the unsafe-filename path, and two regression tests verify plaintext survival byte-for-byte through the real wrapper.

The change is a focused, pre-flight guard addition. The shared predicate is functionally identical to the inline regex it replaces (both use fullmatch on the same character class). The exception plumbing is correct: DotenvxFilenameError is unrelated to DotenvxError in the hierarchy, so widening the except tuple is non-redundant. Regression tests drive the real wrapper without mocking the seam under test and confirm the plaintext is untouched on refusal.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/envdrift/integrations/dotenvx.py | Adds is_dotenvx_safe_filename predicate and _validate_encryptable_filename guard in DotenvxWrapper.encrypt; regex is correct (fullmatch with [A-Za-z0-9._-]+), guard fires before dotenvx invocation on all platforms. |
| src/envdrift/encryption/dotenvx.py | Replaces inline re.fullmatch with shared is_dotenvx_safe_filename predicate — functionally identical, removes drift risk. |
| src/envdrift/core/partial_encryption.py | Imports DotenvxFilenameError and widens two except clauses to catch it alongside DotenvxError, wrapping both into PartialEncryptionError cleanly. |
| tests/unit/test_partial_encryption.py | Adds a parametrized regression test driving the real guard (no wrapper mock) for both push_secrets_only and encrypt_secret_file, asserting PartialEncryptionError is raised and plaintext survives byte-for-byte. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([push_secrets_only / encrypt_secret_file]) --> B[DotenvxWrapper.encrypt]
    B --> C{env_file exists?}
    C -- No --> D[raise DotenvxError]
    C -- Yes --> E{is_dotenvx_safe_filename?}
    E -- No --> F[raise DotenvxFilenameError\nplaintext preserved]
    E -- Yes --> G{Windows + problematic\nfilename?}
    G -- Yes --> H[raise DotenvxFilenameError]
    G -- No --> I[normalize line endings\nclean headers\nrun dotenvx encrypt]
    I --> J{encrypt succeeded?}
    J -- No --> K[raise DotenvxError]
    J -- Yes --> L([file encrypted])
    F --> M[PartialEncryptionError.encrypt_failed]
    H --> M
    D --> M
    K --> M
```

<sub>Reviews (2): Last reviewed commit: ["refactor(encrypt): hoist slug-guard impo..."](https://github.com/jainal09/envdrift/commit/2f04ecbc420a1be2512080201d308cc7c3062d85) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36727309)</sub>

<!-- /greptile_comment -->