### PR TITLE
ci: re-align compose images with CI and fix renovate review-claim copy (#500)

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -44,7 +44,7 @@ jobs:
     # Service containers for integration tests
     services:
       localstack:
-        image: localstack/localstack:4.14
+        image: localstack/localstack:4.14 # Keep in sync with tests/docker-compose.test.yml
         ports:
           - 4566:4566
         env:
@@ -59,8 +59,7 @@ jobs:
           --health-start-period=30s
 
       vault:
-        # Keep in sync with tests/docker-compose.test.yml (hashicorp/vault:1.21).
-        image: hashicorp/vault:1.21
+        image: hashicorp/vault:1.21 # Keep in sync with tests/docker-compose.test.yml
         ports:
           - 8200:8200
         env:
@@ -83,7 +82,7 @@ jobs:
           --health-start-period=5s
 
       lowkey-vault:
-        image: nagyesta/lowkey-vault:7.2.26
+        image: nagyesta/lowkey-vault:7.2.26 # Keep in sync with tests/docker-compose.test.yml
         ports:
           - 8443:8443
         env:

--- a/docs/specs/integration-tests-spec.md
+++ b/docs/specs/integration-tests-spec.md
@@ -31,10 +31,11 @@ forward-looking.
 **Container Setup:**
 
 ```yaml
-# docker-compose.test.yml
+# docker-compose.test.yml — canonical image pins live in tests/docker-compose.test.yml,
+# kept identical to the integration-tests.yml CI service containers (#500)
 services:
   localstack:
-    image: localstack/localstack:4.0
+    image: localstack/localstack:4.14
     ports:
       - "4566:4566"
     environment:
@@ -105,10 +106,11 @@ def vault_server():
 **Container Setup:**
 
 ```yaml
-# docker-compose.test.yml
+# docker-compose.test.yml — canonical image pins live in tests/docker-compose.test.yml,
+# kept identical to the integration-tests.yml CI service containers (#500)
 services:
   lowkey-vault:
-    image: nagyesta/lowkey-vault:7.1.32
+    image: nagyesta/lowkey-vault:7.2.26
     ports:
       - "8443:8443"
     environment:

--- a/renovate.json
+++ b/renovate.json
@@ -108,9 +108,21 @@
         "major-version-bump"
       ],
       "automerge": false
+    },
+    {
+      "description": "Bump the integration test stack images in tests/docker-compose.test.yml and .github/workflows/integration-tests.yml together (#500, #332); tests/unit/test_dev_stack_hygiene.py fails CI if they diverge.",
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "localstack/localstack",
+        "hashicorp/vault",
+        "nagyesta/lowkey-vault"
+      ],
+      "groupName": "integration test stack images"
     }
   ],
-  "prBodyTemplate": "{{{table}}}\n\n---\n\n🤖 **Auto-generated version bump PR**\n\nThis PR was automatically created by Renovate to update dependency versions.\n\n- **Minor/Patch updates**: Requires review and approval\n- **Major updates**: Requires manual review and approval",
+  "prBodyTemplate": "{{{table}}}\n\n---\n\n🤖 **Auto-generated version bump PR**\n\nThis PR was automatically created by Renovate to update dependency versions.\n\n- **Minor/Patch updates**: auto-merged by the `automerge-version-bump` workflow once all required CI checks pass — no human review\n- **Major updates**: require manual review and approval; never auto-merged",
   "schedule": [
     "every weekend"
   ]

--- a/tests/docker-compose.test.yml
+++ b/tests/docker-compose.test.yml
@@ -8,7 +8,7 @@
 
 services:
   localstack:
-    image: localstack/localstack:4.0  # Pin to v4.x for stability
+    image: localstack/localstack:4.14  # Keep in sync with .github/workflows/integration-tests.yml
     ports:
       - "4566:4566"
     environment:
@@ -23,7 +23,7 @@ services:
       start_period: 10s
 
   vault:
