### PR TITLE
fix(parser): parse quoted multiline values like python-dotenv (#458)

### DIFF
--- a/docs/cli/validate.md
+++ b/docs/cli/validate.md
@@ -33,6 +33,17 @@ Type validation mirrors what the real app does at startup:
   and the sensitive-name warning, so encrypted files validate cleanly against an
   `extra="forbid"` schema.
 
+The file itself is parsed with python-dotenv's quoting rules — the parser
+pydantic-settings uses — so the variables envdrift judges are exactly the ones
+the real app loads:
+
+- A value opened with `"` or `'` continues across physical lines until the
+  matching close quote (multiline PEM certificates and keys parse as one
+  value); interior `KEY=value`-looking lines are part of the value, never
+  separate variables.
+- Inside quoted values the python-dotenv escape sequences are decoded (`\n`,
+  `\t`, `\"`, `\\`, ... in double quotes; `\\` and `\'` in single quotes).
+
 ## Arguments
 
 | Argument   | Description                       | Default |

--- a/docs/concepts/how-it-works.md
+++ b/docs/concepts/how-it-works.md
@@ -24,7 +24,9 @@ class Settings(BaseSettings):
 When you run `envdrift validate`, it:
 
 1. Loads your Pydantic Settings class
-2. Parses the `.env` file
+2. Parses the `.env` file with python-dotenv's quoting rules (quoted values
+   may span multiple lines, e.g. PEM certificates), so envdrift sees exactly
+   the variables pydantic-settings would load
 3. Checks for missing required fields
 4. Validates types (string to int/bool conversion)
 5. Optionally checks for extra undefined variables

--- a/src/envdrift/core/parser.py
+++ b/src/envdrift/core/parser.py
@@ -7,6 +7,7 @@ Supports:
 
 from __future__ import annotations
 
+import codecs
 import re
 from dataclasses import dataclass, field
 from enum import Enum
@@ -124,11 +125,14 @@ class EnvParser:
     - dotenvx encrypted: KEY="encrypted:xxxx"
     - SOPS encrypted: KEY="ENC[AES256_GCM,data:...,iv:...,tag:...,type:str]"
     - Comments and blank lines (skipped)
