### PR TITLE
Solution: ci: local compose stack re-diverged from CI images; renovate PR copy cla

### DIFF
--- a/h
+++ b/h
@@ -1,0 +1,4 @@
+# Merge PR
+git checkout main
+git pull origin main
+git merge <PR-number>

--- a/path/to/README.md
+++ b/path/to/README.md
@@ -1,0 +1,19 @@
+# README.md
+## Test Stack
+
+Our test stack is composed of the following services:
+
+* Localstack: `localstack/localstack:4.14`
+* Lowkey-vault: `lowkey/vault:7.2.26`
+
+## Automerge Workflow
+
+Our automerge workflow is designed to automate the process of merging minor and patch updates. However, if review is required, the workflow will gate automerge on approval.
+
+## Contributing
+
+Contributions are welcome! Please see our contributing guidelines for more information.
+
+## License
+
+Our project is licensed under the MIT License.

--- a/path/to/automerge-version-bump.yml
+++ b/path/to/automerge-version-bump.yml
@@ -1,0 +1,32 @@
+// automerge-version-bump.yml
+name: Automerge Version Bump
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Automerge
+        run: |
+          # Check if review is required
+          if [ "${GITHUB_EVENT_NAME}" == "pull_request" ]; then
+            # Check if review is approved
+            if [ "${GITHUB_EVENT_DATA.action}" == "opened" ]; then
+              # Gate automerge on approval
+              echo "Waiting for approval..."
+              exit 1
+            fi
+          fi
+
+          # Automerge
+          echo "Automerging..."
+          git add .
+          git commit -m "Automerge"
+          git push

--- a/path/to/integration-tests.yml
+++ b/path/to/integration-tests.yml
@@ -1,0 +1,25 @@
+# integration-tests.yml
+name: Integration Tests
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Build and test
+        run: |
+          docker-compose up -d
+          docker-compose exec localstack /bin/bash -c "aws sts get-caller-identity"
+          docker-compose exec lowkey-vault /bin/bash -c "vault login -method=userpass username=myuser password=mypassword"
+
+      - name: Keep-in-sync
+        run: |
+          docker-compose exec localstack /bin/bash -c "echo 'keep-in-sync' > /etc/localstack/keep-in-sync"
+          docker-compose exec lowkey-vault /bin/bash -c "echo 'keep-in-sync' > /etc/lowkey-vault/keep-in-sync"

--- a/path/to/renovate.json
+++ b/path/to/renovate.json
@@ -1,0 +1,11 @@
+// renovate.json
+{
+  "extends": ["config:base"],
+  "packageRules": [
+    {
+      "match": "hashicorp/vault",
+      "version": "^1.21",
+      "prBodyTemplate": "Minor/Patch updates: Auto-merged on green CI"
+    }
+  ]
+}

--- a/path/to/tests/docker-compose.test.yml
+++ b/path/to/tests/docker-compose.test.yml
@@ -1,0 +1,37 @@
+# tests/docker-compose.test.yml
+version: '3'
+
+services:
+  localstack:
+    image: localstack/localstack:4.14
+    ports:
+      - "4566:4566"
+    environment:
+      - AWS_ACCESS_KEY_ID=foo
+      - AWS_SECRET_ACCESS_KEY=bar
+      - DEFAULT_REGION=us-east-1
+      - SERVICES=aws-lambda,cloudformation,cloudwatch,dynamodb,dynamodb-local,kinesis,kinesis-video,kms,logs,lambda,ses,sqs,s3
+      - DEBUG=true
+      - DATA_DIR=/tmp/localstack/data
+      - LAMBDA_EXECUTOR=docker
+      - LAMBDA_RUNTIME_DIR=/tmp/localstack/lambda
+      - LAMBDA_VPC_ID=vpc-12345678
+      - LAMBDA_VPC_SUBNET_ID=subnet-12345678
+      - LAMBDA_VPC_SECURITY_GROUP_ID=sg-12345678
+      - LAMBDA_FUNCTION_HANDLER=index.handler
+      - LAMBDA_FUNCTION_NAME=my-lambda-function
+      - LAMBDA_ROLE_ARN=arn:aws:iam::123456789012:role/lambda-execution-role
+    labels:
+      - keep-in-sync
+
+  lowkey-vault:
+    image: lowkey/vault:7.2.26
+    ports:
+      - "8200:8200"
+    environment:
+      - VAULT_ADDR=http://localhost:8200
+      - VAULT_FORMAT=json
+      - VAULT_SKIP_VERIFY=true
+      - VAULT_TOKEN=example
+    labels:
+      - keep-in-sync


### PR DESCRIPTION
## Solution
This PR addresses #500.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jainal09/envdrift/pull/557?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds CI infrastructure — a Renovate config, a test Docker Compose stack, an integration-test workflow, and an automerge workflow — to keep the local compose stack and CI images in sync. However, most of the new files contain blocking defects that prevent them from working at all.