-    image: hashicorp/vault:1.21  # Pin to v1.21.x for stability
+    image: hashicorp/vault:1.21  # Keep in sync with .github/workflows/integration-tests.yml
     # Match integration-tests.yml (`--user root`) so the setcap/IPC_LOCK
     # behavior is identical between the local compose stack and CI.
     user: root
@@ -47,7 +47,7 @@ services:
       start_period: 5s
 
   lowkey-vault:
-    image: nagyesta/lowkey-vault:7.1.32  # Pin to v7.x for stability
+    image: nagyesta/lowkey-vault:7.2.26  # Keep in sync with .github/workflows/integration-tests.yml
     ports:
       - "8443:8443"
     environment:

--- a/tests/unit/test_dev_stack_hygiene.py
+++ b/tests/unit/test_dev_stack_hygiene.py
@@ -1,0 +1,196 @@
+"""Regression tests pinning local/CI dev-stack parity and Renovate copy (#500).
+
+Two hygiene properties the repo must keep true:
+
+- ``tests/docker-compose.test.yml`` and the ``integration-tests.yml`` service
+  containers must pin the *same* image tags, so local runs exercise the same
+  backends CI does (#332 established this once; CI-only Renovate bumps
+  re-diverged localstack 4.0 vs 4.14 and lowkey-vault 7.1.32 vs 7.2.26).
+  Every image line carries a keep-in-sync pointer at its counterpart file, and
+  ``renovate.json`` groups the stack images so one Renovate PR moves both
+  files together.
+- The Renovate PR body template must describe the merge policy the repo
+  actually enforces: ``automerge-version-bump.yml`` squash-merges minor/patch
+  bumps with zero human review, so the template must not claim
+  "Requires review and approval" for them.
+
+These parse the real compose/workflow/Renovate files — no mocking of the
+behavior under test.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_COMPOSE_PATH = _REPO_ROOT / "tests" / "docker-compose.test.yml"
+_WORKFLOWS = _REPO_ROOT / ".github" / "workflows"
+_INTEGRATION_WORKFLOW_PATH = _WORKFLOWS / "integration-tests.yml"
+_AUTOMERGE_WORKFLOW_PATH = _WORKFLOWS / "automerge-version-bump.yml"
+_RENOVATE_PATH = _REPO_ROOT / "renovate.json"
+
+# The backends the integration suite drives (LocalStack/AWS, HashiCorp Vault,
+# Lowkey-Vault/Azure). Both stacks must define all three.
+_STACK_SERVICES = ("localstack", "vault", "lowkey-vault")
+_STACK_IMAGES = frozenset({"localstack/localstack", "hashicorp/vault", "nagyesta/lowkey-vault"})
+
+_IMAGE_LINE = re.compile(r"^\s*-?\s*image:\s")
+
+
+def _compose_images() -> dict[str, str]:
+    compose = yaml.safe_load(_COMPOSE_PATH.read_text(encoding="utf-8"))
+    return {name: svc["image"] for name, svc in compose["services"].items()}
+
+
+def _ci_service_images() -> dict[str, str]:
+    workflow = yaml.safe_load(_INTEGRATION_WORKFLOW_PATH.read_text(encoding="utf-8"))
+    services = workflow["jobs"]["integration-tests"]["services"]
+    return {name: svc["image"] for name, svc in services.items()}
+
+
+def _renovate_config() -> dict[str, Any]:
+    return json.loads(_RENOVATE_PATH.read_text(encoding="utf-8"))
+
+
+def test_compose_stack_pins_same_images_as_ci_service_containers() -> None:
+    """Local compose images must equal the CI service-container images (#500).
+
+    Pre-fix the local stack ran localstack 4.0 (fourteen minors behind CI's
+    4.14) and lowkey-vault 7.1.32 (vs CI's 7.2.26), so a locally-green
+    integration run proved nothing about the backends CI exercises (#332
+    fixed this once; it re-diverged).
+    """
+    compose = _compose_images()
+    ci = _ci_service_images()
+    for service in _STACK_SERVICES:
+        assert service in compose, (
+            f"tests/docker-compose.test.yml lost the {service!r} service (#500)."
+        )
+        assert service in ci, (
+            f"integration-tests.yml lost the {service!r} service container (#500)."
+        )
+    mismatched = {
+        service: {"compose": compose[service], "ci": ci[service]}
+        for service in sorted(set(compose) & set(ci))
+        if compose[service] != ci[service]
+    }
+    assert not mismatched, (
+        "Local compose stack diverged from CI service containers (#500, "
+        f"previously #332) — bump both together: {mismatched}"
+    )
+
+
+def test_stack_images_pin_explicit_version_tags() -> None:
+    """Every stack image pins an explicit non-latest tag (#500).
+
+    Tag parity is only meaningful while both sides pin explicit versions; an
+    untagged or ``:latest`` image would let local and CI silently resolve to
+    different backends while the parity check still passes.
+    """
+    for source, images in (
+        ("tests/docker-compose.test.yml", _compose_images()),
+        ("integration-tests.yml", _ci_service_images()),
+    ):
+        for service, image in images.items():
+            repository, _, tag = image.rpartition(":")
+            assert repository and tag and tag != "latest", (
+                f"{source}: service {service!r} image {image!r} must pin an "
+                "explicit version tag (#500)."
+            )
+
+
+def test_every_stack_image_line_carries_keep_in_sync_pointer() -> None:
+    """Each image line names its counterpart file in a comment (#500).
+
+    Pre-fix only the CI vault entry carried a keep-in-sync comment; the other
+    five image lines gave a human editor (or a reviewer of a Renovate diff)
+    no hint that a second copy of the pin exists.
+    """
+    missing: list[str] = []
+    for path, counterpart in (
+        (_COMPOSE_PATH, "integration-tests.yml"),
+        (_INTEGRATION_WORKFLOW_PATH, "docker-compose.test.yml"),
+    ):
+        lines = path.read_text(encoding="utf-8").splitlines()
+        for index, line in enumerate(lines):
+            if not _IMAGE_LINE.match(line):
+                continue
+            previous = lines[index - 1] if index else ""
+            if counterpart not in line and counterpart not in previous:
+                missing.append(f"{path.name}:{index + 1}: {line.strip()}")
+    assert not missing, (
+        "Every stack image line must carry a keep-in-sync comment naming the "
+        f"counterpart file (#500): {missing}"
+    )
+
+
+def test_renovate_groups_stack_images_across_both_files() -> None:
+    """Renovate must group the stack image bumps into one branch (#500).
+
+    Pre-fix nothing tied the two copies of each pin together, so Renovate
+    bumps landed in CI only and the stacks re-diverged (the regression #332
+    had already fixed). A ``groupName`` rule over the three docker packages
+    makes a single Renovate PR move tests/docker-compose.test.yml and
+    integration-tests.yml together.
+    """
+    rules = _renovate_config().get("packageRules", [])
+    grouping = [
+        rule
+        for rule in rules
+        if rule.get("groupName")
+        and "docker" in rule.get("matchDatasources", [])
+        and _STACK_IMAGES.issubset(rule.get("matchPackageNames", []))
+    ]
+    assert grouping, (
+        "renovate.json must contain a packageRule grouping the integration "
+        f"stack images {sorted(_STACK_IMAGES)} (matchDatasources: docker, "
+        "groupName) so one PR bumps the compose file and the CI workflow "
+        "together (#500)."
+    )
+
+
+def test_renovate_pr_body_copy_matches_automerge_reality() -> None:
+    """The Renovate PR body must describe the real merge policy (#500).
+
+    automerge-version-bump.yml squash-merges every ``minor-version-bump``
+    labeled PR once CI is green — branch protection requires zero approvals —
+    yet pre-fix every PR body claimed "Minor/Patch updates: Requires review
+    and approval". The copy must match the automation it documents.
+    """
+    automerge = _AUTOMERGE_WORKFLOW_PATH.read_text(encoding="utf-8")
+    # The premise: the workflow really does merge minor/patch bumps unreviewed.
+    assert "minor-version-bump" in automerge and "pulls.merge" in automerge, (
+        "automerge-version-bump.yml no longer auto-merges minor-version-bump "
+        "PRs — update this test AND the renovate.json prBodyTemplate copy "
+        "together (#500)."
+    )
+
+    body = _renovate_config()["prBodyTemplate"]
+    lines = [line for line in body.splitlines() if line.strip()]
+    minor_lines = [line for line in lines if "Minor/Patch" in line]
+    major_lines = [line for line in lines if "Major" in line]
+    assert minor_lines and major_lines, (
+        "renovate.json prBodyTemplate must document both the Minor/Patch and "
+        "the Major update policy (#500)."
+    )
+    for line in minor_lines:
+        assert "requires review" not in line.lower(), (
+            f"prBodyTemplate claims review for minor/patch bumps ({line!r}) "
+            "but automerge-version-bump.yml merges them with zero human "
+            "review (#500)."
+        )
+        assert re.search(r"auto-?merge", line, re.IGNORECASE), (
+            f"prBodyTemplate minor/patch line ({line!r}) must state that the "
+            "automerge-version-bump workflow merges these once CI passes "
+            "(#500)."
+        )
+    for line in major_lines:
+        assert re.search(r"manual review", line, re.IGNORECASE), (
+            f"prBodyTemplate major line ({line!r}) must keep requiring manual "
+            "review — automerge-version-bump.yml refuses major bumps (#500)."
+        )


### PR DESCRIPTION
## Summary

Resolves the two dev-stack hygiene drifts from #500: the local docker-compose test stack had re-diverged
from the CI service-container image tags (the same drift #332 fixed once), and every Renovate PR body
claimed a review policy that `automerge-version-bump.yml` actually bypasses. This PR re-aligns the images,
adds the missing keep-in-sync mechanism plus a CI guard so the drift cannot silently recur, and makes the
Renovate copy truthful.

Stacked on `fix/495-release-workflows` (base of this PR); GitHub retargets to `main` when the parent merges.

## Fixes

| Issue checklist item | Change |
| --- | --- |
| Compose stack re-diverged from CI (localstack 4.0 vs 4.14, lowkey-vault 7.1.32 vs 7.2.26) | `tests/docker-compose.test.yml` now pins `localstack/localstack:4.14` and `nagyesta/lowkey-vault:7.2.26`, matching `integration-tests.yml`; all six image lines in both files now carry a keep-in-sync comment naming the counterpart file; a new `renovate.json` packageRule groups the three stack images (docker datasource) so one Renovate PR bumps both files together; `tests/unit/test_dev_stack_hygiene.py` fails CI on any future divergence (the regression guard #332 never got) |
| Renovate PR bodies claim "Minor/Patch updates: Requires review and approval" while automerge merges them unreviewed | `renovate.json` `prBodyTemplate` now states the real flow: minor/patch bumps are auto-merged by the `automerge-version-bump` workflow once all required CI checks pass (no human review); major bumps require manual review and are never auto-merged (copy fix, per the issue's suggested direction) |
| Docs in sync | `docs/specs/integration-tests-spec.md` snippets updated to the current tags with a pointer to the canonical pins |

## Test evidence

New regression tests in `tests/unit/test_dev_stack_hygiene.py` parse the real compose/workflow/Renovate
files (no mocking), written first and run against unfixed code:

**Pre-fix (4 of 5 fail for exactly the issue's reasons):**

```text
FAILED test_compose_stack_pins_same_images_as_ci_service_containers
  AssertionError: Local compose stack diverged from CI service containers (#500, previously #332) —
  bump both together: {'localstack': {'compose': 'localstack/localstack:4.0', 'ci': 'localstack/localstack:4.14'},
  'lowkey-vault': {'compose': 'nagyesta/lowkey-vault:7.1.32', 'ci': 'nagyesta/lowkey-vault:7.2.26'}}
FAILED test_every_stack_image_line_carries_keep_in_sync_pointer   (5 of 6 image lines had no pointer)
FAILED test_renovate_groups_stack_images_across_both_files        (no grouping packageRule existed)
FAILED test_renovate_pr_body_copy_matches_automerge_reality
  AssertionError: prBodyTemplate claims review for minor/patch bumps
  ('- **Minor/Patch updates**: Requires review and approval') but automerge-version-bump.yml merges
  them with zero human review (#500).
```

**Post-fix:** `5 passed` (`uv run pytest tests/unit/test_dev_stack_hygiene.py -q`).

Gates in the worktree: `ruff check` / `ruff format --check` / `pyrefly check` / `bandit` all clean;
`pytest -m "not integration"` → 2534 passed, 4 skipped; `pytest -m integration` against the live
LocalStack/Vault/Lowkey backends → 318 passed, 13 skipped; `make lint-docs` → 0 errors;
`docker compose -f tests/docker-compose.test.yml config -q` validates (CI service containers already run
the exact 4.14/7.2.26 tags, so the bumped images are proven against the suite).

Fixes #500

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jainal09/envdrift/pull/523?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes two dev-stack hygiene drifts from #500: the local Docker Compose test stack had re-diverged from the CI service-container image tags (localstack 4.0 vs 4.14, lowkey-vault 7.1.32 vs 7.2.26), and the Renovate PR body template falsely claimed minor/patch updates required human review when the `automerge-version-bump` workflow merges them unreviewed.

- **Image alignment**: `tests/docker-compose.test.yml` now pins `localstack/localstack:4.14` and `nagyesta/lowkey-vault:7.2.26` to match CI; inline `# Keep in sync` comments added to all six image lines; a new Renovate `groupName` rule groups the three Docker stack images so one Renovate PR bumps both files together.
- **Renovate copy fix**: `prBodyTemplate` updated to accurately state that minor/patch bumps are auto-merged by `automerge-version-bump` once CI passes, while major bumps require manual review.
- **Regression guard**: `tests/unit/test_dev_stack_hygiene.py` (5 new tests) parses the real compose, workflow, and Renovate files to fail CI on any future divergence.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the core image alignment and Renovate grouping changes are correct and the new regression tests enforce the invariants going forward.

The image tag bumps and Renovate config changes are correct and well-tested. Three minor test-design fragilities in the new regression guard do not affect the correctness of the changes being landed.

tests/unit/test_dev_stack_hygiene.py - the unbounded image-line scan, hardcoded job name, and intersection-only mismatch check make the guard more fragile than needed.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/integration-tests.yml | Added inline keep-in-sync comments on all three service image lines; no tag changes. |
| docs/specs/integration-tests-spec.md | Doc snippets updated from stale tags (localstack 4.0 to 4.14, lowkey-vault 7.1.32 to 7.2.26) with pointer to canonical pins. |
| renovate.json | Adds groupName packageRule over three Docker stack images; prBodyTemplate updated to accurately describe the auto-merge policy. |
| tests/docker-compose.test.yml | Bumped localstack (4.0 to 4.14) and lowkey-vault (7.1.32 to 7.2.26) to match CI; inline keep-in-sync comments added. |
| tests/unit/test_dev_stack_hygiene.py | New regression test file with 5 tests; hardcoded job name and unbounded image-line scan are minor fragility concerns. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Renovate detects Docker image update] --> B{matchPackageNames}
    B --> C[groupName: integration test stack images]
    C --> D[tests/docker-compose.test.yml updated]
    C --> E[integration-tests.yml updated]
    D --> F[CI runs test_dev_stack_hygiene.py]
    E --> F
    F --> G{All hygiene tests pass?}
    G -- Yes --> H{minor-version-bump label?}
    G -- No --> I[CI fails - drift detected]
    H -- Yes --> J[automerge-version-bump.yml squash-merges]
    H -- No major --> K[Requires manual review]
```

<sub>Reviews (1): Last reviewed commit: ["ci: re-align compose images with CI and ..."](https://github.com/jainal09/envdrift/commit/8d57a1ccb00f10dfe9d86cea5aecb47fc9c0e2b9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37244277)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->