-
-    Note:
-        Multiline values are not currently supported. Each line is parsed
-        independently. For multiline secrets (e.g., PEM keys), consider
-        base64 encoding or using a single-line escaped format.
+    - Quoted multiline values (#458): a value opened with ``"`` or ``'``
+      continues across physical lines until the matching unescaped close
+      quote, exactly like python-dotenv (the parser pydantic-settings uses).
+      Newlines inside the value are preserved (normalized to ``\\n``), and the
+      python-dotenv escape sets are decoded inside quoted values
+      (``\\\\ \\' \\" \\a \\b \\f \\n \\r \\t \\v`` in double quotes,
+      ``\\\\ \\'`` in single quotes). An unterminated quote falls back to the
+      legacy per-line treatment so malformed files still parse line by line.
     """
 
     # dotenvx encrypted value pattern
@@ -153,6 +157,21 @@ class EnvParser:
     # .env), keeping the init→validate round-trip intact. Other callers keep the
     # strict pattern so their behaviour is unchanged.
     LENIENT_LINE_PATTERN = re.compile(r"^(?:export\s+)?([^\s=#]+)\s*=(.*)$")
+
+    # python-dotenv's quoted-value escape sets (dotenv/parser.py): decoded
+    # inside double-/single-quoted values so `validate`/`diff` see exactly the
+    # values pydantic-settings loads (#458). The value itself runs to the first
+    # unescaped close quote — across physical lines — found by
+    # ``_find_close_quote`` (an escape-aware scan, equivalent to dotenv's
+    # greedy `(?:\\"|[^"])*` lexing without its backtracking pathologies).
+    DOUBLE_QUOTE_ESCAPES_PATTERN = re.compile(r"\\[\\'\"abfnrtv]")
+    SINGLE_QUOTE_ESCAPES_PATTERN = re.compile(r"\\[\\']")
+
+    # What may legally follow a closing quote on its physical line: optional
+    # whitespace and an optional `#...` comment (python-dotenv's `_comment` +
+    # `_end_of_line`). Anything else means the quote did not cleanly terminate
+    # the assignment, and the legacy raw treatment applies.
+    TRAILING_AFTER_QUOTE_PATTERN = re.compile(r"[^\S\r\n]*(?:#.*)?")
 
     def parse(self, path: Path | str, *, lenient: bool = False) -> EnvFile:
         """
@@ -210,9 +229,12 @@ class EnvParser:
         lines = content.splitlines()
         pattern = self.LENIENT_LINE_PATTERN if lenient else self.LINE_PATTERN
 
-        for line_num, line in enumerate(lines, start=1):
-            original_line = line
-            line = line.strip()
+        index = 0
+        while index < len(lines):
+            line_num = index + 1
+            original_line = lines[index]
+            index += 1
+            line = original_line.strip()
 
             # Skip empty lines
             if not line:
@@ -229,7 +251,19 @@ class EnvParser:
                 continue
 
             key = match.group(1)
-            value = self.value_from_raw(match.group(2))
+            raw_value = match.group(2)
+            raw_lines = [original_line]
+
+            # Quoted multiline continuation (#458): when the RHS opens a quote
+            # that closes on a later physical line, the continuation lines are
+            # part of THIS value — not new assignments or comments.
+            joined_raw, consumed = self._continue_quoted_value(raw_value, lines, index)
+            if consumed:
+                raw_value = joined_raw
+                raw_lines.extend(lines[index : index + consumed])
+                index += consumed
+
+            value = self.value_from_raw(raw_value)
 
             # Determine encryption status and backend
             encryption_status, encryption_backend = self._detect_encryption_status(value)
@@ -239,7 +273,7 @@ class EnvParser:
                 value=value,
                 line_number=line_num,
                 encryption_status=encryption_status,
-                raw_line=original_line,
+                raw_line="\n".join(raw_lines),
                 encryption_backend=encryption_backend,
             )
 
@@ -248,17 +282,118 @@ class EnvParser:
         return env_file
 
     def value_from_raw(self, raw_value: str) -> str:
-        """Normalize the raw RHS of a ``KEY=value`` line to its final value.
+        """Normalize the raw RHS of a ``KEY=value`` assignment to its final value.
 
-        Strips an unquoted inline comment, then surrounding whitespace, then a
-        single matching pair of surrounding quotes — the same transformation
-        ``parse`` applies. Public so callers that recover assignments the strict
-        ``LINE_PATTERN`` rejects (e.g. ``init`` for non-identifier keys) reuse
-        this canonical handling instead of the private helpers. The whitespace
-        context matters, so pass the RAW value (the regex's ``=`` group),
-        unstripped: ``K= # c`` is a comment but ``K=#FF0000`` is a value.
+        A cleanly quoted value (single- or multi-line) is lexed exactly like
+        python-dotenv: the value runs to the matching unescaped close quote,
+        anything after it must be whitespace or a ``#`` comment, and the
+        quote-appropriate escape set is decoded (#458). Otherwise the legacy
+        treatment applies: strip an unquoted inline comment, then surrounding
+        whitespace, then a single matching pair of surrounding quotes. Public so
+        callers that recover assignments the strict ``LINE_PATTERN`` rejects
+        (e.g. ``init`` for non-identifier keys) reuse this canonical handling
+        instead of the private helpers. The whitespace context matters, so pass
+        the RAW value (the regex's ``=`` group), unstripped: ``K= # c`` is a
+        comment but ``K=#FF0000`` is a value.
         """
+        quoted = self._match_quoted_value(raw_value.strip())
+        if quoted is not None:
+            return quoted
         return self._unquote(self._strip_inline_comment(raw_value).strip())
+
+    def _match_quoted_value(self, text: str) -> str | None:
+        """Lex ``text`` as a python-dotenv quoted value, or return ``None``.
+
+        ``text`` must start at the opening quote (callers strip leading
+        whitespace). Returns the decoded inner value when the quote closes and
+        only whitespace / a ``#`` comment follows on the closing line;
+        ``None`` when ``text`` is not quoted, the quote never closes, or
+        non-comment content trails the close quote (legacy handling applies).
+        """
+        if len(text) < 2 or text[0] not in "\"'":
+            return None
+        close = self._find_close_quote(text)
+        if close is None:
+            return None
+        if not self.TRAILING_AFTER_QUOTE_PATTERN.fullmatch(text, close + 1):
+            return None
+        escapes = (
+            self.DOUBLE_QUOTE_ESCAPES_PATTERN
+            if text[0] == '"'
+            else self.SINGLE_QUOTE_ESCAPES_PATTERN
+        )
+        return self._decode_escapes(escapes, text[1:close])
+
+    @staticmethod
+    def _find_close_quote(text: str) -> int | None:
+        """Index of the unescaped quote closing ``text[0]``, or ``None``.
+
+        Escape-aware scan: a backslash consumes the next character, so ``\\"``
+        (or ``\\'``) never closes the value — matching python-dotenv's quoted
+        value lexing, where newlines are ordinary value characters.
+        """
+        quote = text[0]
+        i = 1
+        n = len(text)
+        while i < n:
+            ch = text[i]
+            if ch == "\\":
+                i += 2
+                continue
+            if ch == quote:
+                return i
+            i += 1
+        return None
+
+    def _continue_quoted_value(
+        self, raw_value: str, lines: list[str], start: int
+    ) -> tuple[str, int]:
+        """Extend a quote-opening RHS across physical lines until it closes.
+
+        ``raw_value`` is the RHS of the assignment on the line before
+        ``lines[start]``. When it opens a quote that does not terminate on its
+        own line, successive lines are joined with ``\\n`` until the matching
+        unescaped close quote is found (python-dotenv semantics, #458).
+
+        Returns:
+            tuple[str, int]: ``(joined_raw, consumed)`` where ``consumed`` is
+            the number of continuation lines absorbed into the value. ``(raw_value, 0)``
+            when the RHS is not quoted, already terminates on its own line, is
+            never terminated (legacy per-line fallback), or closes with
+            non-comment trailing content.
+        """
+        text = raw_value.strip()
+        if not text or text[0] not in "\"'":
+            return raw_value, 0
+        quote = text[0]
+        if self._find_close_quote(text) is not None:
+            # The quote terminates on this physical line (validly or not);
+            # single-line handling owns it.
+            return raw_value, 0
+
+        joined = raw_value
+        for offset, next_line in enumerate(lines[start:], start=1):
+            joined += "\n" + next_line
+            if quote not in next_line:
+                continue  # close quote can't be here; skip the re-scan
+            lstripped = joined.lstrip()
+            close = self._find_close_quote(lstripped)
+            if close is None:
+                continue  # the quote(s) on this line were escaped
+            if self.TRAILING_AFTER_QUOTE_PATTERN.fullmatch(lstripped, close + 1):
+                return joined, offset
+            # Closes, but non-comment content trails the quote — not a clean
+            # quoted value; keep the legacy per-line treatment.
+            return raw_value, 0
+        return raw_value, 0  # unterminated: legacy per-line fallback
+
+    @staticmethod
+    def _decode_escapes(escapes: re.Pattern[str], value: str) -> str:
+        """Decode a quoted value's escape sequences like python-dotenv."""
+        return escapes.sub(
+            lambda match: codecs.decode(match.group(0), "unicode-escape"),
+            value,
+        )
 
     def _strip_inline_comment(self, value: str) -> str:
         """Strip an unquoted trailing ` #...` comment from a (raw) value.

--- a/tests/integration/test_multiline_parsing_cli.py
+++ b/tests/integration/test_multiline_parsing_cli.py
@@ -1,0 +1,186 @@
+"""CLI regression tests for #458: multiline quoted values end-to-end.
+
+The parser used to split quoted multiline values per physical line, so
+``validate`` produced false PASS/FAIL verdicts (phantom variables satisfied or
+violated the schema), ``diff`` missed drift hidden past the first line of a
+value, and ``encrypt --check`` blocked commits on secrets the user never
+wrote. These tests drive the real ``envdrift`` CLI as a subprocess against
+multiline fixtures and assert exit codes plus machine-readable output.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.integration]
+
+# PEM-style fixture material, built by concatenation so the literals never look
+# like real key material (GitHub push protection).
+PEM_HEADER = "-----BEGIN " + "TEST CERT-----"
+PEM_FOOTER = "-----END " + "TEST CERT-----"
+PEM_BODY = "QUJDREVGMDEyMzQ1Njc4OQ" + "=="
+PEM_VALUE = f"{PEM_HEADER}\n{PEM_BODY}\n{PEM_FOOTER}"
+
+
+def _run_cli(args: list[str], cwd: Path, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    """Run the envdrift CLI in-tree with deterministic output."""
+    return subprocess.run(
+        [sys.executable, "-m", "envdrift.cli", *args],
+        cwd=cwd,
+        env=env,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        timeout=120,
+        check=False,
+    )
+
+
+def _write_schema(tmp_path: Path, body: str) -> None:
+    (tmp_path / "sc.py").write_text(textwrap.dedent(body), encoding="utf-8")
+
+
+def _validate_ci(tmp_path: Path, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    return _run_cli(
+        [
+            "validate",
+            ".env",
+            "--schema",
+            "sc:Settings",
+            "--service-dir",
+            str(tmp_path),
+            "--no-check-encryption",
+            "--ci",
+        ],
+        cwd=tmp_path,
+        env=env,
+    )
+
+
+class TestValidateMultiline:
+    """validate must judge the file the way pydantic-settings parses it."""
+
+    def test_required_var_swallowed_by_multiline_value_fails_ci(self, tmp_path, integration_env):
+        """Issue #458 headline: an interior ``DB_PASSWORD=...`` line is part of
+        CERT's value, so the required DB_PASSWORD is MISSING. This used to be a
+        false PASS (exit 0) from the phantom variable."""
+        _write_schema(
+            tmp_path,
+            """
+            from pydantic_settings import BaseSettings
+
+            class Settings(BaseSettings):
+                CERT: str
+                DB_PASSWORD: str
+            """,
+        )
+        (tmp_path / ".env").write_text(
+            'CERT="-----BEGIN CERT-----\n'
+            "DB_PASSWORD=oops_interpreted_as_assignment\n"
+            '-----END CERT-----"\n',
+            encoding="utf-8",
+        )
+
+        result = _validate_ci(tmp_path, integration_env)
+
+        out = " ".join((result.stdout + result.stderr).split())
+        assert result.returncode == 1, out
+        assert "DB_PASSWORD" in out
+
+    def test_clean_multiline_pem_passes_without_phantom_extras(self, tmp_path, integration_env):
+        """A well-formed multiline PEM under ``extra='forbid'`` must PASS: the
+        interior base64 lines used to surface as phantom extra variables (false
+        FAIL) and the value was truncated to the stray-quote first line."""
+        _write_schema(
+            tmp_path,
+            """
+            from pydantic_settings import BaseSettings, SettingsConfigDict
+
+            class Settings(BaseSettings):
+                model_config = SettingsConfigDict(extra="forbid")
+
+                TLS_CERT: str
+                PORT: int
+            """,
+        )
+        (tmp_path / ".env").write_text(f'TLS_CERT="{PEM_VALUE}"\nPORT=8080\n', encoding="utf-8")
+
+        result = _validate_ci(tmp_path, integration_env)
+
+        out = " ".join((result.stdout + result.stderr).split())
+        assert result.returncode == 0, out
+        assert "Validation PASSED" in out
+
+
+class TestDiffMultiline:
+    """diff must compare full multiline values, not their first lines."""
+
+    def test_drift_inside_multiline_value_is_detected(self, tmp_path, integration_env):
+        """Two CERTs identical on their first physical line but different
+        inside used to compare equal (false no-drift)."""
+        (tmp_path / ".env.dev").write_text(
+            f'CERT="{PEM_HEADER}\nAAAACONTENTDEV\n{PEM_FOOTER}"\n', encoding="utf-8"
+        )
+        (tmp_path / ".env.prod").write_text(
+            f'CERT="{PEM_HEADER}\nBBBBCONTENTPROD\n{PEM_FOOTER}"\n', encoding="utf-8"
+        )
+
+        result = _run_cli(
+            ["diff", ".env.dev", ".env.prod", "--format", "json"],
+            cwd=tmp_path,
+            env=integration_env,
+        )
+
+        assert result.returncode == 0, result.stdout + result.stderr
+        data = json.loads(result.stdout)
+        changed = {d["name"] for d in data["differences"] if d["type"] == "changed"}
+        assert changed == {"CERT"}
+        assert data["summary"]["has_drift"] is True
+
+    def test_drift_on_interior_assignment_line_names_the_real_var(self, tmp_path, integration_env):
+        """An interior ``DB_PASSWORD=...`` line that differs is drift in CERT —
+        not in a phantom DB_PASSWORD variable."""
+        (tmp_path / ".env.dev").write_text(
+            f'CERT="{PEM_HEADER}\nDB_PASSWORD=devvalue\n{PEM_FOOTER}"\n',
+            encoding="utf-8",
+        )
+        (tmp_path / ".env.prod").write_text(
+            f'CERT="{PEM_HEADER}\nDB_PASSWORD=prodvalue\n{PEM_FOOTER}"\n',
+            encoding="utf-8",
+        )
+
+        result = _run_cli(
+            ["diff", ".env.dev", ".env.prod", "--format", "json"],
+            cwd=tmp_path,
+            env=integration_env,
+        )
+
+        assert result.returncode == 0, result.stdout + result.stderr
+        data = json.loads(result.stdout)
+        names = {d["name"] for d in data["differences"]}
+        assert "CERT" in names
+        assert "DB_PASSWORD" not in names
+
+
+class TestEncryptCheckMultiline:
+    """encrypt --check classification reads parsed values."""
+
+    def test_no_phantom_secret_blocks_commit(self, tmp_path, integration_env):
+        """A phantom DB_PASSWORD fabricated from a multiline value used to be
+        classified as a plaintext secret and block (exit 1)."""
+        (tmp_path / ".env").write_text(
+            f'CERT="{PEM_HEADER}\nDB_PASSWORD=not_a_real_var\n{PEM_FOOTER}"\nAPP_NAME=demo\n',
+            encoding="utf-8",
+        )
+
+        result = _run_cli(["encrypt", ".env", "--check"], cwd=tmp_path, env=integration_env)
+
+        out = " ".join((result.stdout + result.stderr).split())
+        assert result.returncode == 0, out
+        assert "DB_PASSWORD" not in out

--- a/tests/unit/test_parser_multiline.py
+++ b/tests/unit/test_parser_multiline.py
@@ -1,0 +1,270 @@
+"""Regression tests for #458: quoted multiline values parse like python-dotenv.
+
+``EnvParser`` used to split content per physical line, truncating a quoted
+multiline value at its first line (keeping the stray opening quote) and
+re-parsing the interior lines as phantom assignments. python-dotenv — and
+therefore pydantic-settings, the ground truth for ``validate`` — treats a
+value opened with ``"``/``'`` as continuing across physical lines until the
+matching close quote. These tests pin the parser to those semantics, including
+byte-for-byte parity checks against the real python-dotenv and a real
+pydantic-settings class loading the same file in-process.
+"""
+
+from __future__ import annotations
+
+import pytest
+from dotenv import dotenv_values
+
+from envdrift.core.parser import EncryptionStatus, EnvParser
+
+# PEM-style fixture material, built by concatenation so the literals never look
+# like real key material (GitHub push protection).
+PEM_HEADER = "-----BEGIN " + "TEST CERT-----"
+PEM_FOOTER = "-----END " + "TEST CERT-----"
+PEM_BODY_1 = "QUJDREVGMDEyMzQ1Njc4OQ" + "=="
+PEM_BODY_2 = "MDEyMzQ1Njc4OWFiY2RlZg" + "=="
+PEM_VALUE = "\n".join([PEM_HEADER, PEM_BODY_1, PEM_BODY_2, PEM_FOOTER])
+
+
+def _values(env_file) -> dict[str, str]:
+    """Plain ``{name: value}`` view of a parsed EnvFile."""
+    return {name: var.value for name, var in env_file.variables.items()}
+
+
+class TestMultilineQuotedValues:
+    """#458: a quoted value continues across lines until the close quote."""
+
+    def test_double_quoted_multiline_value_parsed_fully(self):
+        """The full multiline value is kept — no truncation, no phantom vars."""
+        content = f'CERT="{PEM_VALUE}"\nAFTER=ok\n'
+
+        result = EnvParser().parse_string(content)
+
+        assert set(result.variables) == {"CERT", "AFTER"}
+        assert result.variables["CERT"].value == PEM_VALUE
+        assert result.variables["AFTER"].value == "ok"
+
+    def test_interior_assignment_is_value_not_phantom_var(self):
+        """Issue #458 evidence: an interior ``KEY=...`` line is part of the
+        value, not a fabricated variable the user never wrote."""
+        inner = "DB_PASSWORD=oops_interpreted_as_assignment"
+        cert_value = f"-----BEGIN CERT-----\n{inner}\n-----END CERT-----"
+        content = f'CERT="{cert_value}"\n'
+
+        result = EnvParser().parse_string(content)
+
+        assert set(result.variables) == {"CERT"}
+        assert "DB_PASSWORD" not in result
+        assert result.variables["CERT"].value == cert_value
+
+    def test_single_quoted_multiline_value(self):
+        content = "NOTE='line one\nline two'\nX=1\n"
+
+        result = EnvParser().parse_string(content)
+
+        assert set(result.variables) == {"NOTE", "X"}
+        assert result.variables["NOTE"].value == "line one\nline two"
+
+    def test_escaped_double_quote_inside_multiline_does_not_close(self):
+        """A ``\\"`` inside the value neither closes the quote nor survives
+        verbatim — python-dotenv decodes it to ``"``."""
+        content = 'MSG="say \\"hi\\"\nsecond line"\n'
+
+        result = EnvParser().parse_string(content)
+
+        assert set(result.variables) == {"MSG"}
+        assert result.variables["MSG"].value == 'say "hi"\nsecond line'
+
+    def test_escaped_single_quote_inside_multiline_does_not_close(self):
+        content = "S='it\\'s\nfine'\n"
+
+        result = EnvParser().parse_string(content)
+
+        assert set(result.variables) == {"S"}
+        assert result.variables["S"].value == "it's\nfine"
+
+    def test_interior_comment_and_blank_lines_stay_in_value(self):
+        """``#``/blank interior lines belong to the value — they are neither
+        comments nor line separators."""
+        block = "first\n# not a comment\n\nlast"
+        content = f'BLOCK="{block}"\nX=1\n'
+
+        result = EnvParser().parse_string(content)
+
+        assert result.variables["BLOCK"].value == block
+        assert result.comments == []
+
+    def test_inline_comment_after_closing_quote_is_stripped(self):
+        content = 'CERT="a\nb"  # trailing comment\n'
+
+        result = EnvParser().parse_string(content)
+
+        assert result.variables["CERT"].value == "a\nb"
+
+    def test_line_numbers_resume_after_multiline_value(self):
+        content = f'CERT="{PEM_VALUE}"\nAFTER=ok\n'
+
+        result = EnvParser().parse_string(content)
+
+        assert result.variables["CERT"].line_number == 1
+        # CERT spans physical lines 1-4 (the 4-line PEM), so AFTER sits on 5.
+        assert result.variables["AFTER"].line_number == 5
+
+    def test_multiline_raw_line_preserves_physical_lines(self):
+        content = f'CERT="{PEM_VALUE}"\n'
+
+        result = EnvParser().parse_string(content)
+
+        assert result.variables["CERT"].raw_line == f'CERT="{PEM_VALUE}"'
+
+    def test_multiline_value_is_plaintext_status(self):
+        content = f'CERT="{PEM_VALUE}"\n'
+
+        result = EnvParser().parse_string(content)
+
+        var = result.variables["CERT"]
+        assert var.encryption_status == EncryptionStatus.PLAINTEXT
+        assert var.encryption_backend is None
+
+    def test_escaped_quote_on_continuation_line_does_not_close(self):
+        """A continuation line containing only an escaped quote keeps the
+        value open until the real close quote."""
+        content = 'M="start\nmid \\" still\nend"\n'
+
+        result = EnvParser().parse_string(content)
+
+        assert set(result.variables) == {"M"}
+        assert result.variables["M"].value == 'start\nmid " still\nend'
+
+    def test_close_quote_with_trailing_junk_falls_back_to_legacy(self):
+        """A close quote followed by non-comment content is not a clean quoted
+        value; the legacy per-line treatment applies (python-dotenv drops the
+        binding entirely — either way no multiline value is fabricated)."""
+        content = 'B="start\nend" garbage\nNEXT=1\n'
+
+        result = EnvParser().parse_string(content)
+
+        assert result.variables["B"].value == '"start'
+        assert result.variables["NEXT"].value == "1"
+
+    def test_unterminated_quote_keeps_legacy_per_line_parsing(self):
+        """No closing quote anywhere: the legacy single-line treatment is kept
+        (truncated value with the stray quote) and later lines still parse."""
+        content = 'BROKEN="no closing quote\nNEXT=ok\n'
+
+        result = EnvParser().parse_string(content)
+
+        assert result.variables["BROKEN"].value == '"no closing quote'
+        assert result.variables["NEXT"].value == "ok"
+
+    def test_lenient_parse_honors_multiline_values(self):
+        """``validate`` parses with ``lenient=True``; the continuation must
+        apply there too (base64 ``==`` padding lines used to become phantom
+        vars under the lenient pattern)."""
+        content = f'X-API-KEY="{PEM_VALUE}"\nOK_KEY=1\n'
+
+        result = EnvParser().parse_string(content, lenient=True)
+
+        assert set(result.variables) == {"X-API-KEY", "OK_KEY"}
+        assert result.variables["X-API-KEY"].value == PEM_VALUE
+
+    def test_crlf_multiline_value_normalizes_to_lf(self, tmp_path):
+        """A CRLF (Windows) file yields LF-joined values, exactly like
+        python-dotenv reading the same file."""
+        raw = f'CERT="{PEM_HEADER}\r\n{PEM_BODY_1}\r\n{PEM_FOOTER}"\r\nAFTER=ok\r\n'
+        env_path = tmp_path / ".env"
+        env_path.write_bytes(raw.encode("utf-8"))
+
+        result = EnvParser().parse(env_path)
+
+        assert set(result.variables) == {"CERT", "AFTER"}
+        expected = f"{PEM_HEADER}\n{PEM_BODY_1}\n{PEM_FOOTER}"
+        assert result.variables["CERT"].value == expected
+
+
+class TestSingleLineQuotedEscapes:
+    """Quoted single-line values follow python-dotenv's escape decoding."""
+
+    def test_double_quoted_escape_sequences_are_decoded(self):
+        content = 'K="a\\nb\\tc"\n'
+
+        result = EnvParser().parse_string(content)
+
+        assert result.variables["K"].value == "a\nb\tc"
+
+    def test_single_quoted_only_decodes_backslash_and_quote(self):
+        content = "K='a\\nb\\'c'\n"
+
+        result = EnvParser().parse_string(content)
+
+        assert result.variables["K"].value == "a\\nb'c"
+
+    def test_close_quote_with_trailing_junk_keeps_legacy_raw_value(self):
+        """Non-comment content after the close quote disqualifies the quoted
+        lexing; the legacy raw treatment is preserved."""
+        content = 'K="a" trailing\n'
+
+        result = EnvParser().parse_string(content)
+
+        assert result.variables["K"].value == '"a" trailing'
+
+    def test_unquoted_value_backslashes_untouched(self):
+        content = "K=a\\nb\n"
+
+        result = EnvParser().parse_string(content)
+
+        assert result.variables["K"].value == "a\\nb"
+
+
+class TestPythonDotenvParity:
+    """Byte-for-byte parity with the real python-dotenv / pydantic-settings."""
+
+    @pytest.mark.parametrize(
+        "content",
+        [
+            pytest.param(f'CERT="{PEM_VALUE}"\nAFTER=ok\n', id="multiline-pem-double-quoted"),
+            pytest.param("NOTE='line one\nline two'\nX=1\n", id="multiline-single-quoted"),
+            pytest.param('MSG="say \\"hi\\"\nsecond line"\n', id="multiline-escaped-quote"),
+            pytest.param('CERT="a\nb"  # trailing comment\nX=1\n', id="comment-after-close"),
+            pytest.param('BLOCK="first\n# inside\n\nlast"\n', id="interior-comment-and-blank"),
+            pytest.param("K=\"a\\nb\\tc\"\nS='a\\nb'\n", id="single-line-escapes"),
+            pytest.param("PORT=8080 # http port\nCOLOR=#FF0000\n", id="unquoted-inline-comment"),
+            pytest.param('EMPTY=""\nPADDED= "x"\nexport E="y"\n', id="quoting-shapes"),
+        ],
+    )
+    def test_parsed_values_match_python_dotenv(self, tmp_path, content):
+        env_path = tmp_path / ".env"
+        env_path.write_text(content, encoding="utf-8")
+
+        parsed = _values(EnvParser().parse(env_path))
+
+        assert parsed == dict(dotenv_values(env_path))
+
+    def test_crlf_file_matches_python_dotenv(self, tmp_path):
+        raw = f'CERT="{PEM_HEADER}\r\n{PEM_BODY_1}\r\n{PEM_FOOTER}"\r\nAFTER=ok\r\n'
+        env_path = tmp_path / ".env"
+        env_path.write_bytes(raw.encode("utf-8"))
+
+        parsed = _values(EnvParser().parse(env_path))
+
+        assert parsed == dict(dotenv_values(env_path))
+
+    def test_pydantic_settings_loads_identical_multiline_value(self, tmp_path):
+        """The same file, loaded by a real pydantic-settings class, yields the
+        exact value the parser reports (newlines included)."""
+        from pydantic_settings import BaseSettings, SettingsConfigDict
+
+        env_path = tmp_path / ".env"
+        env_path.write_text(f'CERT="{PEM_VALUE}"\n', encoding="utf-8")
+
+        class Settings(BaseSettings):
+            model_config = SettingsConfigDict(
+                env_file=str(env_path), env_file_encoding="utf-8", extra="ignore"
+            )
+
+            CERT: str
+
+        loaded = Settings()
+        parsed = EnvParser().parse(env_path)
+
+        assert loaded.CERT == parsed.variables["CERT"].value == PEM_VALUE


### PR DESCRIPTION
## Summary

`EnvParser.parse_string` matched `KEY=value` per **physical** line, so a quoted multiline value
(e.g. a PEM certificate) was **truncated** to its first line — keeping the stray opening quote —
and its interior lines were **re-parsed as phantom variables**. python-dotenv (and therefore
pydantic-settings, validate's ground truth) treats the value as continuing until the matching
close quote.

Consequences fixed here:

- **validate**: a phantom variable could satisfy a required field → **false PASS** (exit 0 even
  with `--ci`); phantom extras also produced false FAILs under `extra="forbid"`.
- **diff**: drift hidden past a value's first line compared equal → **false no-drift**; real drift
  was attributed to phantom variable names.
- **encrypt --check**: phantom variables with sensitive-looking names (e.g. `DB_PASSWORD`) were
  classified as plaintext secrets and **blocked commits** on variables the user never wrote.

## Fix

- `parse_string` now lexes quoted values like python-dotenv: a value opened with `"`/`'` continues
  across physical lines to the matching **unescaped** close quote (escape-aware scan — `\"`/`\'`
  never close), with newlines preserved and CRLF input normalizing to LF exactly like dotenv.
- python-dotenv's quoted-value **escape sets are decoded** (`\\ \' \" \a \b \f \n \r \t \v` in
  double quotes; `\\ \'` in single quotes) so parsed values match pydantic-settings byte-for-byte.
- Unterminated quotes (and a close quote followed by non-comment junk) keep the **legacy per-line
  fallback**, so malformed files parse exactly as before.
- Continuation applies to both strict and lenient (`validate`) parsing; `raw_line` keeps all
  physical lines and line numbers resume after the value.
- Docs updated: `docs/cli/validate.md`, `docs/concepts/how-it-works.md`.

## Test evidence (fail-then-pass)

Regression tests were written first and run on the base branch
(`origin/fix/472-validate-pydantic-parity`, 2e573b8):

```text
$ uv run pytest tests/unit/test_parser_multiline.py tests/integration/test_multiline_parsing_cli.py
26 failed, 5 passed   # truncation, phantom vars, false PASS (exit 0 with --ci),
                      # false no-drift, encrypt --check exit 1 naming phantom DB_PASSWORD
```

With the fix (490ac70):

```text
$ uv run pytest tests/unit/test_parser_multiline.py tests/integration/test_multiline_parsing_cli.py
31 passed
$ uv run pytest -m "not integration" -q     # full unit lane
2634 passed, 2 skipped
$ uv run pytest -m integration -q           # full integration lane
333 passed, 13 skipped
```

Coverage: `src/envdrift/core/parser.py` 96% (≥ 80% gate). Tests include in-process
**byte-for-byte parity** with real `dotenv.dotenv_values` and a real pydantic-settings class
loading the same multiline fixture, plus a CRLF (Windows) fixture; PEM-like fixture literals are
built by concatenation. ruff / ruff format / pyrefly / bandit / `make lint-docs` all green.

Fixes #458

**Stacked on #517 — merge that first** (this PR targets `fix/472-validate-pydantic-parity` and
retargets to `main` when #517 merges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jainal09/envdrift/pull/529?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes `EnvParser.parse_string` so that quoted multiline values (e.g. PEM certificates) are lexed the same way python-dotenv / pydantic-settings lex them, eliminating false PASS/FAIL verdicts in `validate`, hidden drift in `diff`, and phantom plaintext-secret blocks in `encrypt --check`.

- `_continue_quoted_value` extends the raw RHS across physical lines until the matching unescaped close quote is found, with an unterminated-quote or trailing-junk fallback that preserves legacy per-line behaviour for malformed files.
- `_match_quoted_value` + `_decode_escapes` now handle escape decoding for both single-line and multiline quoted values, matching python-dotenv's escape sets exactly; tests include byte-for-byte parity checks against `dotenv.dotenv_values` and a live pydantic-settings class.
- The `raw_line` field is widened to cover all physical lines consumed by a multiline value, and line numbers resume correctly after the value ends.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the multiline lexing logic is correct and the test suite provides strong byte-for-byte parity coverage against python-dotenv and pydantic-settings.

The core parsing algorithm is logically sound across all edge cases examined — escaped quotes, CRLF normalisation, unterminated-quote fallback, trailing-junk rejection, lenient mode. The three findings are quality concerns rather than correctness defects: _decode_escapes passes a str to a bytes codec via undocumented CPython behaviour, _continue_quoted_value rescans the entire accumulated string on each iteration containing the quote character, and the early-exit-on-trailing-junk invariant is load-bearing but undocumented. None affect results for any input covered by the test suite.

src/envdrift/core/parser.py — specifically _decode_escapes and _continue_quoted_value

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/envdrift/core/parser.py | Core parser rewritten to lex quoted multiline values like python-dotenv; logic is correct but _decode_escapes relies on undocumented codecs.decode(str, unicode-escape) behaviour, and _continue_quoted_value rescans the entire joined string on each iteration (O(n²)). |
| tests/unit/test_parser_multiline.py | Comprehensive regression suite covering double/single quotes, escape sequences, CRLF normalisation, line-number resumption, raw_line preservation, unterminated-quote fallback, and byte-for-byte parity with python-dotenv and pydantic-settings; no issues found. |
| tests/integration/test_multiline_parsing_cli.py | End-to-end CLI tests for validate, diff, and encrypt --check commands against multiline fixtures; uses subprocess correctly with a deterministic environment fixture; no issues found. |
| docs/cli/validate.md | Documents the new multiline quoting behaviour and escape decoding rules accurately. |
| docs/concepts/how-it-works.md | Minor copy update to step 2 of the validate description; accurate. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant C as Caller
    participant PS as parse_string
    participant CQV as _continue_quoted_value
    participant FCQ as _find_close_quote
    participant VFR as value_from_raw
    participant MQV as _match_quoted_value
    participant DE as _decode_escapes

    C->>PS: parse_string(content)
    loop each physical line
        PS->>PS: regex match → key, raw_value
        PS->>CQV: (raw_value, lines, index)
        CQV->>FCQ: raw_value stripped
        FCQ-->>CQV: None — no close quote on this line
        loop each continuation line
            CQV->>CQV: "joined += newline + next_line"
            alt quote char not in next_line
                CQV->>CQV: continue — skip rescan
            else quote char present
                CQV->>FCQ: lstripped — entire joined string
                FCQ-->>CQV: close position or None
                alt trailing is whitespace or comment
                    CQV-->>PS: joined, consumed
                else junk after close quote
                    CQV-->>PS: raw_value, 0 — legacy fallback
                end
            end
        end
        PS->>VFR: joined_raw
        VFR->>MQV: raw_value.strip()
        MQV->>FCQ: text
        FCQ-->>MQV: close position
        MQV->>DE: inner text between quotes
        DE-->>MQV: decoded value
        MQV-->>VFR: decoded value
        VFR-->>PS: final string value
        PS->>PS: detect encryption, build EnvVar
    end
    PS-->>C: EnvFile
```

<sub>Reviews (1): Last reviewed commit: ["fix(parser): parse quoted multiline valu..."](https://github.com/jainal09/envdrift/commit/490ac70f2677343e15bf77b377544e2b3e5122ce) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37247078)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->