### PR TITLE
fix(hook): make encryption checks complete

### DIFF
--- a/docs/cli/encrypt.md
+++ b/docs/cli/encrypt.md
@@ -29,7 +29,7 @@ exit code (dotenvx can exit `0` without encrypting):
 - **Refuses content-free files.** An empty, blank-line-only, or comment-only file
   has no variables to encrypt, so the command declines with a non-zero exit
   instead of letting dotenvx scaffold a placeholder-secrets template into it.
-- **Refuses the key store and companion files.** `envdrift encrypt .env.keys`
+- **Refuses key stores and companion files when encrypting.** `envdrift encrypt .env.keys`
   would encrypt the dotenvx private-key store itself — the keys become
   ciphertext under a brand-new keypair whose private half is never saved,
   permanently locking out every encrypted file in the project — so the command
@@ -37,7 +37,9 @@ exit code (dotenvx can exit `0` without encrypting):
   every backend. The name match is case-insensitive (`.env.KEYS` names the
   same file on macOS/Windows default filesystems), and a renamed or symlinked
   key store (`mv .env.keys prodkeys.env`) is still refused by content: a file
-  carrying `DOTENV_PRIVATE_KEY*` entries is never encrypted.
+  carrying `DOTENV_PRIVATE_KEY*` entries is never encrypted. With `--check`,
+  companions are instead reported as skipped so a pre-commit filename batch
+  still checks its secret stores.
 - **Handles leading-dash filenames.** A file like `-dash.env` is passed to
   dotenvx as `./-dash.env` so its CLI cannot misparse the name as flags
   (which previously fabricated a different file full of placeholder secrets).
@@ -54,11 +56,11 @@ exit code (dotenvx can exit `0` without encrypting):
   re-read after the call; if any plaintext value survives, the command fails
   loudly instead of printing `[OK]`.
 
-Multiple env files can be passed in one invocation. With `--check`, each file gets
-its own report and the exit code is 1 if any file should block a commit — this keeps
-the command usable as a pre-commit `pass_filenames: true` hook, where every matched
-staged file is appended to a single command line. Without `--check`, each file is
-encrypted in turn.
+Multiple env files can be passed in one invocation. With `--check`, each secret
+store gets its own report, plaintext companions are skipped, and the exit code is 1
+if any file should block a commit — this keeps the command usable as a pre-commit
+`pass_filenames: true` hook, where every matched staged file is appended to a single
+command line. Without `--check`, each file is encrypted in turn.
 
 ## Arguments
 

--- a/src/envdrift/cli_commands/encryption.py
+++ b/src/envdrift/cli_commands/encryption.py
@@ -8,12 +8,13 @@ Supports multiple encryption backends:
 from __future__ import annotations
 
 import shlex
+from collections.abc import Callable
 from pathlib import Path
 from typing import Annotated
 
 import typer
 
-from envdrift.core.encryption import EncryptionDetector
+from envdrift.core.encryption import EncryptionDetector, EncryptionReport
 from envdrift.core.parser import EnvParser
 from envdrift.core.schema import SchemaLoader, SchemaLoadError
 from envdrift.encryption import EncryptionProvider, get_encryption_backend
@@ -99,6 +100,46 @@ def _refuse_companion_target(env_file: Path, action: str) -> None:
             "file (.example/.sample/.template), not a secret store."
         )
     raise typer.Exit(code=1)
+
+
+def _is_companion_target(env_file: Path) -> bool:
+    """Return whether ``env_file`` is a plaintext companion, by filename."""
+    from envdrift.env_files import _is_excluded_env_file
+
+    return _is_excluded_env_file(env_file.name)
+
+
+def _refuse_companion_targets(
+    files: list[Path],
+    action: str,
+    *,
+    allow_plaintext_companions: bool,
+) -> None:
+    """Refuse companion files unless this is a non-destructive check batch."""
+    if allow_plaintext_companions:
+        return
+    for env_file in files:
+        _refuse_companion_target(env_file, action)
+
+
+def _check_files_and_report(
+    files: list[Path],
+    analyze_file: Callable[[Path], EncryptionReport],
+    detector: EncryptionDetector,
+) -> bool:
+    """Print check reports and return whether any non-companion file blocks a commit."""
+    should_block = False
+    for env_file in files:
+        if _is_companion_target(env_file):
+            print_warning(
+                f"Skipping {env_file}: it is a plaintext companion file, not a secret store."
+            )
+            continue
+        report = analyze_file(env_file)
+        print_encryption_report(report)
+        if detector.should_block_commit(report):
+            should_block = True
+    return should_block
 
 
 def _protect_private_keys(env_file: Path) -> None:
@@ -248,12 +289,14 @@ def encrypt_cmd(
             print_error(f"ENV file not found: {env_file}")
         raise typer.Exit(code=1)
 
-    # Refuse companion targets (.keys/.example/.sample/.template) across ALL
-    # requested files — the default single [.env] and every multi-file target —
-    # before touching any of them, so one companion in a batch aborts the whole
-    # invocation with nothing encrypted (#474).
-    for env_file in files:
-        _refuse_companion_target(env_file, "encrypt")
+    # A check invocation can receive a broad pre-commit filename batch. It
+    # permits plaintext companions while the check helper skips them, whereas
+    # a destructive invocation refuses every companion target (#579).
+    _refuse_companion_targets(
+        files,
+        "encrypt",
+        allow_plaintext_companions=check,
+    )
 
     if verify_vault or vault_provider or vault_url or vault_region or vault_secret:
         print_error("Vault verification moved to `envdrift decrypt --verify-vault ...`")
@@ -315,7 +358,7 @@ def encrypt_cmd(
     parser = EnvParser()
     detector = EncryptionDetector()
 
-    def _analyze_file(env_file: Path):
+    def _analyze_file(env_file: Path) -> EncryptionReport:
         """Parse and analyze one env file, exiting cleanly on unreadable input."""
         try:
             # lenient=True so --check analyzes every KEY=value assignment dotenvx
@@ -328,7 +371,11 @@ def encrypt_cmd(
             print_error(str(e))
             raise typer.Exit(code=1) from None
 
-        report = detector.analyze(env, schema_meta)
+        report = detector.analyze(
+            env,
+            schema_meta,
+            include_overridden_assignments=check,
+        )
         detected_backend = detector.detect_backend_for_file(env_file)
         if detected_backend:
             report.detected_backend = detected_backend
@@ -337,15 +384,7 @@ def encrypt_cmd(
         return report
 
     if check:
-        # Report status per file; block if any file would block a commit.
-        should_block = False
-        for env_file in files:
-            report = _analyze_file(env_file)
-            print_encryption_report(report)
-            if detector.should_block_commit(report):
-                should_block = True
-
-        if should_block:
+        if _check_files_and_report(files, _analyze_file, detector):
             raise typer.Exit(code=1)
     else:
         # Analyze every target before touching any backend: unreadable input and

--- a/src/envdrift/core/encryption.py
+++ b/src/envdrift/core/encryption.py
@@ -150,6 +150,8 @@ class EncryptionDetector:
         self,
         env_file: EnvFile,
         schema: SchemaMetadata | None = None,
+        *,
+        include_overridden_assignments: bool = False,
     ) -> EncryptionReport:
         """
         Analyze an EnvFile to determine which variables are encrypted, plaintext, empty, and which plaintext values appear to be secrets.
@@ -157,6 +159,10 @@ class EncryptionDetector:
         Parameters:
             env_file (EnvFile): Parsed env file to analyze.
             schema (SchemaMetadata | None): Optional schema whose sensitive_fields will be treated as sensitive names.
+            include_overridden_assignments: Analyze every accepted assignment,
+                including occurrences hidden by a later duplicate. This is for
+                on-disk safety checks; normal config semantics remain
+                last-assignment-wins.
 
         Returns:
             EncryptionReport: Report containing the file path, sets of encrypted/plaintext/empty variables, detected plaintext secrets, collected warnings, and the is_fully_encrypted flag.
@@ -166,7 +172,11 @@ class EncryptionDetector:
         # Get sensitive fields from schema
         schema_sensitive = set(schema.sensitive_fields) if schema else set()
 
-        for var_name, env_var in env_file.variables.items():
+        assignments = env_file.variables.values()
+        if include_overridden_assignments and env_file.assignments:
+            assignments = env_file.assignments
+        for env_var in assignments:
+            var_name = env_var.name
             # dotenvx's DOTENV_PUBLIC_KEY* artifact is a public key: always
             # plaintext, safe to commit, and never a value to encrypt. Skip it so it
             # neither counts as a plaintext var (which would keep is_fully_encrypted
@@ -206,9 +216,7 @@ class EncryptionDetector:
             report.is_fully_encrypted = len(report.plaintext_vars) == 0
 
         detected_backends = {
-            env_var.encryption_backend
-            for env_var in env_file.variables.values()
-            if env_var.encryption_backend
+            env_var.encryption_backend for env_var in assignments if env_var.encryption_backend
         }
         if len(detected_backends) == 1:
             report.detected_backend = next(iter(detected_backends))

--- a/src/envdrift/core/parser.py
+++ b/src/envdrift/core/parser.py
@@ -60,6 +60,10 @@ class EnvFile:
 
     path: Path
     variables: dict[str, EnvVar] = field(default_factory=dict)
+    # ``variables`` mirrors python-dotenv's last-assignment-wins lookup. Keep
+    # every accepted assignment too: safety checks must see a plaintext secret
+    # that a later encrypted duplicate would otherwise hide (#583).
+    assignments: list[EnvVar] = field(default_factory=list)
     comments: list[str] = field(default_factory=list)
     # True when the source text began with a UTF-8 BOM (U+FEFF). The parser
     # strips it so reports name the variable the user wrote — but
@@ -360,6 +364,7 @@ class EnvParser:
                 encryption_backend=encryption_backend,
             )
 
+            env_file.assignments.append(env_var)
             env_file.variables[key] = env_var
 
         return env_file

--- a/src/envdrift/integrations/precommit.py
+++ b/src/envdrift/integrations/precommit.py
@@ -249,6 +249,16 @@ def _fresh_config_text(hook_ids: list[str]) -> str:
     return "repos:\n" + _render_repo_block(hook_ids, "  ")
 
 
+def _create_missing_config(config_path: Path, create_if_missing: bool) -> None:
+    """Create a fresh config, or explain why an absent explicit path is an error."""
+    if not create_if_missing:
+        raise FileNotFoundError(
+            f"Pre-commit config not found: {config_path}. "
+            "Run from repository root or specify --config path."
+        )
+    config_path.write_text(_fresh_config_text(_active_hook_ids()), encoding="utf-8")
+
+
 def _block_sequence_indent(repos_value: Any) -> str:
     """Indent (dash column) of an existing block-style repos sequence."""
     return " " * repos_value.start_mark.column
@@ -358,7 +368,7 @@ def install_hooks(
             )
 
     if not config_path.exists():
-        config_path.write_text(_fresh_config_text(_active_hook_ids()), encoding="utf-8")
+        _create_missing_config(config_path, create_if_missing)
         return True
 
     content = _read_config_text(config_path)

--- a/tests/integration/test_hook_generated_config.py
+++ b/tests/integration/test_hook_generated_config.py
@@ -133,6 +133,51 @@ class TestGeneratedConfigRunsAsEmitted:
         )
         assert result.returncode == 1, _diag(result)
 
+    def test_encrypt_check_skips_companions_and_checks_remaining_files(
+        self, tmp_path: Path
+    ) -> None:
+        """A companion must not abort a pre-commit filename batch (#579)."""
+        env = _cli_env(tmp_path)
+        (tmp_path / ".env.production").write_text("API_KEY=plaintext-value\n", encoding="utf-8")
+        (tmp_path / ".env.example").write_text("API_KEY=example-value\n", encoding="utf-8")
+
+        result = _run_envdrift(
+            ["encrypt", "--check", ".env.production", ".env.example"], cwd=tmp_path, env=env
+        )
+        output = " ".join((result.stdout + result.stderr).split())
+
+        assert result.returncode == 1, _diag(result)
+        assert ".env.production" in output
+        assert "Skipping .env.example" in output
+
+    def test_encrypt_check_skips_a_companion_only_batch(self, tmp_path: Path) -> None:
+        """Named plaintext companions are intentionally outside encryption policy (#579)."""
+        env = _cli_env(tmp_path)
+        (tmp_path / ".env.example").write_text("API_KEY=example-value\n", encoding="utf-8")
+
+        result = _run_envdrift(["encrypt", "--check", ".env.example"], cwd=tmp_path, env=env)
+        output = " ".join((result.stdout + result.stderr).split())
+
+        assert result.returncode == 0, _diag(result)
+        assert "Skipping .env.example" in output
+        assert "Encryption Status" not in output
+
+    def test_encrypt_check_blocks_plaintext_duplicate_shadowed_by_ciphertext(
+        self, tmp_path: Path
+    ) -> None:
+        """Every on-disk assignment must be checked, not just the last duplicate (#583)."""
+        env = _cli_env(tmp_path)
+        (tmp_path / ".env.production").write_text(
+            'SECRET_KEY=plaintext-value\nSECRET_KEY="encrypted:BDqDBJ24bUq3x"\n',
+            encoding="utf-8",
+        )
+
+        result = _run_envdrift(["encrypt", "--check", ".env.production"], cwd=tmp_path, env=env)
+        output = " ".join((result.stdout + result.stderr).split())
+
+        assert result.returncode == 1, _diag(result)
+        assert "Plaintext: 1" in output
+
     def test_validate_hook_entry_with_schema_accepts_multiple_files(self, tmp_path: Path) -> None:
         """The documented validate hook entry works with 2 staged files appended."""
         env = _cli_env(tmp_path)

--- a/tests/integration/test_scanner_git_tools.py
+++ b/tests/integration/test_scanner_git_tools.py
@@ -258,6 +258,10 @@ class TestGitSecretsRealBinary:
         assert len(result.findings) >= 1, "git-secrets finding (emitted on stderr) was not captured"
         assert any("aws" in f.rule_id for f in result.findings)
 
+    @pytest.mark.xfail(
+        strict=False,
+        reason="git-secrets scans its registered Bedrock pattern in .git/config (see #581)",
+    )
     def test_scan_clean_repo_has_no_findings(self, scanner_test_env):
         """scan() of a repo without secrets yields no findings and no error."""
         work_dir = scanner_test_env["work_dir"]

--- a/tests/scanner/test_output.py
+++ b/tests/scanner/test_output.py
@@ -445,6 +445,10 @@ class TestRichOutput:
         assert "aws-access-key-id" in out  # Rule kept for CI triage
         assert "AKIA1234" in out  # Preview kept
 
+    @pytest.mark.xfail(
+        strict=False,
+        reason="format_rich ignores the supplied wide Console under pytest capture (see #441)",
+    )
     def test_format_rich_wide_terminal_shows_all_columns(self):
         """Wide terminal shows the Rule and Preview columns too."""
         console = Console(record=True, force_terminal=True, width=140)
@@ -474,6 +478,10 @@ class TestRichOutput:
         format_rich(self._aws_finding_result(), console)
         assert "AKIA1234" not in console.export_text()
 
+    @pytest.mark.xfail(
+        strict=False,
+        reason="format_rich ignores the supplied wide Console under pytest capture (see #441)",
+    )
     def test_format_rich_threshold_100_is_wide(self):
         """Width 100 (exactly the threshold) shows the secondary Preview column."""
         console = Console(record=True, force_terminal=True, width=100)

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -22,6 +22,19 @@ class TestEnvParser:
         assert result.variables["FOO"].value == "bar"
         assert result.variables["BAZ"].value == "qux"
 
+    def test_duplicate_assignments_keep_audit_history_and_last_value(self, tmp_path):
+        """Lookup remains last-wins while safety checks can inspect every line (#583)."""
+        env_file = tmp_path / ".env"
+        env_file.write_text(
+            'SECRET_KEY=plaintext-value\nSECRET_KEY="encrypted:BDqDBJ24bUq3x"\n',
+            encoding="utf-8",
+        )
+
+        result = EnvParser().parse(env_file)
+
+        assert result.variables["SECRET_KEY"].is_encrypted
+        assert [assignment.line_number for assignment in result.assignments] == [1, 2]
+
     def test_parse_quoted_values(self, tmp_path):
         """Parse KEY="value" and KEY='value'."""
         content = """

--- a/tests/unit/test_precommit.py
+++ b/tests/unit/test_precommit.py
@@ -209,11 +209,6 @@ class TestInstallHooks:
         with pytest.raises(FileNotFoundError):
             install_hooks(create_if_missing=False)
 
-    @pytest.mark.xfail(
-        strict=False,
-        reason="install_hooks creates an explicit missing config_path even when "
-        "create_if_missing=False (see #580)",
-    )
     def test_explicit_missing_path_respects_create_if_missing_false(self, tmp_path: Path):
         """An explicit missing config_path with create_if_missing=False must raise,
         not silently create the file (docstring contract; see #580)."""


### PR DESCRIPTION
## Summary

Make encryption checks safe and complete when they run from a pre-commit filename batch.

## Changes

- Check every accepted assignment, so a later encrypted duplicate cannot hide an earlier plaintext secret.
- Skip plaintext companion files during `encrypt --check`, while continuing to check other requested secret stores.
- Honor `create_if_missing=False` for an explicit missing pre-commit config path.
- Keep two confirmed scanner-output regressions (#441) and the git-secrets clean-repo regression (#581) runnable as non-strict expected failures until their dedicated fixes land.

## Related issues

Closes #579
Closes #580
Closes #583

Tracks #441 and #581.

## Testing

- [x] `uv run pytest -m "not integration" -q` — 3313 passed, 5 skipped, 2 xfailed, 1 xpassed
- [x] `uv run pytest -m integration -q` with pinned dotenvx 2.1.5 and LocalStack/Vault/Lowkey — 496 passed, 37 skipped, 3 xfailed
- [x] `make lint-docs`
- [x] `uv run ruff check src tests`, `uv run ruff format --check .`, `uv run pyrefly check`, and `uv run bandit -r src -c pyproject.toml`
- [x] CLI dogfood for mixed `.env.production`/`.env.example` input and duplicate plaintext/ciphertext assignments

## Checklist

- [x] New/changed behavior has a **real** regression test (containers/binaries/CLI, not mocks)
- [x] Confirmed-but-unfixed bugs are `xfail(strict=False)` with an issue ref
- [x] Touched files keep **≥ 80%** coverage (CodeCov CI green)
- [x] No hardcoded binary versions — read from `src/envdrift/constants.json` (Renovate-managed)
- [x] `ruff check` / `ruff format` / `pyrefly` / `bandit` clean
- [x] Docs (`docs/`) updated for behavior change
- [x] Any pre-existing bug found was fixed or filed as an issue
- [x] No `FORCE_COLOR`-dependent integration output; no `importlib.reload()` of package modules

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR tightens encryption checks for pre-commit batches and duplicate assignments. The main changes are:

- Skip plaintext companion files during `encrypt --check` while still checking secret stores.
- Track accepted duplicate assignments so hidden plaintext secrets are checked.
- Respect `create_if_missing=False` for explicit missing pre-commit config paths.
- Keep known scanner-output regressions runnable as non-strict expected failures.
- Update docs and tests for the new check behavior.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/envdrift/cli_commands/encryption.py | Adds companion-file skipping for check mode and enables duplicate-assignment analysis for encryption reports. |
| src/envdrift/core/encryption.py | Adds an opt-in path for checking every accepted assignment instead of only last-assignment-wins values. |
| src/envdrift/core/parser.py | Stores accepted assignments in parse order while preserving the existing variable lookup behavior. |
| src/envdrift/integrations/precommit.py | Routes missing config creation through the `create_if_missing` flag. |

<sub>Reviews (4): Last reviewed commit: ["fix(hook): make encryption checks comple..."](https://github.com/jainal09/envdrift/commit/efcb44e05f72983f66274393085cb1903874ceaf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43115601)</sub>

<!-- /greptile_comment -->