- `renovate.json` is invalid JSON (leading `//` comment), uses non-existent field names (`match`, `version`), and tracks `hashicorp/vault` instead of the actual `lowkey/vault` image used in the compose file.
- `automerge-version-bump.yml` starts with a `//` line that breaks YAML parsing; the automerge logic checks for a `pull_request` event on a `push`-only trigger and ends with an unguarded `git push` to `main` on every commit.
- `integration-tests.yml` embeds plaintext vault credentials and omits the `-f` flag, so `docker-compose up` will not find the test compose file.
- A stray file named `h` containing raw git notes should be removed from the repo root.

<h3>Confidence Score: 2/5</h3>

Not safe to merge — multiple new files are either completely non-functional or introduce a direct write-access risk to the main branch.

The automerge workflow will unconditionally run `git push` to `main` on every push event, the two new GitHub Actions workflows cannot even be parsed due to invalid syntax, the Renovate config is invalid JSON with the wrong field names pointing at the wrong image, and plaintext vault credentials are embedded in the integration-test workflow. Together these issues mean none of the intended CI automation will work, and the automerge workflow would actively corrupt the branch if the YAML parse error were fixed without addressing the logic.

All new files need attention: `h` must be deleted; `path/to/automerge-version-bump.yml` and `path/to/renovate.json` need to be rewritten from scratch; `path/to/integration-tests.yml` needs the compose file flag and credential handling fixed; `path/to/tests/docker-compose.test.yml` needs the Docker socket mount added.

<details open><summary><h3>Security Review</h3></summary>

- **Hardcoded credentials** in `path/to/integration-tests.yml` (line 21): `vault login` is called with plaintext `username=myuser password=mypassword` baked into the workflow file, committed to git history and visible to anyone with repo read access. Credentials must be moved to GitHub Actions secrets.
- **Unguarded `git push` to `main`** in `path/to/automerge-version-bump.yml` (lines 28–30): the workflow runs `git add . && git commit && git push` on every push to `main` with no condition, giving any actor who can trigger the workflow the ability to push arbitrary commits to the protected branch.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| h | Stray scratch file containing raw git commands with a literal `<PR-number>` placeholder — should be deleted before merge. |
| path/to/renovate.json | Invalid JSON due to `//` comment, wrong field names (`match`/`version` instead of `matchPackageNames`/`allowedVersions`), and tracks `hashicorp/vault` while compose uses `lowkey/vault` — the rule will never fire. |
| path/to/automerge-version-bump.yml | Unparseable YAML due to `//` comment on line 1; automerge logic checks for `pull_request` event but trigger is `push`; uses invalid bash variable syntax; unconditional `git push` to main on every push event. |
| path/to/integration-tests.yml | Hardcoded vault credentials, missing `-f` flag for docker-compose, and outdated `actions/checkout@v2`; tests will fail at runtime because no compose file is resolved. |
| path/to/tests/docker-compose.test.yml | Service definitions look structurally correct, but `LAMBDA_EXECUTOR=docker` requires a Docker socket mount that is absent, and the image name doesn't align with what Renovate is configured to track. |
| path/to/README.md | Informational README describing the test stack and automerge workflow; content is accurate relative to the other files, no issues found. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Dev as Developer
    participant GH as GitHub Actions
    participant RC as Renovate
    participant DC as Docker Compose (test)

    Dev->>GH: push to main
    GH->>GH: automerge-version-bump.yml (FAILS: invalid YAML)
    GH->>GH: integration-tests.yml triggers
    GH->>DC: docker-compose up -d (no -f flag → wrong file)
    DC-->>GH: service startup fails
    GH->>DC: exec localstack / lowkey-vault (FAILS: services not running)

    RC->>RC: parse renovate.json (FAILS: invalid JSON)
    RC-->>Dev: no package rule applied (hashicorp/vault mismatch)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Dev as Developer
    participant GH as GitHub Actions
    participant RC as Renovate
    participant DC as Docker Compose (test)

    Dev->>GH: push to main
    GH->>GH: automerge-version-bump.yml (FAILS: invalid YAML)
    GH->>GH: integration-tests.yml triggers
    GH->>DC: docker-compose up -d (no -f flag → wrong file)
    DC-->>GH: service startup fails
    GH->>DC: exec localstack / lowkey-vault (FAILS: services not running)

    RC->>RC: parse renovate.json (FAILS: invalid JSON)
    RC-->>Dev: no package rule applied (hashicorp/vault mismatch)
```

</a>

<sub>Reviews (1): Last reviewed commit: ["Solution for #500"](https://github.com/jainal09/envdrift/commit/3edf13ba0f1cdafa2864b77f703a05701cce21a5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41089853)</sub>

> Greptile also left **9 inline comments** on this PR.

<!-- /greptile_comment -->