### PR TITLE
fix(lock): use canonical encryption predicates so lock never blesses plaintext (#470)

### DIFF
--- a/docs/cli/lock.md
+++ b/docs/cli/lock.md
@@ -112,10 +112,16 @@ envdrift lock --sync-keys
 Check encryption status only (dry run). Reports what would be encrypted without making changes.
 
 A file counts as encrypted only when **no plaintext value remains** — the same predicate
-`envdrift push` and `envdrift encrypt --check` use. A mixed file holding even one freshly
-added plaintext secret fails the check, no matter how many other values are already
-ciphertext. The plaintext `DOTENV_PUBLIC_KEY_*` header line is ignored, so fully-encrypted
-files pass regardless of how few variables they hold.
+`envdrift push` uses, applied to every backend (dotenvx and SOPS alike). A mixed file
+holding even one freshly added plaintext secret fails the check, no matter how many other
+values are already ciphertext. The plaintext `DOTENV_PUBLIC_KEY_*` header line and SOPS's
+`sops_*` metadata trailer are ignored, so fully-encrypted files pass regardless of how few
+variables they hold.
+
+`lock --check` is deliberately **stricter** than `envdrift encrypt --check`: the latter
+flags only values that look like secrets (sensitive names, suspicious values, or
+schema-marked fields), while `lock --check` fails on *any* plaintext value left in a file
+that is supposed to be fully encrypted.
 
 Exits 1 when any file still needs encryption (including, with `--all`,
 partial-encryption `.secret` files); exits 0 only when everything is encrypted.

--- a/docs/cli/lock.md
+++ b/docs/cli/lock.md
@@ -111,6 +111,15 @@ envdrift lock --sync-keys
 
 Check encryption status only (dry run). Reports what would be encrypted without making changes.
 
+A file counts as encrypted only when **no plaintext value remains** — the same predicate
+`envdrift push` and `envdrift encrypt --check` use. A mixed file holding even one freshly
+added plaintext secret fails the check, no matter how many other values are already
+ciphertext. The plaintext `DOTENV_PUBLIC_KEY_*` header line is ignored, so fully-encrypted
+files pass regardless of how few variables they hold.
+
+Exits 1 when any file still needs encryption (including, with `--all`,
+partial-encryption `.secret` files); exits 0 only when everything is encrypted.
+
 ```bash
 envdrift lock --check
 ```
@@ -125,10 +134,12 @@ Include partial encryption files in the locking process. When set:
 
 This is useful when you want to lock everything and clean up generated files before committing.
 
-> **Secrets-only environments are skipped.** Combine-mode handling does not apply to
-> environments configured with `secrets_only = true` — they have no combined file and
-> are encrypted in place with `envdrift push`. `lock --all` reports them as skipped and
-> leaves them untouched.
+> **Secrets-only environments are skipped — but still checked.** Combine-mode handling
+> does not apply to environments configured with `secrets_only = true` — they have no
+> combined file and are encrypted in place with `envdrift push`. `lock --all` reports
+> them as skipped and leaves them untouched. If a skipped environment still holds
+> plaintext secrets, the final summary says so and `lock --all` exits 1 instead of
+> printing the green "ready to commit" banner — run `envdrift push` to encrypt them.
 
 ```bash
 # Lock everything including partial encryption files
@@ -353,7 +364,7 @@ The `lock` command catches many edge cases and provides helpful warnings and err
 | `vault secret not found`                   | The secret doesn't exist in the vault                                |
 | `multiple .env files found`                | Multiple `.env.*` files exist; specify the environment explicitly      |
 | `file not found`                           | The expected `.env.<environment>` file doesn't exist                   |
-| `partially encrypted (N%)`                 | The file is only partially encrypted; will re-encrypt                 |
+| `partially encrypted (plaintext values remain)` | The file mixes ciphertext with plaintext values; will re-encrypt |
 | `partial encryption combined file, use --all to include` | File is a generated combined file; use `--all` to include |
 
 ### Errors
@@ -367,10 +378,12 @@ The `lock` command catches many edge cases and provides helpful warnings and err
 
 ## Exit Codes
 
-| Code | Meaning                                                  |
-|:-----|:---------------------------------------------------------|
-| 0    | Success (all files encrypted or verified)                  |
-| 1    | Error (key mismatch, encryption failure, or vault error) |
+| Code | Meaning                                                                                  |
+|:-----|:------------------------------------------------------------------------------------------|
+| 0    | Success (all files encrypted or verified)                                                  |
+| 1    | Error (key mismatch, encryption failure, or vault error)                                   |
+| 1    | `--check`: one or more files still need encryption                                         |
+| 1    | `--all`: a skipped secrets-only environment still holds plaintext (run `envdrift push`)    |
 
 ## Configuration File Format
 

--- a/docs/guides/partial-encryption.md
+++ b/docs/guides/partial-encryption.md
@@ -366,8 +366,13 @@ envdrift lock -f --all
 This will:
 
 1. Encrypt all regular `.env.*` files
-2. Encrypt all `.secret` files
+2. Encrypt all `.secret` files — like `push`, a mixed-state `.secret` (encrypted values
+   plus a freshly added plaintext value) is re-encrypted, never skipped
 3. Delete the combined files (since they're generated)
 
 This is useful when you want a single command to lock all files before committing,
 rather than using separate `push` and `lock` commands.
+
+> **Note:** Secrets-only environments stay managed by `envdrift push`. `lock --all` skips
+> them, and if a skipped environment still holds plaintext secrets it exits 1 and points
+> you at `envdrift push` instead of claiming everything is ready to commit.

--- a/src/envdrift/cli_commands/sync.py
+++ b/src/envdrift/cli_commands/sync.py
@@ -1087,6 +1087,51 @@ def pull(
     print_success("Setup complete! Your environment files are ready to use.")
 
 
+def _find_stale_private_key_name(env_keys_file: Path, expected_key_name: str) -> str | None:
+    """Return the old ``DOTENV_PRIVATE_KEY_*`` name when it mismatches the env.
+
+    Handles the renamed-file case (e.g. ``.env.local`` -> ``.env.localenv``)
+    where ``.env.keys`` still carries the key under the old name: the expected
+    key is absent but another private key is present. Returns ``None`` when the
+    expected key exists (or the keys file is missing/empty).
+    """
+    if not env_keys_file.exists():
+        return None
+    from envdrift.sync.operations import EnvKeysFile
+
+    if EnvKeysFile(env_keys_file).read_key(expected_key_name):
+        return None
+    for line in env_keys_file.read_text().splitlines():
+        if line.startswith("DOTENV_PRIVATE_KEY_") and "=" in line:
+            old_key_name = line.split("=")[0].strip()
+            if old_key_name != expected_key_name:
+                return old_key_name
+    return None
+
+
+def _rekey_dotenvx_file(
+    env_file: Path,
+    encryption_backend: Any,
+    sops_encrypt_kwargs: dict[str, Any],
+) -> tuple[bool, str]:
+    """Decrypt + re-encrypt ``env_file`` so dotenvx generates the expected key.
+
+    Returns ``(ok, error_message)``; ``error_message`` is empty on success.
+    """
+    from envdrift.encryption import EncryptionBackendError, EncryptionNotFoundError
+
+    try:
+        decrypt_result = encryption_backend.decrypt(env_file.resolve(), **sops_encrypt_kwargs)
+        if not decrypt_result.success:
+            return False, f"decrypt failed: {decrypt_result.message}"
+        result = encryption_backend.encrypt(env_file.resolve(), **sops_encrypt_kwargs)
+        if not result.success:
+            return False, f"re-encrypt failed: {result.message}"
+    except (EncryptionNotFoundError, EncryptionBackendError) as e:
+        return False, f"rekey error: {e}"
+    return True, ""
+
+
 def lock(
     config_file: Annotated[
         Path | None,
@@ -1528,47 +1573,41 @@ def lock(
                 skipped_count += 1
                 continue
         else:
-            if backend_provider == EncryptionProvider.DOTENVX:
-                # Canonical encryption-state predicate (#470): the file is fully
-                # encrypted only when no plaintext secret value remains.
-                # has_plaintext_secret_value ignores comments and the plaintext
-                # DOTENV_PUBLIC_KEY_* header, so a small fully-encrypted file is
-                # no longer mis-flagged as partial (the old N/(N+1) ratio), and
-                # a mixed file holding one freshly added plaintext secret is
-                # never blessed "already encrypted" (the old >=90% ratio).
-                if has_plaintext_secret_value(env_file):
-                    # Mixed state: ciphertext present but at least one plaintext
-                    # secret remains - re-encrypt to cover the new values.
+            # Canonical encryption-state predicate (#470), backend-agnostic: the
+            # file is fully encrypted only when no plaintext secret value
+            # remains. has_plaintext_secret_value ignores comments, the
+            # plaintext DOTENV_PUBLIC_KEY_* header and SOPS's sops_* metadata
+            # trailer, so a small fully-encrypted file is no longer mis-flagged
+            # as partial (the old N/(N+1) ratio), and a mixed file holding one
+            # freshly added plaintext secret is never blessed "already
+            # encrypted" (the old >=90% ratio) — for dotenvx AND SOPS alike.
+            if has_plaintext_secret_value(env_file):
+                warnings.append(f"{env_file}: partially encrypted, plaintext values remain")
+                if check_only:
+                    # Dry run (--check): report only — never the active voice.
                     console.print(
-                        f"  [yellow]~[/yellow] {env_file} "
-                        "[dim]- partially encrypted (plaintext values remain), "
-                        "re-encrypting...[/dim]"
+                        f"  [cyan]?[/cyan] {env_file} "
+                        "[dim]- would re-encrypt (plaintext values remain)[/dim]"
                     )
-                    warnings.append(f"{env_file}: partially encrypted, plaintext values remain")
-                else:
-                    # Fully encrypted. Check if the key name matches the expected
-                    # environment - this handles the case where a file was renamed
-                    # (e.g., .env.local -> .env.localenv) but the .env.keys still
-                    # has the old key name.
+                    encrypted_count += 1
+                    continue
+                # Mixed state: ciphertext present but at least one plaintext
+                # secret remains - re-encrypt to cover the new values.
+                console.print(
+                    f"  [yellow]~[/yellow] {env_file} "
+                    "[dim]- partially encrypted (plaintext values remain), "
+                    "re-encrypting...[/dim]"
+                )
+            else:
+                if backend_provider == EncryptionProvider.DOTENVX:
+                    # Fully encrypted. Check if the key name matches the
+                    # expected environment - this handles the case where a file
+                    # was renamed (e.g., .env.local -> .env.localenv) but the
+                    # .env.keys still has the old key name.
                     expected_key_name = f"DOTENV_PRIVATE_KEY_{effective_env.upper()}"
-                    needs_rekey = False
-                    old_key_name = None
+                    old_key_name = _find_stale_private_key_name(env_keys_file, expected_key_name)
 
-                    if env_keys_file.exists():
-                        from envdrift.sync.operations import EnvKeysFile
-
-                        keys_file = EnvKeysFile(env_keys_file)
-                        if not keys_file.read_key(expected_key_name):
-                            # Expected key not found, check for any other key
-                            keys_content = env_keys_file.read_text()
-                            for line in keys_content.splitlines():
-                                if line.startswith("DOTENV_PRIVATE_KEY_") and "=" in line:
-                                    old_key_name = line.split("=")[0].strip()
-                                    if old_key_name != expected_key_name:
-                                        needs_rekey = True
-                                        break
-
-                    if needs_rekey and old_key_name:
+                    if old_key_name:
                         if check_only:
                             # Dry run: report the intended re-key without
                             # touching the env file or .env.keys on disk (#303).
@@ -1592,56 +1631,27 @@ def lock(
                             f"{env_file}: key name mismatch, re-encrypting to generate "
                             f"{expected_key_name}"
                         )
-                        # Decrypt first, then re-encrypt
-                        try:
-                            decrypt_result = encryption_backend.decrypt(
-                                env_file.resolve(), **sops_encrypt_kwargs
-                            )
-                            if not decrypt_result.success:
-                                console.print(
-                                    f"  [red]![/red] {env_file} "
-                                    f"[red]- decrypt failed: {decrypt_result.message}[/red]"
-                                )
-                                errors.append(f"{env_file}: decrypt for rekey failed")
-                                error_count += 1
-                                continue
-                            # Now re-encrypt (will generate new key with correct name)
-                            result = encryption_backend.encrypt(
-                                env_file.resolve(), **sops_encrypt_kwargs
-                            )
-                            if not result.success:
-                                console.print(
-                                    f"  [red]![/red] {env_file} "
-                                    f"[red]- re-encrypt failed: {result.message}[/red]"
-                                )
-                                errors.append(f"{env_file}: re-encryption for rekey failed")
-                                error_count += 1
-                                continue
-                            _normalize_mapped_dotenvx_metadata(
-                                env_file,
-                                env_keys_file,
-                                effective_env,
-                                backend_provider,
-                            )
-                            console.print(
-                                f"  [green]+[/green] {env_file} [dim]- re-encrypted with new key[/dim]"
-                            )
-                            encrypted_count += 1
-                            continue
-                        except (EncryptionNotFoundError, EncryptionBackendError) as e:
-                            console.print(
-                                f"  [red]![/red] {env_file} [red]- rekey error: {e}[/red]"
-                            )
-                            errors.append(f"{env_file}: rekey failed - {e}")
+                        # Decrypt first, then re-encrypt (generates the new key)
+                        rekey_ok, rekey_error = _rekey_dotenvx_file(
+                            env_file, encryption_backend, sops_encrypt_kwargs
+                        )
+                        if not rekey_ok:
+                            console.print(f"  [red]![/red] {env_file} [red]- {rekey_error}[/red]")
+                            errors.append(f"{env_file}: {rekey_error}")
                             error_count += 1
                             continue
+                        _normalize_mapped_dotenvx_metadata(
+                            env_file,
+                            env_keys_file,
+                            effective_env,
+                            backend_provider,
+                        )
+                        console.print(
+                            f"  [green]+[/green] {env_file} [dim]- re-encrypted with new key[/dim]"
+                        )
+                        encrypted_count += 1
+                        continue
 
-                    console.print(
-                        f"  [dim]=[/dim] {env_file} [dim]- skipped (already encrypted)[/dim]"
-                    )
-                    already_encrypted_count += 1
-                    continue
-            else:
                 console.print(f"  [dim]=[/dim] {env_file} [dim]- skipped (already encrypted)[/dim]")
                 already_encrypted_count += 1
                 continue
@@ -1777,7 +1787,7 @@ def lock(
         from envdrift.config import load_config as load_envdrift_config
         from envdrift.core.partial_encryption import (
             PartialEncryptionError,
-            _is_fully_encrypted,
+            is_fully_encrypted,
             push_secrets_only,
         )
 
@@ -1819,13 +1829,13 @@ def lock(
                         combined_file = Path(env_config.combined_file)
 
                         # Encrypt the .secret file unless it is FULLY encrypted.
-                        # _is_fully_encrypted is the same predicate `envdrift push`
+                        # is_fully_encrypted is the same predicate `envdrift push`
                         # uses: ciphertext present AND no leftover plaintext secret
                         # value. The old any-ciphertext check skipped a MIXED
                         # .secret (one encrypted value + one fresh plaintext) and
                         # shipped the new secret in cleartext (#470).
                         if secret_file.exists():
-                            if not _is_fully_encrypted(secret_file):
+                            if not is_fully_encrypted(secret_file):
                                 if check_only:
                                     console.print(
                                         f"  [cyan]?[/cyan] {secret_file} "

--- a/src/envdrift/cli_commands/sync.py
+++ b/src/envdrift/cli_commands/sync.py
@@ -1411,6 +1411,9 @@ def lock(
         print_error(f"Unsupported encryption backend: {e}")
         raise typer.Exit(code=1) from None
 
+    # Canonical encryption-state predicate, shared with the push paths (#470).
+    from envdrift.core.partial_encryption import has_plaintext_secret_value
+
     sops_encrypt_kwargs = {}
     if backend_provider == EncryptionProvider.SOPS:
         sops_encrypt_kwargs = encryption_helpers.build_sops_encrypt_kwargs(encryption_config)
@@ -1526,122 +1529,113 @@ def lock(
                 continue
         else:
             if backend_provider == EncryptionProvider.DOTENVX:
-                # Check encryption ratio
-                encrypted_lines = sum(
-                    1 for line in content.splitlines() if "encrypted:" in line.lower()
-                )
-                total_value_lines = sum(
-                    1
-                    for line in content.splitlines()
-                    if line.strip() and not line.strip().startswith("#") and "=" in line
-                )
+                # Canonical encryption-state predicate (#470): the file is fully
+                # encrypted only when no plaintext secret value remains.
+                # has_plaintext_secret_value ignores comments and the plaintext
+                # DOTENV_PUBLIC_KEY_* header, so a small fully-encrypted file is
+                # no longer mis-flagged as partial (the old N/(N+1) ratio), and
+                # a mixed file holding one freshly added plaintext secret is
+                # never blessed "already encrypted" (the old >=90% ratio).
+                if has_plaintext_secret_value(env_file):
+                    # Mixed state: ciphertext present but at least one plaintext
+                    # secret remains - re-encrypt to cover the new values.
+                    console.print(
+                        f"  [yellow]~[/yellow] {env_file} "
+                        "[dim]- partially encrypted (plaintext values remain), "
+                        "re-encrypting...[/dim]"
+                    )
+                    warnings.append(f"{env_file}: partially encrypted, plaintext values remain")
+                else:
+                    # Fully encrypted. Check if the key name matches the expected
+                    # environment - this handles the case where a file was renamed
+                    # (e.g., .env.local -> .env.localenv) but the .env.keys still
+                    # has the old key name.
+                    expected_key_name = f"DOTENV_PRIVATE_KEY_{effective_env.upper()}"
+                    needs_rekey = False
+                    old_key_name = None
 
-                if total_value_lines > 0:
-                    ratio = encrypted_lines / total_value_lines
-                    if ratio >= 0.9:  # 90%+ encrypted = fully encrypted
-                        # Check if the key name matches the expected environment
-                        # This handles the case where a file was renamed (e.g., .env.local -> .env.localenv)
-                        # but the .env.keys still has the old key name
-                        expected_key_name = f"DOTENV_PRIVATE_KEY_{effective_env.upper()}"
-                        needs_rekey = False
-                        old_key_name = None
+                    if env_keys_file.exists():
+                        from envdrift.sync.operations import EnvKeysFile
 
-                        if env_keys_file.exists():
-                            from envdrift.sync.operations import EnvKeysFile
+                        keys_file = EnvKeysFile(env_keys_file)
+                        if not keys_file.read_key(expected_key_name):
+                            # Expected key not found, check for any other key
+                            keys_content = env_keys_file.read_text()
+                            for line in keys_content.splitlines():
+                                if line.startswith("DOTENV_PRIVATE_KEY_") and "=" in line:
+                                    old_key_name = line.split("=")[0].strip()
+                                    if old_key_name != expected_key_name:
+                                        needs_rekey = True
+                                        break
 
-                            keys_file = EnvKeysFile(env_keys_file)
-                            if not keys_file.read_key(expected_key_name):
-                                # Expected key not found, check for any other key
-                                keys_content = env_keys_file.read_text()
-                                for line in keys_content.splitlines():
-                                    if line.startswith("DOTENV_PRIVATE_KEY_") and "=" in line:
-                                        old_key_name = line.split("=")[0].strip()
-                                        if old_key_name != expected_key_name:
-                                            needs_rekey = True
-                                            break
-
-                        if needs_rekey and old_key_name:
-                            if check_only:
-                                # Dry run: report the intended re-key without
-                                # touching the env file or .env.keys on disk (#303).
-                                console.print(
-                                    f"  [cyan]?[/cyan] {env_file} "
-                                    f"[dim]- would re-key ({old_key_name} -> "
-                                    f"{expected_key_name})[/dim]"
-                                )
-                                warnings.append(
-                                    f"{env_file}: key name mismatch, would re-encrypt to "
-                                    f"generate {expected_key_name}"
-                                )
-                                encrypted_count += 1
-                                continue
+                    if needs_rekey and old_key_name:
+                        if check_only:
+                            # Dry run: report the intended re-key without
+                            # touching the env file or .env.keys on disk (#303).
                             console.print(
-                                f"  [yellow]~[/yellow] {env_file} "
-                                f"[dim]- key name mismatch ({old_key_name} -> {expected_key_name}), "
-                                "re-encrypting...[/dim]"
+                                f"  [cyan]?[/cyan] {env_file} "
+                                f"[dim]- would re-key ({old_key_name} -> "
+                                f"{expected_key_name})[/dim]"
                             )
                             warnings.append(
-                                f"{env_file}: key name mismatch, re-encrypting to generate "
-                                f"{expected_key_name}"
+                                f"{env_file}: key name mismatch, would re-encrypt to "
+                                f"generate {expected_key_name}"
                             )
-                            # Decrypt first, then re-encrypt
-                            try:
-                                decrypt_result = encryption_backend.decrypt(
-                                    env_file.resolve(), **sops_encrypt_kwargs
-                                )
-                                if not decrypt_result.success:
-                                    console.print(
-                                        f"  [red]![/red] {env_file} "
-                                        f"[red]- decrypt failed: {decrypt_result.message}[/red]"
-                                    )
-                                    errors.append(f"{env_file}: decrypt for rekey failed")
-                                    error_count += 1
-                                    continue
-                                # Now re-encrypt (will generate new key with correct name)
-                                result = encryption_backend.encrypt(
-                                    env_file.resolve(), **sops_encrypt_kwargs
-                                )
-                                if not result.success:
-                                    console.print(
-                                        f"  [red]![/red] {env_file} "
-                                        f"[red]- re-encrypt failed: {result.message}[/red]"
-                                    )
-                                    errors.append(f"{env_file}: re-encryption for rekey failed")
-                                    error_count += 1
-                                    continue
-                                _normalize_mapped_dotenvx_metadata(
-                                    env_file,
-                                    env_keys_file,
-                                    effective_env,
-                                    backend_provider,
-                                )
-                                console.print(
-                                    f"  [green]+[/green] {env_file} [dim]- re-encrypted with new key[/dim]"
-                                )
-                                encrypted_count += 1
-                                continue
-                            except (EncryptionNotFoundError, EncryptionBackendError) as e:
-                                console.print(
-                                    f"  [red]![/red] {env_file} [red]- rekey error: {e}[/red]"
-                                )
-                                errors.append(f"{env_file}: rekey failed - {e}")
-                                error_count += 1
-                                continue
-
-                        console.print(
-                            f"  [dim]=[/dim] {env_file} [dim]- skipped (already encrypted)[/dim]"
-                        )
-                        already_encrypted_count += 1
-                        continue
-                    else:
-                        # Partially encrypted - re-encrypt to catch new values
+                            encrypted_count += 1
+                            continue
                         console.print(
                             f"  [yellow]~[/yellow] {env_file} "
-                            f"[dim]- partially encrypted ({int(ratio * 100)}%), "
+                            f"[dim]- key name mismatch ({old_key_name} -> {expected_key_name}), "
                             "re-encrypting...[/dim]"
                         )
-                        warnings.append(f"{env_file}: was only {int(ratio * 100)}% encrypted")
-                else:
+                        warnings.append(
+                            f"{env_file}: key name mismatch, re-encrypting to generate "
+                            f"{expected_key_name}"
+                        )
+                        # Decrypt first, then re-encrypt
+                        try:
+                            decrypt_result = encryption_backend.decrypt(
+                                env_file.resolve(), **sops_encrypt_kwargs
+                            )
+                            if not decrypt_result.success:
+                                console.print(
+                                    f"  [red]![/red] {env_file} "
+                                    f"[red]- decrypt failed: {decrypt_result.message}[/red]"
+                                )
+                                errors.append(f"{env_file}: decrypt for rekey failed")
+                                error_count += 1
+                                continue
+                            # Now re-encrypt (will generate new key with correct name)
+                            result = encryption_backend.encrypt(
+                                env_file.resolve(), **sops_encrypt_kwargs
+                            )
+                            if not result.success:
+                                console.print(
+                                    f"  [red]![/red] {env_file} "
+                                    f"[red]- re-encrypt failed: {result.message}[/red]"
+                                )
+                                errors.append(f"{env_file}: re-encryption for rekey failed")
+                                error_count += 1
+                                continue
+                            _normalize_mapped_dotenvx_metadata(
+                                env_file,
+                                env_keys_file,
+                                effective_env,
+                                backend_provider,
+                            )
+                            console.print(
+                                f"  [green]+[/green] {env_file} [dim]- re-encrypted with new key[/dim]"
+                            )
+                            encrypted_count += 1
+                            continue
+                        except (EncryptionNotFoundError, EncryptionBackendError) as e:
+                            console.print(
+                                f"  [red]![/red] {env_file} [red]- rekey error: {e}[/red]"
+                            )
+                            errors.append(f"{env_file}: rekey failed - {e}")
+                            error_count += 1
+                            continue
+
                     console.print(
                         f"  [dim]=[/dim] {env_file} [dim]- skipped (already encrypted)[/dim]"
                     )
@@ -1767,6 +1761,10 @@ def lock(
     # === STEP 3: PROCESS PARTIAL ENCRYPTION FILES (OPTIONAL) ===
     partial_encrypted_count = 0
     combined_deleted_count = 0
+    secrets_only_skipped = 0
+    # (env name, pending file count) for skipped secrets-only environments that
+    # still hold plaintext - the final banner/exit must not overclaim (#470).
+    secrets_only_pending: list[tuple[str, int]] = []
 
     if all_files:
         step_num = "Step 3" if verify_vault else "Step 2"
@@ -1777,6 +1775,11 @@ def lock(
         # Load partial encryption config using shared helper
         from envdrift.config import ConfigNotFoundError
         from envdrift.config import load_config as load_envdrift_config
+        from envdrift.core.partial_encryption import (
+            PartialEncryptionError,
+            _is_fully_encrypted,
+            push_secrets_only,
+        )
 
         config_path = _find_config_path(config_file)
 
@@ -1794,16 +1797,35 @@ def lock(
                                 f"  [dim]=[/dim] {env_config.secrets_dir} "
                                 "[dim]- skipped (secrets-only, managed by 'envdrift push')[/dim]"
                             )
+                            secrets_only_skipped += 1
+                            # The skip is by design, but the final "ready to
+                            # commit" banner/exit 0 must not paper over plaintext
+                            # knowingly left on disk (#470). Reuse push's dry run
+                            # (check=True touches nothing) to count the files a
+                            # real push would still need to encrypt.
+                            try:
+                                stats = push_secrets_only(env_config, check=True)
+                            except PartialEncryptionError as e:
+                                warnings.append(
+                                    f"{env_config.name}: skipped secrets-only environment "
+                                    f"could not be checked - {e}"
+                                )
+                                continue
+                            pending = int(stats["encrypted"])
+                            if pending:
+                                secrets_only_pending.append((env_config.name, pending))
                             continue
                         secret_file = Path(env_config.secret_file)
                         combined_file = Path(env_config.combined_file)
 
-                        # Encrypt the .secret file if it exists and is not encrypted
+                        # Encrypt the .secret file unless it is FULLY encrypted.
+                        # _is_fully_encrypted is the same predicate `envdrift push`
+                        # uses: ciphertext present AND no leftover plaintext secret
+                        # value. The old any-ciphertext check skipped a MIXED
+                        # .secret (one encrypted value + one fresh plaintext) and
+                        # shipped the new secret in cleartext (#470).
                         if secret_file.exists():
-                            secret_content = secret_file.read_text()
-                            if not encryption_helpers.is_encrypted_content(
-                                backend_provider, encryption_backend, secret_content
-                            ):
+                            if not _is_fully_encrypted(secret_file):
                                 if check_only:
                                     console.print(
                                         f"  [cyan]?[/cyan] {secret_file} "
@@ -1897,6 +1919,8 @@ def lock(
         else:
             summary_lines.append(f"Partial secrets encrypted: {partial_encrypted_count}")
             summary_lines.append(f"Combined files deleted: {combined_deleted_count}")
+        if secrets_only_skipped:
+            summary_lines.append(f"Secrets-only environments skipped: {secrets_only_skipped}")
 
     console.print(
         Panel(
@@ -1925,13 +1949,29 @@ def lock(
         raise typer.Exit(code=1)
 
     console.print()
+    if secrets_only_pending:
+        # Truthful result (#470): these environments were knowingly skipped
+        # (they are managed by 'envdrift push'), but they still hold plaintext
+        # secrets - no green "ready to commit" banner, no exit 0.
+        pending_total = sum(count for _, count in secrets_only_pending)
+        pending_names = ", ".join(name for name, _ in secrets_only_pending)
+        print_warning(
+            f"Skipped secrets-only environment(s) ({pending_names}) still have "
+            f"{pending_total} file(s) needing encryption. "
+            "Run 'envdrift push' to encrypt them."
+        )
+        raise typer.Exit(code=1)
     if check_only:
-        if encrypted_count > 0:
+        # Partial-encryption secrets pending under --all count too: a dry run
+        # that reports "would be encrypted" must not exit 0 (#470).
+        pending_check = encrypted_count + partial_encrypted_count
+        if pending_check > 0:
             # In check mode, if files would be encrypted, this is a failure
             # (useful for CI/pre-commit hooks to ensure all files are encrypted)
+            rerun_cmd = "envdrift lock --all" if all_files else "envdrift lock"
             print_warning(
-                f"Found {encrypted_count} file(s) that need encryption. "
-                "Run 'envdrift lock' to encrypt them."
+                f"Found {pending_check} file(s) that need encryption. "
+                f"Run '{rerun_cmd}' to encrypt them."
             )
             raise typer.Exit(code=1)
         else:

--- a/src/envdrift/cli_commands/sync.py
+++ b/src/envdrift/cli_commands/sync.py
@@ -1787,6 +1787,7 @@ def lock(
         from envdrift.config import load_config as load_envdrift_config
         from envdrift.core.partial_encryption import (
             PartialEncryptionError,
+            encrypt_secret_file,
             is_fully_encrypted,
             push_secrets_only,
         )
@@ -1834,6 +1835,14 @@ def lock(
                         # value. The old any-ciphertext check skipped a MIXED
                         # .secret (one encrypted value + one fresh plaintext) and
                         # shipped the new secret in cleartext (#470).
+                        # enc_state gates the combined-file deletion below:
+                        # only a successful / already-encrypted .secret may have
+                        # its combined artifact removed (#507 review). Routing
+                        # the encrypt through encrypt_secret_file() keeps the
+                        # canonical partial-encryption lifecycle: read-back
+                        # verification and clearing the skip-worktree bit a
+                        # pull-partial left behind, exactly like `envdrift push`.
+                        enc_state = "missing"
                         if secret_file.exists():
                             if not is_fully_encrypted(secret_file):
                                 if check_only:
@@ -1842,72 +1851,90 @@ def lock(
                                         "[dim]- would be encrypted[/dim]"
                                     )
                                     partial_encrypted_count += 1
+                                    enc_state = "encrypted"
                                 else:
                                     try:
-                                        result = encryption_backend.encrypt(
-                                            secret_file.resolve(), **sops_encrypt_kwargs
+                                        encrypt_secret_file(env_config)
+                                        console.print(
+                                            f"  [green]+[/green] {secret_file} "
+                                            "[dim]- encrypted[/dim]"
                                         )
-                                        if result.success:
-                                            console.print(
-                                                f"  [green]+[/green] {secret_file} "
-                                                "[dim]- encrypted[/dim]"
-                                            )
-                                            partial_encrypted_count += 1
-                                        else:
-                                            console.print(
-                                                f"  [red]![/red] {secret_file} "
-                                                f"[red]- error: {result.message}[/red]"
-                                            )
-                                            errors.append(
-                                                f"{secret_file}: encryption failed - {result.message}"
-                                            )
-                                            error_count += 1
-                                    except (EncryptionNotFoundError, EncryptionBackendError) as e:
+                                        partial_encrypted_count += 1
+                                        enc_state = "encrypted"
+                                    except PartialEncryptionError as e:
                                         console.print(
                                             f"  [red]![/red] {secret_file} [red]- error: {e}[/red]"
                                         )
                                         errors.append(f"{secret_file}: encryption failed - {e}")
                                         error_count += 1
+                                        enc_state = "failed"
                             else:
+                                if not check_only:
+                                    # Already fully encrypted: still run the
+                                    # canonical no-op path so a stale
+                                    # skip-worktree bit is lifted (#507 review).
+                                    encrypt_secret_file(env_config)
                                 console.print(
                                     f"  [dim]=[/dim] {secret_file} "
                                     "[dim]- skipped (already encrypted)[/dim]"
                                 )
                                 already_encrypted_count += 1
+                                enc_state = "already"
                         else:
                             console.print(
                                 f"  [dim]=[/dim] {secret_file} [dim]- skipped (not found)[/dim]"
                             )
 
-                        # Delete the combined file if it exists
+                        # Delete the combined file ONLY when the .secret is in a
+                        # good state: deleting it after a failed encryption (or
+                        # with no .secret source at all) would destroy the one
+                        # remaining runtime artifact while plaintext lingers
+                        # (#507 review; same data-loss class as #471).
                         if combined_file.exists():
-                            if check_only:
-                                console.print(
-                                    f"  [cyan]?[/cyan] {combined_file} "
-                                    "[dim]- would be deleted[/dim]"
-                                )
-                                combined_deleted_count += 1
-                            else:
-                                try:
-                                    combined_file.unlink()
+                            if enc_state in ("encrypted", "already"):
+                                if check_only:
                                     console.print(
-                                        f"  [yellow]-[/yellow] {combined_file} "
-                                        "[dim]- deleted (combined file)[/dim]"
+                                        f"  [cyan]?[/cyan] {combined_file} "
+                                        "[dim]- would be deleted[/dim]"
                                     )
                                     combined_deleted_count += 1
-                                except OSError as e:
-                                    console.print(
-                                        f"  [red]![/red] {combined_file} "
-                                        f"[red]- delete failed: {e}[/red]"
-                                    )
-                                    errors.append(f"{combined_file}: delete failed - {e}")
-                                    error_count += 1
+                                else:
+                                    try:
+                                        combined_file.unlink()
+                                        console.print(
+                                            f"  [yellow]-[/yellow] {combined_file} "
+                                            "[dim]- deleted (combined file)[/dim]"
+                                        )
+                                        combined_deleted_count += 1
+                                    except OSError as e:
+                                        console.print(
+                                            f"  [red]![/red] {combined_file} "
+                                            f"[red]- delete failed: {e}[/red]"
+                                        )
+                                        errors.append(f"{combined_file}: delete failed - {e}")
+                                        error_count += 1
+                            else:
+                                reason = (
+                                    "encryption failed"
+                                    if enc_state == "failed"
+                                    else "no .secret source"
+                                )
+                                console.print(
+                                    f"  [yellow]![/yellow] {combined_file} "
+                                    f"[dim]- kept ({reason})[/dim]"
+                                )
                 else:
                     console.print("  [dim]Partial encryption not enabled in config[/dim]")
             except ConfigNotFoundError:
                 print_warning("Could not find partial encryption config")
             except (OSError, AttributeError, KeyError) as e:
-                print_warning(f"Could not load partial encryption config: {e}")
+                # A failure ANYWHERE in the partial step (unreadable .secret,
+                # broken config types, ...) must not melt into a warning under
+                # the green "ready to commit" banner with exit 0 — the partial
+                # environments were NOT processed (#507 review follow-up).
+                print_warning(f"Partial encryption step failed: {e}")
+                errors.append(f"partial encryption step failed: {e}")
+                error_count += 1
 
     # === SUMMARY ===
     console.print()

--- a/src/envdrift/core/partial_encryption.py
+++ b/src/envdrift/core/partial_encryption.py
@@ -330,7 +330,7 @@ def is_file_encrypted(file_path: Path) -> bool:
     return "sops_version" in content and _SOPS_CIPHERTEXT_PREFIX in content
 
 
-def _is_fully_encrypted(file_path: Path) -> bool:
+def is_fully_encrypted(file_path: Path) -> bool:
     """Return True only when the file is FULLY encrypted (push would no-op).
 
     Fully encrypted means ciphertext is present AND no leftover plaintext secret
@@ -338,10 +338,17 @@ def _is_fully_encrypted(file_path: Path) -> bool:
     so a MIXED-STATE file (some values encrypted, one freshly-added plaintext)
     looks "encrypted" to it alone; pairing it with ``has_plaintext_secret_value``
     distinguishes a file a real push would re-encrypt from one it would skip.
-    The encrypt paths and the dry-run ``--check`` sync test share this predicate
-    so they agree on what "already pushed" means.
+
+    This is the canonical shared predicate: the push paths, ``envdrift lock``
+    and the dry-run ``--check`` sync test all use it so they agree on what
+    "already pushed/encrypted" means.
     """
     return is_file_encrypted(file_path) and not has_plaintext_secret_value(file_path)
+
+
+# Backward-compatible alias for the pre-#507 private name (in-flight branches
+# still import it); new code should use ``is_fully_encrypted``.
+_is_fully_encrypted = is_fully_encrypted
 
 
 def combine_files(
@@ -506,7 +513,7 @@ def encrypt_secret_file(env_config: PartialEncryptionEnvironmentConfig) -> None:
     # re-encrypted — otherwise the new plaintext secret leaks into the committed
     # .secret file and the combined file. is_file_encrypted() returns True on
     # the first ciphertext value, so it alone cannot tell the two apart.
-    if _is_fully_encrypted(secret_file):
+    if is_fully_encrypted(secret_file):
         # Already fully encrypted (e.g. push run twice) — still lift any stale
         # skip-worktree protection so the encrypted diff is visible to git.
         _git_unskip_worktree(secret_file)
@@ -600,7 +607,7 @@ def push_partial_encryption(
         # added plaintext value) trips is_file_encrypted but would still be
         # re-encrypted, so it must report out of sync.
         secret_file = Path(env_config.secret_file)
-        if secret_file.exists() and not _is_fully_encrypted(secret_file):
+        if secret_file.exists() and not is_fully_encrypted(secret_file):
             stats["in_sync"] = False
         return stats
 
@@ -694,7 +701,7 @@ def _encrypt_secrets_only_file(dotenvx: DotenvxWrapper, file: Path, *, check: bo
     Returns False (already-encrypted) without touching ``dotenvx`` when the file
     is fully encrypted. In ``check`` mode no file is modified.
     """
-    if _is_fully_encrypted(file):
+    if is_fully_encrypted(file):
         if not check:
             # Already fully encrypted — lift any stale skip-worktree protection
             # so the encrypted diff is visible to git.

--- a/tests/integration/test_lock_encryption_state.py
+++ b/tests/integration/test_lock_encryption_state.py
@@ -1,0 +1,439 @@
+"""Regression tests for issue #470: lock must use the canonical encryption predicates.
+
+``envdrift lock`` used to decide "already encrypted" with a >=90% ciphertext-line
+ratio (and ``lock --all`` with an any-ciphertext regex), instead of the canonical
+predicates (``has_plaintext_secret_value`` / ``_is_fully_encrypted``). That cut
+both ways:
+
+- a MIXED file (>=18 encrypted values + 1 fresh plaintext secret) was blessed
+  "already encrypted" and ``lock --check`` exited 0 — a false security PASS;
+- a FULLY-encrypted file with fewer than 9 variables was forever flagged
+  "partially encrypted" (the plaintext ``DOTENV_PUBLIC_KEY_*`` header counted in
+  the ratio denominator) and ``lock --check`` exited 1 — a false FAIL;
+- ``lock --all`` skipped a mixed ``.secret`` file and deleted the combined file
+  while the fresh plaintext secret survived, exit 0;
+- ``lock --all`` printed the unconditional "ready to commit" banner with exit 0
+  while knowingly skipping secrets-only environments that still held plaintext.
+
+These tests drive the real ``envdrift`` CLI as a subprocess with the real
+``dotenvx`` binary. All fixtures are produced by a real ``envdrift encrypt`` so
+they carry the exact production input shape, including the ``DOTENV_PUBLIC_KEY``
+header line (contributes regression coverage for issue #485).
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(shutil.which("dotenvx") is None, reason="dotenvx binary not installed"),
+]
+
+# Built by concatenation so the fixture never contains a realistic secret
+# literal (GitHub push protection).
+LEAKED_VALUE = "ghp_" + "realtokenplaintext12345"
+
+CONFIG_BASE = """\
+[vault]
+provider = "aws"
+
+[vault.aws]
+region = "us-east-1"
+
+[encryption]
+backend = "dotenvx"
+
+[[vault.sync.mappings]]
+secret_name = "svc-key"
+folder_path = "svc"
+environment = "production"
+"""
+
+CONFIG_COMBINE_PARTIAL = (
+    CONFIG_BASE
+    + """
+[partial_encryption]
+enabled = true
+
+[[partial_encryption.environments]]
+name = "production"
+clear_file = "partial/.env.production.clear"
+secret_file = "partial/.env.production.secret"
+combined_file = "partial/.env.production"
+"""
+)
+
+CONFIG_SECRETS_ONLY_PARTIAL = (
+    CONFIG_BASE
+    + """
+[partial_encryption]
+enabled = true
+
+[[partial_encryption.environments]]
+name = "api"
+secrets_only = true
+secrets_dir = "secrets"
+"""
+)
+
+
+def _run(
+    envdrift_cmd: list[str],
+    args: list[str],
+    cwd: Path,
+    pythonpath: str,
+    timeout: int = 120,
+) -> subprocess.CompletedProcess[str]:
+    """Run the real envdrift CLI as a subprocess in ``cwd``."""
+    env = os.environ.copy()
+    env["PYTHONPATH"] = pythonpath
+    return subprocess.run(
+        [*envdrift_cmd, *args],
+        cwd=cwd,
+        env=env,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=timeout,
+    )
+
+
+def _norm(result: subprocess.CompletedProcess[str]) -> str:
+    """Normalize Rich output (line wraps under narrow CI consoles) for substring asserts."""
+    return " ".join((result.stdout + result.stderr).split())
+
+
+def _write_and_encrypt(
+    envdrift_cmd: list[str],
+    pythonpath: str,
+    project: Path,
+    rel_path: str,
+    pairs: list[str],
+) -> Path:
+    """Write ``pairs`` to ``rel_path`` and encrypt it with the real dotenvx backend."""
+    file = project / rel_path
+    file.parent.mkdir(parents=True, exist_ok=True)
+    file.write_text("\n".join(pairs) + "\n", encoding="utf-8")
+    result = _run(envdrift_cmd, ["encrypt", rel_path], project, pythonpath)
+    assert result.returncode == 0, f"setup encrypt failed:\n{result.stdout}\n{result.stderr}"
+    content = file.read_text(encoding="utf-8")
+    # The exact production input shape: dotenvx writes a plaintext public-key
+    # header line above the ciphertext (#485).
+    assert "DOTENV_PUBLIC_KEY" in content
+    assert "encrypted:" in content
+    return file
+
+
+def _append_plaintext(file: Path, line: str) -> None:
+    file.write_text(file.read_text(encoding="utf-8") + line + "\n", encoding="utf-8")
+
+
+@pytest.fixture
+def project(tmp_path: Path) -> Path:
+    """A minimal envdrift project with one dotenvx-backed sync mapping."""
+    (tmp_path / "envdrift.toml").write_text(CONFIG_BASE, encoding="utf-8")
+    (tmp_path / "svc").mkdir()
+    return tmp_path
+
+
+def _make_mixed_env_file(envdrift_cmd: list[str], pythonpath: str, project: Path) -> Path:
+    """18 encrypted values + 1 fresh plaintext secret: >=90% ciphertext lines.
+
+    18 encrypted lines over 20 assignment lines (incl. the public-key header and
+    the appended plaintext) is exactly the 0.90 ratio the old heuristic blessed
+    as "already encrypted".
+    """
+    env_file = _write_and_encrypt(
+        envdrift_cmd,
+        pythonpath,
+        project,
+        "svc/.env.production",
+        [f"SECRET_{i}=value{i}" for i in range(1, 19)],
+    )
+    _append_plaintext(env_file, "NEW_SECRET=" + LEAKED_VALUE)
+    return env_file
+
+
+class TestLockMixedStateFile:
+    """Item 2 of #470: a mixed dotenvx file must never be blessed as encrypted."""
+
+    def test_lock_check_fails_on_mixed_file_with_fresh_plaintext(
+        self, project: Path, integration_pythonpath: str, envdrift_cmd: list[str]
+    ):
+        """lock --check must exit 1 when a fresh plaintext secret hides in ciphertext."""
+        env_file = _make_mixed_env_file(envdrift_cmd, integration_pythonpath, project)
+        before = env_file.read_bytes()
+
+        result = _run(envdrift_cmd, ["lock", "--check"], project, integration_pythonpath)
+
+        assert result.returncode == 1, (
+            f"lock --check blessed a mixed file with a plaintext secret:\n{result.stdout}"
+        )
+        assert "need encryption" in _norm(result).lower()
+        # --check is a dry run: the file must not be modified.
+        assert env_file.read_bytes() == before
+
+    def test_lock_force_reencrypts_mixed_file(
+        self, project: Path, integration_pythonpath: str, envdrift_cmd: list[str]
+    ):
+        """lock --force must re-encrypt the fresh plaintext value, not skip the file."""
+        env_file = _make_mixed_env_file(envdrift_cmd, integration_pythonpath, project)
+
+        result = _run(envdrift_cmd, ["lock", "--force"], project, integration_pythonpath)
+
+        assert result.returncode == 0, f"lock --force failed:\n{result.stdout}\n{result.stderr}"
+        content = env_file.read_text(encoding="utf-8")
+        assert LEAKED_VALUE not in content, "fresh plaintext secret survived lock --force"
+        assert "NEW_SECRET=encrypted:" in content.replace('"', "")
+        # Post-condition verified end-to-end: a subsequent check now passes.
+        recheck = _run(envdrift_cmd, ["lock", "--check"], project, integration_pythonpath)
+        assert recheck.returncode == 0, f"re-check after lock failed:\n{recheck.stdout}"
+
+
+class TestLockFullyEncryptedSmallFile:
+    """Item 3 of #470: the public-key header must not count as a plaintext variable."""
+
+    def test_lock_check_passes_fully_encrypted_three_var_file(
+        self, project: Path, integration_pythonpath: str, envdrift_cmd: list[str]
+    ):
+        """A fully-encrypted 3-variable file is not 'partially encrypted (75%)'."""
+        _write_and_encrypt(
+            envdrift_cmd,
+            integration_pythonpath,
+            project,
+            "svc/.env.production",
+            ["API_KEY=s1", "DB_PASS=s2", "TOKEN=s3"],
+        )
+
+        result = _run(envdrift_cmd, ["lock", "--check"], project, integration_pythonpath)
+
+        assert result.returncode == 0, (
+            f"lock --check flagged a fully-encrypted small file:\n{result.stdout}"
+        )
+        assert "all files are already encrypted" in _norm(result).lower()
+
+    def test_lock_force_does_not_churn_fully_encrypted_small_file(
+        self, project: Path, integration_pythonpath: str, envdrift_cmd: list[str]
+    ):
+        """lock --force must skip (not re-encrypt) a fully-encrypted small file."""
+        env_file = _write_and_encrypt(
+            envdrift_cmd,
+            integration_pythonpath,
+            project,
+            "svc/.env.production",
+            ["API_KEY=s1", "DB_PASS=s2", "TOKEN=s3"],
+        )
+        before = env_file.read_bytes()
+
+        result = _run(envdrift_cmd, ["lock", "--force"], project, integration_pythonpath)
+
+        assert result.returncode == 0, f"lock --force failed:\n{result.stdout}\n{result.stderr}"
+        # dotenvx encryption is non-deterministic, so any re-encrypt would change
+        # the bytes; identical bytes prove the file was correctly skipped.
+        assert env_file.read_bytes() == before
+        assert "skipped (already encrypted)" in _norm(result).lower()
+
+
+class TestLockEncryptCheckParity:
+    """Item 2 of #470 (verifier note): lock --check and encrypt --check must agree."""
+
+    def test_gates_agree_on_mixed_file(
+        self, project: Path, integration_pythonpath: str, envdrift_cmd: list[str]
+    ):
+        _make_mixed_env_file(envdrift_cmd, integration_pythonpath, project)
+
+        encrypt_check = _run(
+            envdrift_cmd,
+            ["encrypt", "svc/.env.production", "--check"],
+            project,
+            integration_pythonpath,
+        )
+        lock_check = _run(envdrift_cmd, ["lock", "--check"], project, integration_pythonpath)
+
+        assert encrypt_check.returncode == 1, (
+            f"encrypt --check missed the plaintext secret:\n{encrypt_check.stdout}"
+        )
+        assert lock_check.returncode == encrypt_check.returncode, (
+            "lock --check and encrypt --check disagree on the same mixed file: "
+            f"lock={lock_check.returncode} encrypt={encrypt_check.returncode}\n"
+            f"{lock_check.stdout}"
+        )
+
+    def test_gates_agree_on_fully_encrypted_file(
+        self, project: Path, integration_pythonpath: str, envdrift_cmd: list[str]
+    ):
+        _write_and_encrypt(
+            envdrift_cmd,
+            integration_pythonpath,
+            project,
+            "svc/.env.production",
+            ["API_KEY=s1", "DB_PASS=s2", "TOKEN=s3"],
+        )
+
+        encrypt_check = _run(
+            envdrift_cmd,
+            ["encrypt", "svc/.env.production", "--check"],
+            project,
+            integration_pythonpath,
+        )
+        lock_check = _run(envdrift_cmd, ["lock", "--check"], project, integration_pythonpath)
+
+        assert encrypt_check.returncode == 0, (
+            f"encrypt --check flagged a fully-encrypted file:\n{encrypt_check.stdout}"
+        )
+        assert lock_check.returncode == encrypt_check.returncode, (
+            "lock --check and encrypt --check disagree on the same encrypted file: "
+            f"lock={lock_check.returncode} encrypt={encrypt_check.returncode}\n"
+            f"{lock_check.stdout}"
+        )
+
+
+class TestLockAllMixedSecretFile:
+    """Item 1 of #470: lock --all must re-encrypt a mixed-state .secret file."""
+
+    @pytest.fixture
+    def partial_project(
+        self, tmp_path: Path, integration_pythonpath: str, envdrift_cmd: list[str]
+    ) -> tuple[Path, Path, Path]:
+        """Project with a combine-mode partial env whose .secret is mixed-state."""
+        (tmp_path / "envdrift.toml").write_text(CONFIG_COMBINE_PARTIAL, encoding="utf-8")
+        (tmp_path / "svc").mkdir()
+        # The regular mapping is fully encrypted so step 2 is uneventful.
+        _write_and_encrypt(
+            envdrift_cmd,
+            integration_pythonpath,
+            tmp_path,
+            "svc/.env.production",
+            ["API_KEY=s1", "DB_PASS=s2", "TOKEN=s3"],
+        )
+        secret_file = _write_and_encrypt(
+            envdrift_cmd,
+            integration_pythonpath,
+            tmp_path,
+            "partial/.env.production.secret",
+            ["API_KEY=oldvalue1"],
+        )
+        # A fresh plaintext secret appended after the file was encrypted.
+        _append_plaintext(secret_file, "NEW_SECRET=" + LEAKED_VALUE)
+        combined_file = tmp_path / "partial" / ".env.production"
+        combined_file.write_text("APP_NAME=myapp\nAPI_KEY=oldvalue1\n", encoding="utf-8")
+        return tmp_path, secret_file, combined_file
+
+    def test_lock_all_reencrypts_mixed_secret_file(
+        self,
+        partial_project: tuple[Path, Path, Path],
+        integration_pythonpath: str,
+        envdrift_cmd: list[str],
+    ):
+        """The mixed .secret is re-encrypted; the plaintext never survives exit 0."""
+        project, secret_file, combined_file = partial_project
+
+        result = _run(envdrift_cmd, ["lock", "--all", "--force"], project, integration_pythonpath)
+
+        assert result.returncode == 0, (
+            f"lock --all --force failed:\n{result.stdout}\n{result.stderr}"
+        )
+        content = secret_file.read_text(encoding="utf-8")
+        assert LEAKED_VALUE not in content, (
+            "lock --all skipped a mixed .secret and left the fresh secret plaintext"
+        )
+        assert "NEW_SECRET=encrypted:" in content.replace('"', "")
+        # Combined-file cleanup still happens.
+        assert not combined_file.exists()
+
+    def test_lock_all_check_fails_on_mixed_secret_file(
+        self,
+        partial_project: tuple[Path, Path, Path],
+        integration_pythonpath: str,
+        envdrift_cmd: list[str],
+    ):
+        """lock --all --check must exit 1 while the .secret still needs encryption."""
+        project, secret_file, combined_file = partial_project
+        before = secret_file.read_bytes()
+
+        result = _run(envdrift_cmd, ["lock", "--all", "--check"], project, integration_pythonpath)
+
+        assert result.returncode == 1, (
+            f"lock --all --check blessed a mixed .secret file:\n{result.stdout}"
+        )
+        # Dry run: nothing was modified or deleted.
+        assert secret_file.read_bytes() == before
+        assert combined_file.exists()
+
+
+class TestLockAllSecretsOnlySkip:
+    """Item 4 of #470: the final banner/exit must reflect skipped secrets-only envs."""
+
+    @pytest.fixture
+    def secrets_only_project(
+        self, tmp_path: Path, integration_pythonpath: str, envdrift_cmd: list[str]
+    ) -> Path:
+        (tmp_path / "envdrift.toml").write_text(CONFIG_SECRETS_ONLY_PARTIAL, encoding="utf-8")
+        (tmp_path / "svc").mkdir()
+        (tmp_path / "secrets").mkdir()
+        # The regular mapping is fully encrypted so only the skipped
+        # secrets-only environment decides the outcome.
+        _write_and_encrypt(
+            envdrift_cmd,
+            integration_pythonpath,
+            tmp_path,
+            "svc/.env.production",
+            ["API_KEY=s1", "DB_PASS=s2", "TOKEN=s3"],
+        )
+        return tmp_path
+
+    def test_lock_all_fails_when_skipped_secrets_only_env_holds_plaintext(
+        self,
+        secrets_only_project: Path,
+        integration_pythonpath: str,
+        envdrift_cmd: list[str],
+    ):
+        """No green 'ready to commit' / exit 0 while a skipped env holds plaintext."""
+        project = secrets_only_project
+        api_file = project / "secrets" / ".env.api"
+        api_file.write_text("API_TOKEN=" + LEAKED_VALUE + "\n", encoding="utf-8")
+
+        result = _run(envdrift_cmd, ["lock", "--all", "--force"], project, integration_pythonpath)
+
+        assert result.returncode == 1, (
+            "lock --all exited 0 while a skipped secrets-only environment still "
+            f"held plaintext:\n{result.stdout}"
+        )
+        norm = _norm(result).lower()
+        assert "envdrift push" in norm
+        assert "ready to commit" not in norm
+        # lock --all does not own these files; push does. They must be untouched.
+        assert api_file.read_text(encoding="utf-8") == "API_TOKEN=" + LEAKED_VALUE + "\n"
+
+    def test_lock_all_passes_when_skipped_secrets_only_env_is_encrypted(
+        self,
+        secrets_only_project: Path,
+        integration_pythonpath: str,
+        envdrift_cmd: list[str],
+    ):
+        """A fully-encrypted secrets-only env is a benign skip: summary notes it, exit 0."""
+        project = secrets_only_project
+        _write_and_encrypt(
+            envdrift_cmd,
+            integration_pythonpath,
+            project,
+            "secrets/.env.api",
+            ["API_TOKEN=value1"],
+        )
+
+        result = _run(envdrift_cmd, ["lock", "--all", "--force"], project, integration_pythonpath)
+
+        assert result.returncode == 0, (
+            f"lock --all failed on a fully-encrypted secrets-only env:\n"
+            f"{result.stdout}\n{result.stderr}"
+        )
+        norm = _norm(result).lower()
+        assert "secrets-only environments skipped: 1" in norm
+        assert "ready to commit" in norm

--- a/tests/integration/test_lock_encryption_state.py
+++ b/tests/integration/test_lock_encryption_state.py
@@ -2,7 +2,7 @@
 
 ``envdrift lock`` used to decide "already encrypted" with a >=90% ciphertext-line
 ratio (and ``lock --all`` with an any-ciphertext regex), instead of the canonical
-predicates (``has_plaintext_secret_value`` / ``_is_fully_encrypted``). That cut
+predicates (``has_plaintext_secret_value`` / ``is_fully_encrypted``). That cut
 both ways:
 
 - a MIXED file (>=18 encrypted values + 1 fresh plaintext secret) was blessed
@@ -15,10 +15,16 @@ both ways:
 - ``lock --all`` printed the unconditional "ready to commit" banner with exit 0
   while knowingly skipping secrets-only environments that still held plaintext.
 
+The mixed-state gate is backend-agnostic (PR #507 review): a SOPS-encrypted file
+holding a freshly appended plaintext secret must fail ``lock --check`` exactly
+like a dotenvx one, and ``--check`` must stay a pure dry run in its messaging
+(report "would re-encrypt", never the active "re-encrypting...").
+
 These tests drive the real ``envdrift`` CLI as a subprocess with the real
-``dotenvx`` binary. All fixtures are produced by a real ``envdrift encrypt`` so
-they carry the exact production input shape, including the ``DOTENV_PUBLIC_KEY``
-header line (contributes regression coverage for issue #485).
+``dotenvx`` (and, where present, ``sops``) binaries. All dotenvx fixtures are
+produced by a real ``envdrift encrypt`` so they carry the exact production input
+shape, including the ``DOTENV_PUBLIC_KEY`` header line (contributes regression
+coverage for issue #485).
 """
 
 from __future__ import annotations
@@ -26,7 +32,9 @@ from __future__ import annotations
 import os
 import shutil
 import subprocess
+import textwrap
 from pathlib import Path
+from typing import NamedTuple
 
 import pytest
 
@@ -38,6 +46,10 @@ pytestmark = [
 # Built by concatenation so the fixture never contains a realistic secret
 # literal (GitHub push protection).
 LEAKED_VALUE = "ghp_" + "realtokenplaintext12345"
+
+# Test-only age keypair, identical to tests/integration/test_encryption_tools.py.
+AGE_PUBLIC_KEY = "age1c89jtrvyl72y0muvdp5lm3jpemvc2gr303up4g37tuq4uftcku3q4svqau"
+AGE_PRIVATE_KEY = "AGE-SECRET-KEY-1HGE3ZE9NPEN5R76LVKKJ2Z3G9TYZJLW84P2CHAF6UGL43R7TWPUSZ89MK6"
 
 CONFIG_BASE = """\
 [vault]
@@ -82,27 +94,64 @@ secrets_dir = "secrets"
 """
 )
 
+CONFIG_SOPS = f"""\
+[vault]
+provider = "aws"
 
-def _run(
-    envdrift_cmd: list[str],
-    args: list[str],
-    cwd: Path,
-    pythonpath: str,
-    timeout: int = 120,
-) -> subprocess.CompletedProcess[str]:
-    """Run the real envdrift CLI as a subprocess in ``cwd``."""
-    env = os.environ.copy()
-    env["PYTHONPATH"] = pythonpath
-    return subprocess.run(
-        [*envdrift_cmd, *args],
-        cwd=cwd,
-        env=env,
-        capture_output=True,
-        text=True,
-        encoding="utf-8",
-        errors="replace",
-        timeout=timeout,
-    )
+[vault.aws]
+region = "us-east-1"
+
+[encryption]
+backend = "sops"
+
+[encryption.sops]
+config_file = ".sops.yaml"
+age_key_file = "age.key"
+age_recipients = "{AGE_PUBLIC_KEY}"
+
+[[vault.sync.mappings]]
+secret_name = "svc-key"
+folder_path = "svc"
+environment = "production"
+"""
+
+
+class Cli(NamedTuple):
+    """The real envdrift CLI bound to this test session's interpreter env."""
+
+    cmd: list[str]
+    pythonpath: str
+
+    def run(
+        self, args: list[str], cwd: Path, timeout: int = 120
+    ) -> subprocess.CompletedProcess[str]:
+        """Run the real envdrift CLI as a subprocess in ``cwd``."""
+        env = os.environ.copy()
+        env["PYTHONPATH"] = self.pythonpath
+        return subprocess.run(
+            [*self.cmd, *args],
+            cwd=cwd,
+            env=env,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=timeout,
+        )
+
+    def write_and_encrypt(self, project: Path, rel_path: str, pairs: list[str]) -> Path:
+        """Write ``pairs`` to ``rel_path`` and encrypt it with the real dotenvx backend."""
+        file = project / rel_path
+        file.parent.mkdir(parents=True, exist_ok=True)
+        file.write_text("\n".join(pairs) + "\n", encoding="utf-8")
+        result = self.run(["encrypt", rel_path], project)
+        assert result.returncode == 0, f"setup encrypt failed:\n{result.stdout}\n{result.stderr}"
+        content = file.read_text(encoding="utf-8")
+        # The exact production input shape: dotenvx writes a plaintext public-key
+        # header line above the ciphertext (#485).
+        assert "DOTENV_PUBLIC_KEY" in content
+        assert "encrypted:" in content
+        return file
 
 
 def _norm(result: subprocess.CompletedProcess[str]) -> str:
@@ -110,29 +159,14 @@ def _norm(result: subprocess.CompletedProcess[str]) -> str:
     return " ".join((result.stdout + result.stderr).split())
 
 
-def _write_and_encrypt(
-    envdrift_cmd: list[str],
-    pythonpath: str,
-    project: Path,
-    rel_path: str,
-    pairs: list[str],
-) -> Path:
-    """Write ``pairs`` to ``rel_path`` and encrypt it with the real dotenvx backend."""
-    file = project / rel_path
-    file.parent.mkdir(parents=True, exist_ok=True)
-    file.write_text("\n".join(pairs) + "\n", encoding="utf-8")
-    result = _run(envdrift_cmd, ["encrypt", rel_path], project, pythonpath)
-    assert result.returncode == 0, f"setup encrypt failed:\n{result.stdout}\n{result.stderr}"
-    content = file.read_text(encoding="utf-8")
-    # The exact production input shape: dotenvx writes a plaintext public-key
-    # header line above the ciphertext (#485).
-    assert "DOTENV_PUBLIC_KEY" in content
-    assert "encrypted:" in content
-    return file
-
-
 def _append_plaintext(file: Path, line: str) -> None:
     file.write_text(file.read_text(encoding="utf-8") + line + "\n", encoding="utf-8")
+
+
+@pytest.fixture
+def cli(envdrift_cmd: list[str], integration_pythonpath: str) -> Cli:
+    """The real envdrift CLI runner for this session."""
+    return Cli(cmd=envdrift_cmd, pythonpath=integration_pythonpath)
 
 
 @pytest.fixture
@@ -143,16 +177,14 @@ def project(tmp_path: Path) -> Path:
     return tmp_path
 
 
-def _make_mixed_env_file(envdrift_cmd: list[str], pythonpath: str, project: Path) -> Path:
+def _make_mixed_env_file(cli: Cli, project: Path) -> Path:
     """18 encrypted values + 1 fresh plaintext secret: >=90% ciphertext lines.
 
     18 encrypted lines over 20 assignment lines (incl. the public-key header and
     the appended plaintext) is exactly the 0.90 ratio the old heuristic blessed
     as "already encrypted".
     """
-    env_file = _write_and_encrypt(
-        envdrift_cmd,
-        pythonpath,
+    env_file = cli.write_and_encrypt(
         project,
         "svc/.env.production",
         [f"SECRET_{i}=value{i}" for i in range(1, 19)],
@@ -164,75 +196,131 @@ def _make_mixed_env_file(envdrift_cmd: list[str], pythonpath: str, project: Path
 class TestLockMixedStateFile:
     """Item 2 of #470: a mixed dotenvx file must never be blessed as encrypted."""
 
-    def test_lock_check_fails_on_mixed_file_with_fresh_plaintext(
-        self, project: Path, integration_pythonpath: str, envdrift_cmd: list[str]
-    ):
+    def test_lock_check_fails_on_mixed_file_with_fresh_plaintext(self, project: Path, cli: Cli):
         """lock --check must exit 1 when a fresh plaintext secret hides in ciphertext."""
-        env_file = _make_mixed_env_file(envdrift_cmd, integration_pythonpath, project)
+        env_file = _make_mixed_env_file(cli, project)
         before = env_file.read_bytes()
 
-        result = _run(envdrift_cmd, ["lock", "--check"], project, integration_pythonpath)
+        result = cli.run(["lock", "--check"], project)
 
         assert result.returncode == 1, (
             f"lock --check blessed a mixed file with a plaintext secret:\n{result.stdout}"
         )
-        assert "need encryption" in _norm(result).lower()
+        norm = _norm(result).lower()
+        assert "need encryption" in norm
+        # --check is a dry run and must SPEAK like one (PR #507 review): the
+        # mixed file is reported as "would re-encrypt", never with the active
+        # "re-encrypting..." voice that implies the file was touched.
+        assert "would re-encrypt (plaintext values remain)" in norm
+        assert "re-encrypting" not in norm
         # --check is a dry run: the file must not be modified.
         assert env_file.read_bytes() == before
 
-    def test_lock_force_reencrypts_mixed_file(
-        self, project: Path, integration_pythonpath: str, envdrift_cmd: list[str]
-    ):
+    def test_lock_force_reencrypts_mixed_file(self, project: Path, cli: Cli):
         """lock --force must re-encrypt the fresh plaintext value, not skip the file."""
-        env_file = _make_mixed_env_file(envdrift_cmd, integration_pythonpath, project)
+        env_file = _make_mixed_env_file(cli, project)
 
-        result = _run(envdrift_cmd, ["lock", "--force"], project, integration_pythonpath)
+        result = cli.run(["lock", "--force"], project)
 
         assert result.returncode == 0, f"lock --force failed:\n{result.stdout}\n{result.stderr}"
         content = env_file.read_text(encoding="utf-8")
         assert LEAKED_VALUE not in content, "fresh plaintext secret survived lock --force"
         assert "NEW_SECRET=encrypted:" in content.replace('"', "")
         # Post-condition verified end-to-end: a subsequent check now passes.
-        recheck = _run(envdrift_cmd, ["lock", "--check"], project, integration_pythonpath)
+        recheck = cli.run(["lock", "--check"], project)
         assert recheck.returncode == 0, f"re-check after lock failed:\n{recheck.stdout}"
+
+
+class TestLockSopsMixedStateFile:
+    """PR #507 review (high): the mixed-state gate must cover SOPS, not just dotenvx.
+
+    A SOPS-encrypted file with a freshly appended plaintext secret used to be
+    skipped as "already encrypted" purely because ``is_encrypted_content`` saw a
+    SOPS header — the exact #470 item-2 bug class, surviving for the SOPS
+    backend. ``lock --check`` must flag it and exit 1. (Whether the SOPS backend
+    then re-encrypts such a mixed file correctly is tracked separately in #475.)
+    """
+
+    pytestmark = pytest.mark.skipif(
+        shutil.which("sops") is None, reason="sops binary not installed"
+    )
+
+    @pytest.fixture
+    def sops_project(self, tmp_path: Path, cli: Cli) -> tuple[Path, Path]:
+        """A SOPS-backed project whose env file is encrypted, then made mixed."""
+        (tmp_path / "envdrift.toml").write_text(CONFIG_SOPS, encoding="utf-8")
+        (tmp_path / "svc").mkdir()
+        (tmp_path / "age.key").write_text(
+            textwrap.dedent(
+                f"""\
+                # public key: {AGE_PUBLIC_KEY}
+                {AGE_PRIVATE_KEY}
+                """
+            ),
+            encoding="utf-8",
+        )
+        (tmp_path / ".sops.yaml").write_text(
+            textwrap.dedent(
+                f"""\
+                creation_rules:
+                  - path_regex: \\.env\\.production$
+                    age: {AGE_PUBLIC_KEY}
+                """
+            ),
+            encoding="utf-8",
+        )
+        env_file = tmp_path / "svc" / ".env.production"
+        env_file.write_text("API_KEY=oldvalue1\nDB_PASS=oldvalue2\n", encoding="utf-8")
+        result = cli.run(["encrypt", "svc/.env.production", "--backend", "sops"], tmp_path)
+        assert result.returncode == 0, (
+            f"sops setup encrypt failed:\n{result.stdout}\n{result.stderr}"
+        )
+        content = env_file.read_text(encoding="utf-8")
+        assert "ENC[AES256_GCM," in content, f"sops did not encrypt the fixture:\n{content}"
+        _append_plaintext(env_file, "NEW_SECRET=" + LEAKED_VALUE)
+        return tmp_path, env_file
+
+    def test_lock_check_fails_on_mixed_sops_file(self, sops_project: tuple[Path, Path], cli: Cli):
+        """lock --check must exit 1 on a SOPS file holding a fresh plaintext secret."""
+        project, env_file = sops_project
+        before = env_file.read_bytes()
+
+        result = cli.run(["lock", "--check"], project)
+
+        assert result.returncode == 1, (
+            f"lock --check blessed a mixed SOPS file with a plaintext secret:\n{result.stdout}"
+        )
+        norm = _norm(result).lower()
+        assert "would re-encrypt (plaintext values remain)" in norm
+        assert "re-encrypting" not in norm
+        # Dry run: the file must not be modified.
+        assert env_file.read_bytes() == before
 
 
 class TestLockFullyEncryptedSmallFile:
     """Item 3 of #470: the public-key header must not count as a plaintext variable."""
 
-    def test_lock_check_passes_fully_encrypted_three_var_file(
-        self, project: Path, integration_pythonpath: str, envdrift_cmd: list[str]
-    ):
+    def test_lock_check_passes_fully_encrypted_three_var_file(self, project: Path, cli: Cli):
         """A fully-encrypted 3-variable file is not 'partially encrypted (75%)'."""
-        _write_and_encrypt(
-            envdrift_cmd,
-            integration_pythonpath,
-            project,
-            "svc/.env.production",
-            ["API_KEY=s1", "DB_PASS=s2", "TOKEN=s3"],
+        cli.write_and_encrypt(
+            project, "svc/.env.production", ["API_KEY=s1", "DB_PASS=s2", "TOKEN=s3"]
         )
 
-        result = _run(envdrift_cmd, ["lock", "--check"], project, integration_pythonpath)
+        result = cli.run(["lock", "--check"], project)
 
         assert result.returncode == 0, (
             f"lock --check flagged a fully-encrypted small file:\n{result.stdout}"
         )
         assert "all files are already encrypted" in _norm(result).lower()
 
-    def test_lock_force_does_not_churn_fully_encrypted_small_file(
-        self, project: Path, integration_pythonpath: str, envdrift_cmd: list[str]
-    ):
+    def test_lock_force_does_not_churn_fully_encrypted_small_file(self, project: Path, cli: Cli):
         """lock --force must skip (not re-encrypt) a fully-encrypted small file."""
-        env_file = _write_and_encrypt(
-            envdrift_cmd,
-            integration_pythonpath,
-            project,
-            "svc/.env.production",
-            ["API_KEY=s1", "DB_PASS=s2", "TOKEN=s3"],
+        env_file = cli.write_and_encrypt(
+            project, "svc/.env.production", ["API_KEY=s1", "DB_PASS=s2", "TOKEN=s3"]
         )
         before = env_file.read_bytes()
 
-        result = _run(envdrift_cmd, ["lock", "--force"], project, integration_pythonpath)
+        result = cli.run(["lock", "--force"], project)
 
         assert result.returncode == 0, f"lock --force failed:\n{result.stdout}\n{result.stderr}"
         # dotenvx encryption is non-deterministic, so any re-encrypt would change
@@ -244,52 +332,29 @@ class TestLockFullyEncryptedSmallFile:
 class TestLockEncryptCheckParity:
     """Item 2 of #470 (verifier note): lock --check and encrypt --check must agree."""
 
-    def test_gates_agree_on_mixed_file(
-        self, project: Path, integration_pythonpath: str, envdrift_cmd: list[str]
-    ):
-        _make_mixed_env_file(envdrift_cmd, integration_pythonpath, project)
+    @pytest.mark.parametrize(
+        ("mixed", "expected_rc", "label"),
+        [
+            pytest.param(True, 1, "mixed file with a fresh plaintext secret", id="mixed"),
+            pytest.param(False, 0, "fully-encrypted file", id="fully-encrypted"),
+        ],
+    )
+    def test_gates_agree(self, project: Path, cli: Cli, mixed: bool, expected_rc: int, label: str):
+        if mixed:
+            _make_mixed_env_file(cli, project)
+        else:
+            cli.write_and_encrypt(
+                project, "svc/.env.production", ["API_KEY=s1", "DB_PASS=s2", "TOKEN=s3"]
+            )
 
-        encrypt_check = _run(
-            envdrift_cmd,
-            ["encrypt", "svc/.env.production", "--check"],
-            project,
-            integration_pythonpath,
-        )
-        lock_check = _run(envdrift_cmd, ["lock", "--check"], project, integration_pythonpath)
+        encrypt_check = cli.run(["encrypt", "svc/.env.production", "--check"], project)
+        lock_check = cli.run(["lock", "--check"], project)
 
-        assert encrypt_check.returncode == 1, (
-            f"encrypt --check missed the plaintext secret:\n{encrypt_check.stdout}"
+        assert encrypt_check.returncode == expected_rc, (
+            f"encrypt --check gave the wrong verdict on a {label}:\n{encrypt_check.stdout}"
         )
         assert lock_check.returncode == encrypt_check.returncode, (
-            "lock --check and encrypt --check disagree on the same mixed file: "
-            f"lock={lock_check.returncode} encrypt={encrypt_check.returncode}\n"
-            f"{lock_check.stdout}"
-        )
-
-    def test_gates_agree_on_fully_encrypted_file(
-        self, project: Path, integration_pythonpath: str, envdrift_cmd: list[str]
-    ):
-        _write_and_encrypt(
-            envdrift_cmd,
-            integration_pythonpath,
-            project,
-            "svc/.env.production",
-            ["API_KEY=s1", "DB_PASS=s2", "TOKEN=s3"],
-        )
-
-        encrypt_check = _run(
-            envdrift_cmd,
-            ["encrypt", "svc/.env.production", "--check"],
-            project,
-            integration_pythonpath,
-        )
-        lock_check = _run(envdrift_cmd, ["lock", "--check"], project, integration_pythonpath)
-
-        assert encrypt_check.returncode == 0, (
-            f"encrypt --check flagged a fully-encrypted file:\n{encrypt_check.stdout}"
-        )
-        assert lock_check.returncode == encrypt_check.returncode, (
-            "lock --check and encrypt --check disagree on the same encrypted file: "
+            f"lock --check and encrypt --check disagree on the same {label}: "
             f"lock={lock_check.returncode} encrypt={encrypt_check.returncode}\n"
             f"{lock_check.stdout}"
         )
@@ -299,26 +364,16 @@ class TestLockAllMixedSecretFile:
     """Item 1 of #470: lock --all must re-encrypt a mixed-state .secret file."""
 
     @pytest.fixture
-    def partial_project(
-        self, tmp_path: Path, integration_pythonpath: str, envdrift_cmd: list[str]
-    ) -> tuple[Path, Path, Path]:
+    def partial_project(self, tmp_path: Path, cli: Cli) -> tuple[Path, Path, Path]:
         """Project with a combine-mode partial env whose .secret is mixed-state."""
         (tmp_path / "envdrift.toml").write_text(CONFIG_COMBINE_PARTIAL, encoding="utf-8")
         (tmp_path / "svc").mkdir()
         # The regular mapping is fully encrypted so step 2 is uneventful.
-        _write_and_encrypt(
-            envdrift_cmd,
-            integration_pythonpath,
-            tmp_path,
-            "svc/.env.production",
-            ["API_KEY=s1", "DB_PASS=s2", "TOKEN=s3"],
+        cli.write_and_encrypt(
+            tmp_path, "svc/.env.production", ["API_KEY=s1", "DB_PASS=s2", "TOKEN=s3"]
         )
-        secret_file = _write_and_encrypt(
-            envdrift_cmd,
-            integration_pythonpath,
-            tmp_path,
-            "partial/.env.production.secret",
-            ["API_KEY=oldvalue1"],
+        secret_file = cli.write_and_encrypt(
+            tmp_path, "partial/.env.production.secret", ["API_KEY=oldvalue1"]
         )
         # A fresh plaintext secret appended after the file was encrypted.
         _append_plaintext(secret_file, "NEW_SECRET=" + LEAKED_VALUE)
@@ -327,15 +382,12 @@ class TestLockAllMixedSecretFile:
         return tmp_path, secret_file, combined_file
 
     def test_lock_all_reencrypts_mixed_secret_file(
-        self,
-        partial_project: tuple[Path, Path, Path],
-        integration_pythonpath: str,
-        envdrift_cmd: list[str],
+        self, partial_project: tuple[Path, Path, Path], cli: Cli
     ):
         """The mixed .secret is re-encrypted; the plaintext never survives exit 0."""
         project, secret_file, combined_file = partial_project
 
-        result = _run(envdrift_cmd, ["lock", "--all", "--force"], project, integration_pythonpath)
+        result = cli.run(["lock", "--all", "--force"], project)
 
         assert result.returncode == 0, (
             f"lock --all --force failed:\n{result.stdout}\n{result.stderr}"
@@ -349,16 +401,13 @@ class TestLockAllMixedSecretFile:
         assert not combined_file.exists()
 
     def test_lock_all_check_fails_on_mixed_secret_file(
-        self,
-        partial_project: tuple[Path, Path, Path],
-        integration_pythonpath: str,
-        envdrift_cmd: list[str],
+        self, partial_project: tuple[Path, Path, Path], cli: Cli
     ):
         """lock --all --check must exit 1 while the .secret still needs encryption."""
         project, secret_file, combined_file = partial_project
         before = secret_file.read_bytes()
 
-        result = _run(envdrift_cmd, ["lock", "--all", "--check"], project, integration_pythonpath)
+        result = cli.run(["lock", "--all", "--check"], project)
 
         assert result.returncode == 1, (
             f"lock --all --check blessed a mixed .secret file:\n{result.stdout}"
@@ -372,35 +421,26 @@ class TestLockAllSecretsOnlySkip:
     """Item 4 of #470: the final banner/exit must reflect skipped secrets-only envs."""
 
     @pytest.fixture
-    def secrets_only_project(
-        self, tmp_path: Path, integration_pythonpath: str, envdrift_cmd: list[str]
-    ) -> Path:
+    def secrets_only_project(self, tmp_path: Path, cli: Cli) -> Path:
         (tmp_path / "envdrift.toml").write_text(CONFIG_SECRETS_ONLY_PARTIAL, encoding="utf-8")
         (tmp_path / "svc").mkdir()
         (tmp_path / "secrets").mkdir()
         # The regular mapping is fully encrypted so only the skipped
         # secrets-only environment decides the outcome.
-        _write_and_encrypt(
-            envdrift_cmd,
-            integration_pythonpath,
-            tmp_path,
-            "svc/.env.production",
-            ["API_KEY=s1", "DB_PASS=s2", "TOKEN=s3"],
+        cli.write_and_encrypt(
+            tmp_path, "svc/.env.production", ["API_KEY=s1", "DB_PASS=s2", "TOKEN=s3"]
         )
         return tmp_path
 
     def test_lock_all_fails_when_skipped_secrets_only_env_holds_plaintext(
-        self,
-        secrets_only_project: Path,
-        integration_pythonpath: str,
-        envdrift_cmd: list[str],
+        self, secrets_only_project: Path, cli: Cli
     ):
         """No green 'ready to commit' / exit 0 while a skipped env holds plaintext."""
         project = secrets_only_project
         api_file = project / "secrets" / ".env.api"
         api_file.write_text("API_TOKEN=" + LEAKED_VALUE + "\n", encoding="utf-8")
 
-        result = _run(envdrift_cmd, ["lock", "--all", "--force"], project, integration_pythonpath)
+        result = cli.run(["lock", "--all", "--force"], project)
 
         assert result.returncode == 1, (
             "lock --all exited 0 while a skipped secrets-only environment still "
@@ -413,22 +453,13 @@ class TestLockAllSecretsOnlySkip:
         assert api_file.read_text(encoding="utf-8") == "API_TOKEN=" + LEAKED_VALUE + "\n"
 
     def test_lock_all_passes_when_skipped_secrets_only_env_is_encrypted(
-        self,
-        secrets_only_project: Path,
-        integration_pythonpath: str,
-        envdrift_cmd: list[str],
+        self, secrets_only_project: Path, cli: Cli
     ):
         """A fully-encrypted secrets-only env is a benign skip: summary notes it, exit 0."""
         project = secrets_only_project
-        _write_and_encrypt(
-            envdrift_cmd,
-            integration_pythonpath,
-            project,
-            "secrets/.env.api",
-            ["API_TOKEN=value1"],
-        )
+        cli.write_and_encrypt(project, "secrets/.env.api", ["API_TOKEN=value1"])
 
-        result = _run(envdrift_cmd, ["lock", "--all", "--force"], project, integration_pythonpath)
+        result = cli.run(["lock", "--all", "--force"], project)
 
         assert result.returncode == 0, (
             f"lock --all failed on a fully-encrypted secrets-only env:\n"

--- a/tests/integration/test_lock_encryption_state.py
+++ b/tests/integration/test_lock_encryption_state.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 import os
 import shutil
 import subprocess
+import sys
 import textwrap
 from pathlib import Path
 from typing import NamedTuple
@@ -333,13 +334,14 @@ class TestLockEncryptCheckParity:
     """Item 2 of #470 (verifier note): lock --check and encrypt --check must agree."""
 
     @pytest.mark.parametrize(
-        ("mixed", "expected_rc", "label"),
+        ("mixed", "expected_rc"),
         [
-            pytest.param(True, 1, "mixed file with a fresh plaintext secret", id="mixed"),
-            pytest.param(False, 0, "fully-encrypted file", id="fully-encrypted"),
+            pytest.param(True, 1, id="mixed"),
+            pytest.param(False, 0, id="fully-encrypted"),
         ],
     )
-    def test_gates_agree(self, project: Path, cli: Cli, mixed: bool, expected_rc: int, label: str):
+    def test_gates_agree(self, project: Path, cli: Cli, mixed: bool, expected_rc: int):
+        label = "mixed file with a fresh plaintext secret" if mixed else "fully-encrypted file"
         if mixed:
             _make_mixed_env_file(cli, project)
         else:
@@ -414,6 +416,133 @@ class TestLockAllMixedSecretFile:
         )
         # Dry run: nothing was modified or deleted.
         assert secret_file.read_bytes() == before
+        assert combined_file.exists()
+
+
+class TestLockAllPartialLifecycle:
+    """PR #507 review (CodeRabbit, major): lock --all must honor the partial lifecycle.
+
+    The ``.secret`` branch used to call the encryption backend directly, so it
+    (a) never cleared the skip-worktree bit a ``pull-partial`` leaves behind —
+    hiding the re-encrypted diff from ``git status``/``git add`` — and
+    (b) deleted the combined file even when encryption FAILED, destroying the
+    one remaining runtime artifact while the plaintext ``.secret`` lingered.
+    """
+
+    def _git(self, args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["git", "-c", "user.email=t@t.t", "-c", "user.name=t", *args],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            timeout=60,
+        )
+
+    @pytest.fixture
+    def git_partial_project(self, tmp_path: Path, cli: Cli) -> tuple[Path, Path]:
+        """A git repo with a combine-mode partial env, .secret committed and tracked."""
+        if shutil.which("git") is None:
+            pytest.skip("git not installed")
+        (tmp_path / "envdrift.toml").write_text(CONFIG_COMBINE_PARTIAL, encoding="utf-8")
+        (tmp_path / "svc").mkdir()
+        cli.write_and_encrypt(
+            tmp_path, "svc/.env.production", ["API_KEY=s1", "DB_PASS=s2", "TOKEN=s3"]
+        )
+        secret_file = cli.write_and_encrypt(
+            tmp_path, "partial/.env.production.secret", ["API_KEY=oldvalue1"]
+        )
+        assert self._git(["init", "-q"], tmp_path).returncode == 0
+        assert self._git(["add", "-A"], tmp_path).returncode == 0
+        assert self._git(["commit", "-qm", "init"], tmp_path).returncode == 0
+        return tmp_path, secret_file
+
+    def test_lock_all_clears_skip_worktree_after_reencrypt(
+        self, git_partial_project: tuple[Path, Path], cli: Cli
+    ):
+        """After lock --all re-encrypts, the pull-partial skip-worktree bit is lifted."""
+        project, secret_file = git_partial_project
+        rel = secret_file.relative_to(project).as_posix()
+        # Simulate the state pull-partial leaves: file protected from git.
+        assert self._git(["update-index", "--skip-worktree", rel], project).returncode == 0
+        _append_plaintext(secret_file, "NEW_SECRET=" + LEAKED_VALUE)
+
+        result = cli.run(["lock", "--all", "--force"], project)
+
+        assert result.returncode == 0, f"lock --all failed:\n{result.stdout}\n{result.stderr}"
+        assert LEAKED_VALUE not in secret_file.read_text(encoding="utf-8")
+        flags = self._git(["ls-files", "-v", rel], project).stdout.strip()
+        # 'S' marks skip-worktree; a re-encrypted file must be visible to git again.
+        assert flags.startswith("H"), (
+            f"skip-worktree bit not lifted after lock --all re-encrypt: {flags!r}"
+        )
+
+    @pytest.mark.skipif(
+        sys.platform == "win32" or not hasattr(os, "geteuid") or os.geteuid() == 0,
+        reason="read-only file write is not enforced on Windows or for root",
+    )
+    def test_lock_all_keeps_combined_file_when_encryption_fails(
+        self, git_partial_project: tuple[Path, Path], cli: Cli
+    ):
+        """A failed .secret encryption must NOT delete the combined artifact.
+
+        A read-only ``.secret`` makes dotenvx fail to write the re-encrypted
+        content (it already has the public key, so the keys file is irrelevant):
+        it leaves the new value plaintext, the post-encrypt read-back trips,
+        ``encrypt_secret_file`` raises, and the combined file — the one remaining
+        runtime artifact — must be kept rather than deleted.
+        """
+        project, secret_file = git_partial_project
+        _append_plaintext(secret_file, "NEW_SECRET=" + LEAKED_VALUE)
+        combined_file = project / "partial" / ".env.production"
+        combined_file.write_text("APP_NAME=myapp\nAPI_KEY=oldvalue1\n", encoding="utf-8")
+        secret_file.chmod(0o400)
+        try:
+            result = cli.run(["lock", "--all", "--force"], project)
+        finally:
+            secret_file.chmod(0o600)
+
+        assert result.returncode == 1, (
+            f"lock --all exited 0 despite a failed .secret encryption:\n{result.stdout}"
+        )
+        assert combined_file.exists(), (
+            "lock --all deleted the combined file although the .secret encryption failed"
+        )
+        assert LEAKED_VALUE in secret_file.read_text(encoding="utf-8"), (
+            "the plaintext secret was lost despite the reported failure"
+        )
+        norm = _norm(result).lower()
+        assert "kept (encryption failed)" in norm
+        assert "ready to commit" not in norm
+
+    @pytest.mark.skipif(
+        sys.platform == "win32" or not hasattr(os, "geteuid") or os.geteuid() == 0,
+        reason="chmod-000 unreadability is not enforced on Windows or for root",
+    )
+    def test_lock_all_unreadable_secret_is_an_error_not_a_warning(
+        self, git_partial_project: tuple[Path, Path], cli: Cli
+    ):
+        """An OSError mid-step must fail lock, not melt into a config warning.
+
+        Pre-fix, ANY OSError in the partial step was swallowed by the
+        config-load catch-all as "[WARN] Could not load partial encryption
+        config" and lock still printed the green banner with exit 0.
+        """
+        project, secret_file = git_partial_project
+        combined_file = project / "partial" / ".env.production"
+        combined_file.write_text("APP_NAME=myapp\n", encoding="utf-8")
+        secret_file.chmod(0o000)
+        try:
+            result = cli.run(["lock", "--all", "--force"], project)
+        finally:
+            secret_file.chmod(0o600)
+
+        assert result.returncode == 1, (
+            f"lock --all exited 0 with an unprocessable partial step:\n{result.stdout}"
+        )
+        norm = _norm(result).lower()
+        assert "partial encryption step failed" in norm
+        assert "ready to commit" not in norm
         assert combined_file.exists()
 
 

--- a/tests/unit/coverage/test_cov_cli_commands_sync.py
+++ b/tests/unit/coverage/test_cov_cli_commands_sync.py
@@ -879,6 +879,79 @@ class TestLockCommand:
 
 
 # --------------------------------------------------------------------------
+# lock command - canonical encryption-state predicates (#470)
+# --------------------------------------------------------------------------
+class TestLockCanonicalEncryptionState:
+    """Regressions for #470: lock shares the push paths' encryption predicates.
+
+    The old inline >=90%-ciphertext-line ratio cut both ways: a mixed file with
+    one fresh plaintext secret was blessed "already encrypted" (false PASS),
+    while a fully-encrypted file with fewer than 9 variables was forever
+    "partially encrypted" because the plaintext DOTENV_PUBLIC_KEY_* header
+    counted in the ratio denominator (false FAIL).
+    """
+
+    @patch("envdrift.cli_commands.encryption_helpers.resolve_encryption_backend")
+    def test_lock_check_passes_small_fully_encrypted_file_with_header(
+        self, mock_resolve, tmp_path, loaded_config, no_git_hook
+    ):
+        """A fully-encrypted 3-var file is not 'partially encrypted (75%)'."""
+        backend = DummyEncryptionBackend()
+        mock_resolve.return_value = (backend, EncryptionProvider.DOTENVX, None)
+        (tmp_path / ".env.production").write_text(
+            'DOTENV_PUBLIC_KEY_PRODUCTION="pub"\n'
+            "API_KEY=encrypted:aaa\nDB_PASS=encrypted:bbb\nTOKEN=encrypted:ccc\n"
+        )
+        (tmp_path / ".env.keys").write_text("DOTENV_PRIVATE_KEY_PRODUCTION=k\n")
+        mapping = ServiceMapping(secret_name="s", folder_path=tmp_path, environment="production")
+        loaded_config(_sync_config([mapping]))
+
+        result = runner.invoke(app, ["lock", "--check"])
+        assert result.exit_code == 0, result.output
+        assert "All files are already encrypted" in result.output
+
+    @patch("envdrift.cli_commands.encryption_helpers.resolve_encryption_backend")
+    def test_lock_check_fails_mixed_file_above_old_ratio(
+        self, mock_resolve, tmp_path, loaded_config, no_git_hook
+    ):
+        """>=90% ciphertext lines no longer bless a fresh plaintext secret."""
+        backend = DummyEncryptionBackend()
+        mock_resolve.return_value = (backend, EncryptionProvider.DOTENVX, None)
+        lines = ['DOTENV_PUBLIC_KEY_PRODUCTION="pub"']
+        lines += [f"SECRET_{i}=encrypted:cipher{i}" for i in range(1, 19)]
+        lines += ["NEW_SECRET=plaintext-added-later"]
+        (tmp_path / ".env.production").write_text("\n".join(lines) + "\n")
+        (tmp_path / ".env.keys").write_text("DOTENV_PRIVATE_KEY_PRODUCTION=k\n")
+        mapping = ServiceMapping(secret_name="s", folder_path=tmp_path, environment="production")
+        loaded_config(_sync_config([mapping]))
+
+        result = runner.invoke(app, ["lock", "--check"])
+        assert result.exit_code == 1, result.output
+        assert "would be encrypted" in result.output
+        assert backend.encrypt_calls == []
+
+    @patch("envdrift.cli_commands.encryption_helpers.resolve_encryption_backend")
+    def test_lock_force_reencrypts_mixed_file_above_old_ratio(
+        self, mock_resolve, tmp_path, loaded_config, no_git_hook
+    ):
+        """lock --force re-encrypts the mixed file instead of skipping it."""
+        backend = DummyEncryptionBackend()
+        mock_resolve.return_value = (backend, EncryptionProvider.DOTENVX, None)
+        lines = ['DOTENV_PUBLIC_KEY_PRODUCTION="pub"']
+        lines += [f"SECRET_{i}=encrypted:cipher{i}" for i in range(1, 19)]
+        lines += ["NEW_SECRET=plaintext-added-later"]
+        (tmp_path / ".env.production").write_text("\n".join(lines) + "\n")
+        (tmp_path / ".env.keys").write_text("DOTENV_PRIVATE_KEY_PRODUCTION=k\n")
+        mapping = ServiceMapping(secret_name="s", folder_path=tmp_path, environment="production")
+        loaded_config(_sync_config([mapping]))
+
+        result = runner.invoke(app, ["lock", "--force"])
+        assert result.exit_code == 0, result.output
+        assert "partially encrypted" in result.output
+        assert (tmp_path / ".env.production").resolve() in backend.encrypt_calls
+
+
+# --------------------------------------------------------------------------
 # lock command - key-name-mismatch rekey path (sync.py 1411-1465)
 # --------------------------------------------------------------------------
 class TestLockRekeyOnKeyNameMismatch:
@@ -1141,9 +1214,12 @@ class TestLockPartialEncryptionAll:
         loaded_config(_sync_config([mapping]))
 
         result = runner.invoke(app, ["lock", "--check", "--all", "--config", str(cfg)])
-        assert result.exit_code == 0, result.output
+        # The plaintext .secret would be encrypted by a real run, so the dry run
+        # reports pending work and fails the gate (#470) - it must not exit 0.
+        assert result.exit_code == 1, result.output
         assert "would be encrypted" in result.output
         assert "would be deleted" in result.output
+        assert "need encryption" in result.output
         # check mode must not touch the filesystem
         assert combined_file.exists()
         assert backend.encrypt_calls == []
@@ -1193,3 +1269,65 @@ class TestLockPartialEncryptionAll:
         result = runner.invoke(app, ["lock", "--force", "--all", "--config", str(cfg)])
         assert result.exit_code == 0, result.output
         assert "secrets-only, managed by 'envdrift push'" in result.output
+        # The secrets_dir does not exist, so the plaintext check cannot run;
+        # that is surfaced as a warning, not silently swallowed (#470).
+        normalized = " ".join(result.output.split())
+        assert "could not be checked" in normalized
+
+    @patch("envdrift.cli_commands.encryption_helpers.resolve_encryption_backend")
+    def test_all_secrets_only_pending_plaintext_fails(
+        self, mock_resolve, tmp_path, loaded_config, no_git_hook
+    ):
+        """#470: a skipped secrets-only env that still holds plaintext fails the lock.
+
+        The old code printed the unconditional "ready to commit" banner and
+        exited 0 while a plaintext secret sat on disk in the skipped env.
+        """
+        backend = DummyEncryptionBackend()
+        mock_resolve.return_value = (backend, EncryptionProvider.DOTENVX, None)
+        cfg = _write_partial_config(tmp_path, None, None, secrets_only=True)
+        secrets_dir = tmp_path / "secrets"
+        secrets_dir.mkdir()
+        (secrets_dir / ".env.api").write_text("API_TOKEN=plain\n")
+
+        (tmp_path / ".env.production").write_text(
+            "#/---BEGIN DOTENV ENCRYPTED---/\nSECRET=encrypted:abc\n"
+        )
+        (tmp_path / ".env.keys").write_text("DOTENV_PRIVATE_KEY_PRODUCTION=k\n")
+        mapping = ServiceMapping(secret_name="s", folder_path=tmp_path, environment="production")
+        loaded_config(_sync_config([mapping]))
+
+        result = runner.invoke(app, ["lock", "--force", "--all", "--config", str(cfg)])
+        assert result.exit_code == 1, result.output
+        normalized = " ".join(result.output.split())
+        assert "Secrets-only environments skipped: 1" in normalized
+        assert "envdrift push" in normalized
+        assert "ready to commit" not in normalized
+        # lock --all does not own secrets-only files; push does. Untouched.
+        assert (secrets_dir / ".env.api").read_text() == "API_TOKEN=plain\n"
+        assert backend.encrypt_calls == []
+
+    @patch("envdrift.cli_commands.encryption_helpers.resolve_encryption_backend")
+    def test_all_secrets_only_fully_encrypted_passes(
+        self, mock_resolve, tmp_path, loaded_config, no_git_hook
+    ):
+        """#470: a fully-encrypted secrets-only env is a benign, reported skip."""
+        backend = DummyEncryptionBackend()
+        mock_resolve.return_value = (backend, EncryptionProvider.DOTENVX, None)
+        cfg = _write_partial_config(tmp_path, None, None, secrets_only=True)
+        secrets_dir = tmp_path / "secrets"
+        secrets_dir.mkdir()
+        (secrets_dir / ".env.api").write_text("API_TOKEN=encrypted:abc\n")
+
+        (tmp_path / ".env.production").write_text(
+            "#/---BEGIN DOTENV ENCRYPTED---/\nSECRET=encrypted:abc\n"
+        )
+        (tmp_path / ".env.keys").write_text("DOTENV_PRIVATE_KEY_PRODUCTION=k\n")
+        mapping = ServiceMapping(secret_name="s", folder_path=tmp_path, environment="production")
+        loaded_config(_sync_config([mapping]))
+
+        result = runner.invoke(app, ["lock", "--force", "--all", "--config", str(cfg)])
+        assert result.exit_code == 0, result.output
+        normalized = " ".join(result.output.split())
+        assert "Secrets-only environments skipped: 1" in normalized
+        assert "ready to commit" in normalized

--- a/tests/unit/coverage/test_cov_cli_commands_sync.py
+++ b/tests/unit/coverage/test_cov_cli_commands_sync.py
@@ -927,7 +927,7 @@ class TestLockCanonicalEncryptionState:
 
         result = runner.invoke(app, ["lock", "--check"])
         assert result.exit_code == 1, result.output
-        assert "would be encrypted" in result.output
+        assert "would re-encrypt (plaintext values remain)" in result.output
         assert backend.encrypt_calls == []
 
     @patch("envdrift.cli_commands.encryption_helpers.resolve_encryption_backend")

--- a/tests/unit/coverage/test_cov_cli_commands_sync.py
+++ b/tests/unit/coverage/test_cov_cli_commands_sync.py
@@ -1163,9 +1163,10 @@ def _write_partial_config(tmp_path, secret_file, combined_file, *, secrets_only=
 
 
 class TestLockPartialEncryptionAll:
+    @patch("envdrift.core.partial_encryption.encrypt_secret_file")
     @patch("envdrift.cli_commands.encryption_helpers.resolve_encryption_backend")
     def test_all_encrypts_secret_and_deletes_combined(
-        self, mock_resolve, tmp_path, loaded_config, no_git_hook
+        self, mock_resolve, mock_encrypt_secret, tmp_path, loaded_config, no_git_hook
     ):
         backend = DummyEncryptionBackend()
         mock_resolve.return_value = (backend, EncryptionProvider.DOTENVX, None)
@@ -1187,11 +1188,43 @@ class TestLockPartialEncryptionAll:
         result = runner.invoke(app, ["lock", "--force", "--all", "--config", str(cfg)])
         assert result.exit_code == 0, result.output
         assert "Processing partial encryption files" in result.output
-        # secret file was encrypted
-        assert secret_file.resolve() in backend.encrypt_calls
-        # combined file was deleted
+        # The .secret was encrypted through the partial-encryption lifecycle seam
+        # (encrypt_secret_file: read-back verification + skip-worktree handling),
+        # NOT the raw backend.encrypt — this is the #507-review alignment with push.
+        assert mock_encrypt_secret.call_count == 1
+        # combined file was deleted (the .secret reached a good encrypted state)
         assert not combined_file.exists()
         assert "deleted (combined file)" in result.output
+
+    @patch("envdrift.core.partial_encryption.encrypt_secret_file")
+    @patch("envdrift.cli_commands.encryption_helpers.resolve_encryption_backend")
+    def test_all_keeps_combined_when_secret_encryption_fails(
+        self, mock_resolve, mock_encrypt_secret, tmp_path, loaded_config, no_git_hook
+    ):
+        """#507 review: a failed .secret encryption must keep the combined file."""
+        from envdrift.core.partial_encryption import PartialEncryptionError
+
+        backend = DummyEncryptionBackend()
+        mock_resolve.return_value = (backend, EncryptionProvider.DOTENVX, None)
+        mock_encrypt_secret.side_effect = PartialEncryptionError("did not take effect")
+
+        secret_file = tmp_path / ".env.secret"
+        secret_file.write_text("API_KEY=plain\n")
+        combined_file = tmp_path / ".env"
+        combined_file.write_text("API_KEY=plain\nPUBLIC=ok\n")
+        cfg = _write_partial_config(tmp_path, secret_file, combined_file)
+
+        (tmp_path / ".env.production").write_text(
+            "#/---BEGIN DOTENV ENCRYPTED---/\nSECRET=encrypted:abc\n"
+        )
+        (tmp_path / ".env.keys").write_text("DOTENV_PRIVATE_KEY_PRODUCTION=k\n")
+        mapping = ServiceMapping(secret_name="s", folder_path=tmp_path, environment="production")
+        loaded_config(_sync_config([mapping]))
+
+        result = runner.invoke(app, ["lock", "--force", "--all", "--config", str(cfg)])
+        assert result.exit_code == 1, result.output
+        assert combined_file.exists(), "combined file deleted despite failed encryption"
+        assert "kept (encryption failed)" in result.output
 
     @patch("envdrift.cli_commands.encryption_helpers.resolve_encryption_backend")
     def test_all_check_only_reports_would_actions(

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -4292,12 +4292,25 @@ class TestLockCommand:
         encrypted: list[Path] = []
         _mock_encryption_backend(monkeypatch, encrypted_paths=encrypted)
 
+        # The .secret now goes through the partial-encryption lifecycle seam
+        # (encrypt_secret_file), aligned with `envdrift push` (#507 review),
+        # rather than the raw backend. Patch that seam to record + simulate it.
+        partial_encrypted: list[Path] = []
+
+        def _fake_encrypt_secret(env_config):
+            partial_encrypted.append(Path(env_config.secret_file))
+
+        monkeypatch.setattr(
+            "envdrift.core.partial_encryption.encrypt_secret_file", _fake_encrypt_secret
+        )
+
         result = runner.invoke(app, ["lock", "-c", str(config_file), "--force", "--all"])
 
         assert result.exit_code == 0
-        # Both the main env file and the secret file should be encrypted
+        # The main env file goes through the resolved backend...
         assert env_file.resolve() in [p.resolve() for p in encrypted]
-        assert secret_file.resolve() in [p.resolve() for p in encrypted]
+        # ...and the .secret through the partial-encryption lifecycle seam.
+        assert secret_file.resolve() in [p.resolve() for p in partial_encrypted]
         # Combined file should be deleted
         assert not env_file.exists()
         assert "combined files deleted" in result.output.lower()


### PR DESCRIPTION
## Summary

`envdrift lock` decided "already encrypted" with weak inline heuristics — a >=90% ciphertext-line
ratio in the main loop and an any-ciphertext regex in the `--all` partial-encryption block —
instead of the canonical predicates the push paths already use. This PR replaces both with
`has_plaintext_secret_value` / `_is_fully_encrypted` and makes the final banner and exit code
truthful about knowingly-skipped work.

## Fixes

Mapping each #470 checklist item to the change (all in `src/envdrift/cli_commands/sync.py`):

1. **`lock --all` skipped a mixed-state `.secret` and shipped the fresh plaintext** — the
   `--all` block now uses push's `_is_fully_encrypted` predicate (ciphertext present AND no
   leftover plaintext value) instead of `is_encrypted_content`, so a mixed `.secret` is
   re-encrypted before the combined file is deleted. `lock --all --check` now also fails while
   partial `.secret` files still need encryption (`partial_encrypted_count` joins the check gate).
2. **`lock`/`lock --check` blessed a >=90%-ciphertext mixed file (exit 0)** — the ratio is gone;
   any remaining plaintext secret value means "partially encrypted, re-encrypting" (or exit 1
   under `--check`), matching `encrypt --check`.
3. **Fully-encrypted `<9`-variable files were forever "partially encrypted (75%)"** —
   `has_plaintext_secret_value` ignores the plaintext `DOTENV_PUBLIC_KEY_*` header (and
   comments), so the N/(N+1) false FAIL disappears and `lock --force` no longer churns
   (re-encrypts) those files on every run. The documented pre-commit hook now works for any
   variable count.
4. **Unconditional "[OK] Lock complete! … ready to commit" while skipping secrets-only envs** —
   skipped secrets-only environments are counted in the Lock Summary, and each is probed with
   push's own dry run (`push_secrets_only(check=True)`, touches nothing). If a skipped
   environment still holds plaintext, lock prints a warning pointing at `envdrift push` and
   exits 1 instead of the green banner.

Docs updated in the same PR: `docs/cli/lock.md` (check semantics, warning table, exit codes,
secrets-only note) and `docs/guides/partial-encryption.md` (`lock --all` section).

## Test evidence

New real-CLI integration suite `tests/integration/test_lock_encryption_state.py` (10 tests,
integration-marked, skip-gated on the `dotenvx` binary; fixtures produced by a real
`envdrift encrypt` so they carry the `DOTENV_PUBLIC_KEY` header line), plus hermetic unit tests
in `tests/unit/coverage/test_cov_cli_commands_sync.py` (`TestLockCanonicalEncryptionState`,
secrets-only pending/encrypted cases).

Written first and run against unfixed `origin/main` — 9/10 failed for the exact reasons in the
issue (the 10th passed pre-fix only because the item-3 false FAIL masked it):

```text
FAILED ...::TestLockMixedStateFile::test_lock_check_fails_on_mixed_file_with_fresh_plaintext
        AssertionError: lock --check blessed a mixed file with a plaintext secret  (exit 0)
FAILED ...::TestLockMixedStateFile::test_lock_force_reencrypts_mixed_file
        AssertionError: fresh plaintext secret survived lock --force
FAILED ...::TestLockFullyEncryptedSmallFile::test_lock_check_passes_fully_encrypted_three_var_file
        AssertionError: lock --check flagged a fully-encrypted small file  (exit 1, "75%")
FAILED ...::TestLockFullyEncryptedSmallFile::test_lock_force_does_not_churn_fully_encrypted_small_file
FAILED ...::TestLockEncryptCheckParity::test_gates_agree_on_mixed_file        (lock=0, encrypt=1)
FAILED ...::TestLockEncryptCheckParity::test_gates_agree_on_fully_encrypted_file  (lock=1, encrypt=0)
FAILED ...::TestLockAllMixedSecretFile::test_lock_all_reencrypts_mixed_secret_file
        AssertionError: lock --all skipped a mixed .secret and left the fresh secret plaintext
FAILED ...::TestLockAllSecretsOnlySkip::test_lock_all_fails_when_skipped_secrets_only_env_holds_plaintext
        AssertionError: lock --all exited 0 while a skipped secrets-only environment still held plaintext
FAILED ...::TestLockAllSecretsOnlySkip::test_lock_all_passes_when_skipped_secrets_only_env_is_encrypted
9 failed, 1 passed
```

After the fix: `10 passed`. Full suite in one process (`uv run pytest`, integration containers +
real binaries live): **2858 passed, 15 skipped**. All local gates green (`ruff check`,
`ruff format --check`, `pyrefly`, `bandit`, `make lint-docs`). `sync.py` line coverage 90.3%;
every changed line is covered.

One pre-existing sibling test asserted the dishonest behavior
(`test_all_check_only_reports_would_actions` expected exit 0 while a plaintext `.secret` was
pending under `lock --all --check`); it now asserts the truthful exit 1.

Scope note: changes are confined to the lock/check code paths in `sync.py`;
`partial_encryption.py` and the push paths are untouched (sibling PR #471 owns those).

Fixes #470
Contributes to #485

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jainal09/envdrift/pull/507?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of encryption state detection in `lock` command
  * Fixed `lock --check` exit codes to properly indicate when files need encryption

* **Documentation**
  * Enhanced `lock` command documentation with stricter semantics for `--check` and `--all` flags
  * Clarified behavior for partially encrypted and secrets-only environments
  * Updated exit code definitions and warning messages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the weak inline heuristics `lock` used to decide "already encrypted" (a ≥90% ciphertext-line ratio for the main loop; any-ciphertext regex for `--all`) with the same canonical predicates the push paths use (`has_plaintext_secret_value` / `is_fully_encrypted`). It also fixes the final banner and exit-code to be truthful when secrets-only environments are knowingly skipped.

- **Core predicate swap**: `has_plaintext_secret_value` gates the main loop (backend-agnostic), and `is_fully_encrypted` gates the `--all` partial-encryption `.secret` branch; the old ≥90% ratio and any-ciphertext regex are removed entirely.
- **Combined-file safety**: the combined artifact is now deleted only when encryption succeeded (`enc_state in ("encrypted", "already")`), preventing data loss when re-encryption of a mixed `.secret` fails.
- **Truthful exit code**: `partial_encrypted_count` joins the `--check` exit gate, and skipped secrets-only environments are probed with `push_secrets_only(check=True)` — if any still hold plaintext, lock exits 1 and points at `envdrift push` instead of printing the green banner.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the changes are logically correct, backed by 10 new integration tests and matching unit tests, and the gate is stricter in all the right directions (mixed files now fail, small fully-encrypted files now pass).

The predicate swap is straightforward and well-scoped: every changed path in sync.py has corresponding test coverage that was written against the unfixed code and verified to fail first. The enc_state machine that gates combined-file deletion correctly covers all four reachable states (encrypted, already, failed, missing). No counter leaks, no unguarded exception paths, and the two new helper functions are simple extractions of pre-existing inline code with no behavioral change to that sub-path.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/envdrift/cli_commands/sync.py | Core lock logic rewritten: ≥90% ratio replaced with has_plaintext_secret_value; enc_state gates combined-file deletion; secrets-only pending check added; _rekey_dotenvx_file and _find_stale_private_key_name extracted as helpers. |
| src/envdrift/core/partial_encryption.py | _is_fully_encrypted promoted to public is_fully_encrypted with a backward-compat alias; all internal call-sites updated; no logic changes to the predicate itself. |
| tests/integration/test_lock_encryption_state.py | New 10-test integration suite covering all four #470 checklist items plus SOPS backend parity, lifecycle alignment, and OSError promotion; written-before-fix discipline noted in the PR description. |
| tests/unit/coverage/test_cov_cli_commands_sync.py | New TestLockCanonicalEncryptionState class plus secrets-only pending/encrypted unit cases; pre-existing test corrected to expect exit 1 now that the gate is truthful. |
| tests/unit/test_cli.py | lock --all test updated to assert the .secret goes through encrypt_secret_file (partial-encryption lifecycle seam) rather than the raw backend.encrypt. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(lock): route --all .secret through t..."](https://github.com/jainal09/envdrift/commit/ce645c9c7603bd6f58f1a5e29756e5a6bcd3f020) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37198871)</sub>

<!-- /greptile_comment -->