### PR TITLE
test(scanner): re-enable the format_rich width regression tests

### DIFF
--- a/tests/scanner/test_output.py
+++ b/tests/scanner/test_output.py
@@ -445,10 +445,6 @@ class TestRichOutput:
         assert "aws-access-key-id" in out  # Rule kept for CI triage
         assert "AKIA1234" in out  # Preview kept
 
-    @pytest.mark.xfail(
-        strict=False,
-        reason="format_rich ignores the supplied wide Console under pytest capture (see #441)",
-    )
     def test_format_rich_wide_terminal_shows_all_columns(self):
         """Wide terminal shows the Rule and Preview columns too."""
         console = Console(record=True, force_terminal=True, width=140)
@@ -478,10 +474,6 @@ class TestRichOutput:
         format_rich(self._aws_finding_result(), console)
         assert "AKIA1234" not in console.export_text()
 
-    @pytest.mark.xfail(
-        strict=False,
-        reason="format_rich ignores the supplied wide Console under pytest capture (see #441)",
-    )
     def test_format_rich_threshold_100_is_wide(self):
         """Width 100 (exactly the threshold) shows the secondary Preview column."""
         console = Console(record=True, force_terminal=True, width=100)


### PR DESCRIPTION
## Why
#591 disabled two passing regression tests by marking them `xfail(strict=False, see #441)`:
`test_format_rich_wide_terminal_shows_all_columns` and `test_format_rich_threshold_100_is_wide`.

Both **pass reliably** — verified on `main`: 3× isolated, the full `test_output.py` (48 passed), and the whole `tests/scanner/` tree (745 passed). Under the xfail they **xpass**. Marking a green test as an expected failure disables real coverage: a future regression in `format_rich`'s wide / threshold-100 column output would fail-as-expected and CI would stay green, hiding it.

This reverts only the two `@pytest.mark.xfail` decorators; the tests are otherwise unchanged and now run as active assertions (verified passing).

## Note
If #441 describes a real console-width bug in some environment, it deserves its **own** reproducing test — not the suppression of tests that currently pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PmjB1wAMY8zyHpkF2zzmCj

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jainal09/envdrift/pull/593?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR re-enables two scanner output regression tests.

- Removes the expected-failure marker from the wide-terminal Rich output test.
- Removes the expected-failure marker from the width-100 Rich output test.
- Leaves the test bodies and assertions unchanged.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| tests/scanner/test_output.py | Re-enables two Rich output width regression tests by removing their xfail markers. |

<sub>Reviews (1): Last reviewed commit: ["test(scanner): re-enable the format\_rich..."](https://github.com/jainal09/envdrift/commit/0722ad2ae0d7a0e13460fd62e4503fbdb8b5c284) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43205927)</sub>

<!-- /greptile_comment -->