### PR TITLE
fix(install): retry atomic-install rename on Windows PermissionError

### DIFF
--- a/src/envdrift/install_integrity.py
+++ b/src/envdrift/install_integrity.py
@@ -22,6 +22,7 @@ import shutil
 import stat
 import sys
 import tempfile
+import time
 import urllib.request
 from pathlib import Path
 
@@ -65,6 +66,31 @@ def sha256_file(path: Path) -> str:
     return digest.hexdigest()
 
 
+def _replace_with_windows_retry(staging_path: Path, target_path: Path) -> None:
+    """Atomically rename ``staging_path`` onto ``target_path``.
+
+    On POSIX ``os.replace`` always succeeds atomically. On Windows it raises
+    ``PermissionError`` (``Access is denied``) when the target is momentarily
+    held open by another process — which happens when several installs of the
+    same binary race on one target. Retry briefly so concurrent installs
+    converge instead of one spuriously failing; a genuine permission error
+    still surfaces after the short window is exhausted.
+    """
+    if platform.system() != "Windows":
+        staging_path.replace(target_path)
+        return
+    delay = 0.02
+    for _ in range(9):
+        try:
+            staging_path.replace(target_path)
+            return
+        except PermissionError:
+            time.sleep(delay)
+            delay = min(delay * 2, 0.5)
+    # Final attempt: let a persistent PermissionError propagate to the caller.
+    staging_path.replace(target_path)
+
+
 def atomic_install(source: Path, target_path: Path, *, make_executable: bool = True) -> None:
     """Install ``source`` onto ``target_path`` atomically (stage + rename).
 
@@ -101,7 +127,7 @@ def atomic_install(source: Path, target_path: Path, *, make_executable: bool = T
             staging_path.chmod(
                 staging_path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
             )
-        staging_path.replace(target_path)
+        _replace_with_windows_retry(staging_path, target_path)
     finally:
         # Cleanup must never mask the real error (a non-FileNotFound OSError
         # from unlink would otherwise propagate over the copy/rename failure).


### PR DESCRIPTION
## Problem
The **Cross-Platform Tests** are red on `main` (windows-latest, both Python versions): `tests/unit/test_download_integrity.py::TestInstallIntegrityHelpers::test_atomic_install_concurrent_calls_do_not_corrupt` fails with `PermissionError(13, 'Access is denied')`.

## Root cause
`atomic_install` (added in #519) finishes with `staging_path.replace(target_path)`. On POSIX that rename is always atomic. On **Windows**, `os.replace` raises `PermissionError` when the target is momentarily held open by another process — which is exactly what happens when several installs of the same binary race on one target. The PR's Windows CI passed by timing luck; the collision is real.

## Fix
Retry the rename briefly on Windows `PermissionError` (bounded, exponential backoff capped at 0.5s) so concurrent installs converge instead of one spuriously failing. A genuine, persistent permission error still surfaces after the short window. POSIX behaviour is unchanged.

## Verification (real Windows, Python 3.14 via WSL interop)
Standalone 8-concurrent-install repro against one target:
- **pre-fix (current main):** 7/8 workers raised `PermissionError(13, 'Access is denied')` — reproduces the CI failure exactly.
- **post-fix:** 0 errors, target is one complete payload, no staging leftovers.

The existing `test_atomic_install_concurrent_calls_do_not_corrupt` is the regression test — it passes on POSIX and now passes on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PmjB1wAMY8zyHpkF2zzmCj

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jainal09/envdrift/pull/587?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a Windows retry path for atomic install renames. The main changes are:

- Adds `time` for bounded backoff sleeps.
- Wraps the final staging-to-target rename in `_replace_with_windows_retry`.
- Keeps the direct `Path.replace` behavior on non-Windows platforms.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- Persistent rename failures still propagate to callers.
- The existing staging cleanup path still runs after successful and failed rename attempts.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/envdrift/install_integrity.py | Adds a narrow Windows-only retry loop for transient `PermissionError` during the final atomic rename. |

<sub>Reviews (1): Last reviewed commit: ["fix(install): retry the atomic-install r..."](https://github.com/jainal09/envdrift/commit/072bd14b10184e926edab8e6c492d2a85ea1c67a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42480838)</sub>

<!-- /greptile_comment -->