### PR TITLE
docs(init): leading-underscore keys are aliased, not kept bare (#467)

### DIFF
--- a/docs/cli/init.md
+++ b/docs/cli/init.md
@@ -175,8 +175,11 @@ The generated module is always valid, importable Python:
   ```
 
 - **Valid non-ASCII identifiers are kept verbatim.** A key that passes
-  `str.isidentifier()` and does not start with `_` (e.g. `CAFÉ`, `ΑΛΦΑ`) becomes
-  a bare field with no alias.
+  `str.isidentifier()`, does not start with `_`, and is already NFKC-normalized
+  (e.g. `CAFÉ`, `ΑΛΦΑ`) becomes a bare field with no alias. Python folds
+  identifiers with NFKC at compile time, so a key whose folded form differs from
+  the raw key — an NFD-composed `CAFÉ` or the ligature `ﬁle` — is aliased
+  instead, preserving the exact original variable name.
 
 - **Leading-underscore keys are aliased, not kept bare.** A key like `_PRIVATE`
   passes `str.isidentifier()`, but Pydantic rejects field names with a leading

--- a/docs/cli/init.md
+++ b/docs/cli/init.md
@@ -175,7 +175,18 @@ The generated module is always valid, importable Python:
   ```
 
 - **Valid non-ASCII identifiers are kept verbatim.** A key that passes
-  `str.isidentifier()` (e.g. `CAFÉ`, `ΑΛΦΑ`) becomes a bare field with no alias.
+  `str.isidentifier()` and does not start with `_` (e.g. `CAFÉ`, `ΑΛΦΑ`) becomes
+  a bare field with no alias.
+
+- **Leading-underscore keys are aliased, not kept bare.** A key like `_PRIVATE`
+  passes `str.isidentifier()`, but Pydantic rejects field names with a leading
+  underscore ("Fields must not use names with leading underscores"), so the key
+  is emitted with a sanitized attribute name plus an `alias` — exactly like the
+  non-identifier and reserved-name cases above:
+
+  ```python
+  field__PRIVATE: str = Field(alias='_PRIVATE')
+  ```
 
 - **The round-trip holds.** `envdrift validate` parses the `.env` the same way
   (recovering non-identifier / non-ASCII keys) and matches schema fields by their

--- a/tests/unit/test_docs_accuracy.py
+++ b/tests/unit/test_docs_accuracy.py
@@ -139,6 +139,39 @@ def test_init_md_documents_leading_underscore_aliasing() -> None:
     )
 
 
+def test_init_md_qualifies_nfkc_aliasing() -> None:
+    """init.md's 'kept verbatim' bullet must carve out non-NFKC keys too (#469).
+
+    Python folds identifiers with NFKC at compile time, so ``_resolve_field_name``
+    aliases any key whose NFKC fold differs from the raw key (an NFD-composed
+    ``CAFÉ``, the ligature ``ﬁle``) even though it passes ``str.isidentifier()``
+    and has no leading underscore. The doc's case analysis must not send such a
+    key to the bare-field bullet. Ground truth is the REAL resolver.
+    """
+    import unicodedata
+
+    from envdrift.cli_commands.init_cmd import _resolve_field_name
+
+    nfc_cafe = unicodedata.normalize("NFC", "CAFÉ")
+    nfd_cafe = unicodedata.normalize("NFD", "CAFÉ")
+    ligature = "ﬁle"  # "ﬁle" — NFKC-folds to "file"
+
+    # Real behavior: NFC stays bare; NFD/ligature keys are aliased.
+    assert _resolve_field_name(nfc_cafe, set()) == (nfc_cafe, None)
+    assert _resolve_field_name(nfd_cafe, set()) == (nfd_cafe, nfd_cafe)
+    assert _resolve_field_name(ligature, set()) == (ligature, ligature)
+
+    text = _read("init.md")
+    assert "NFKC-normalized" in text, (
+        "init.md's 'kept verbatim' bullet must require the key to be "
+        "NFKC-normalized — an NFD/ligature key is aliased (#469)."
+    )
+    assert "NFKC at compile time" in text, (
+        "init.md must explain WHY (Python NFKC-folds identifiers at compile "
+        "time), as _resolve_field_name's docstring does (#469)."
+    )
+
+
 def test_sync_md_does_not_claim_vault_name_routes() -> None:
     """sync.md must not claim vault_name overrides/routes to another vault (#413).
 

--- a/tests/unit/test_docs_accuracy.py
+++ b/tests/unit/test_docs_accuracy.py
@@ -109,6 +109,36 @@ def test_init_md_documents_force_option() -> None:
     assert "use --force to overwrite" in text
 
 
+def test_init_md_documents_leading_underscore_aliasing() -> None:
+    """init.md must document leading-underscore keys as aliased, not bare (#467/#460).
+
+    #460 made ``init`` sanitize a key that natively starts with ``_`` (e.g.
+    ``_PRIVATE``) because Pydantic rejects field names with a leading underscore.
+    Such a key passes ``str.isidentifier()``, so the old blanket claim ("a key
+    that passes ``str.isidentifier()`` becomes a bare field with no alias") was
+    wrong for it. Pin the doc to the REAL sanitizer output so it can't drift back.
+    """
+    from envdrift.cli_commands.init_cmd import _sanitize_identifier
+
+    text = _read("init.md")
+
+    # Ground truth from the real sanitizer: a leading-underscore key is aliased,
+    # while a valid non-ASCII identifier (CAFÉ) stays bare.
+    assert _sanitize_identifier("_PRIVATE") == "field__PRIVATE"
+    assert _sanitize_identifier("CAFÉ") == "CAFÉ"
+
+    # The doc must show that exact aliasing, matching the generated field line.
+    assert "field__PRIVATE: str = Field(alias='_PRIVATE')" in text, (
+        "init.md must document that a leading-underscore key like _PRIVATE is "
+        "aliased (field__PRIVATE), not emitted as a bare field (#467/#460)."
+    )
+    # The 'kept verbatim' claim must now carve out leading-underscore keys rather
+    # than make a blanket isidentifier() statement.
+    assert "does not start with `_`" in text, (
+        "init.md's 'kept verbatim' claim must exclude leading-underscore keys (#467)."
+    )
+
+
 def test_sync_md_does_not_claim_vault_name_routes() -> None:
     """sync.md must not claim vault_name overrides/routes to another vault (#413).
 


### PR DESCRIPTION
## Part 2 of #467 — stale `isidentifier()` claim in `docs/cli/init.md` (low · docs)

#460 made `init` sanitize a key that natively starts with `_`:

```python
field__PRIVATE: str = Field(alias='_PRIVATE')   # _PRIVATE, verified live
```

because Pydantic rejects field names with a leading underscore ("Fields must not use names with
leading underscores"). But `docs/cli/init.md` still claimed:

> A key that passes `str.isidentifier()` (e.g. `CAFÉ`, `ΑΛΦΑ`) becomes a bare field with no alias.

A leading-underscore identifier *passes* `str.isidentifier()` yet is now aliased, so the claim was an
over-generalization that contradicted shipped behavior.

### Fix
- Qualify the "kept verbatim" bullet to **exclude** leading-underscore keys.
- Add a dedicated bullet documenting the aliasing, with the real `field__PRIVATE` example.

### Test (real, no mock)
A new `test_docs_accuracy` regression drives the **real** `_sanitize_identifier`
(`_PRIVATE` → `field__PRIVATE`, `CAFÉ` → `CAFÉ`) and pins the doc to that output, so the claim can't
drift back. It fails RED against the pre-fix doc. `make lint-docs` clean (59 files, 0 errors).

Closes #467 (paired with #468, which fixes finding #1 — the partial-encryption data-loss bypass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR tightens the \"valid non-ASCII identifiers are kept verbatim\" bullet in `docs/cli/init.md` to exclude two additional aliasing cases that #460 introduced: keys with a leading underscore, and keys that pass `str.isidentifier()` but whose NFKC-normalized form differs from the raw key (NFD compositions, ligatures). Two regression tests are added to pin the doc to the real `_sanitize_identifier` / `_resolve_field_name` output.

- **`docs/cli/init.md`**: The \"kept verbatim\" bullet now correctly requires the key to be both leading-underscore-free and already NFKC-normalized; a new bullet documents the `_PRIVATE` → `field__PRIVATE` aliasing with a concrete code example.
- **`tests/unit/test_docs_accuracy.py`**: Two new tests drive the real sanitizer/resolver functions against known inputs (NFC/NFD `CAFÉ`, `ﬁle`, `_PRIVATE`) and assert the doc contains the updated prose, preventing silent doc drift.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are confined to documentation prose and regression tests; no production logic is touched.

The doc update correctly narrows the kept-verbatim guarantee to match what _resolve_field_name actually does. The two new tests drive the real sanitizer/resolver against concrete inputs and their assertions match the implementation's return values, so tests would catch any future drift.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/cli/init.md | Documentation accurately updated: 'kept verbatim' bullet now carves out leading-underscore and non-NFKC-normalized keys; new bullet with field__PRIVATE example matches real sanitizer output. |
| tests/unit/test_docs_accuracy.py | Two new regression tests exercise the real _sanitize_identifier and _resolve_field_name functions; assertions on NFC/NFD CAFÉ, the ﬁ ligature, and _PRIVATE all match the implementation's actual return values. |

</details>

<sub>Reviews (2): Last reviewed commit: ["docs(init): qualify the kept-verbatim bu..."](https://github.com/jainal09/envdrift/commit/822bddd55f88589189b2a5bfb70521b1311f47b7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36728312)</sub>

<!-- /greptile_comment -->