### PR TITLE
test(scanner): isolate Rich width tests from host terminals

### DIFF
--- a/tests/scanner/test_output.py
+++ b/tests/scanner/test_output.py
@@ -22,6 +22,11 @@ from envdrift.scanner.output import (
 )
 
 
+def _interactive_console(width: int) -> Console:
+    """Build a fixed-width interactive Console independent of host terminal state."""
+    return Console(record=True, force_terminal=True, width=width, _environ={})
+
+
 class TestJsonOutput:
     """Tests for JSON output formatter."""
 
@@ -421,7 +426,7 @@ class TestRichOutput:
         """Interactive narrow terminal: keep Sev/Location/Description (one line
         each, ellipsized) and drop the Rule/Preview columns.
         """
-        console = Console(record=True, force_terminal=True, width=80)
+        console = _interactive_console(80)
         format_rich(self._aws_finding_result(), console)
         out = console.export_text()
 
@@ -447,7 +452,7 @@ class TestRichOutput:
 
     def test_format_rich_wide_terminal_shows_all_columns(self):
         """Wide terminal shows the Rule and Preview columns too."""
-        console = Console(record=True, force_terminal=True, width=140)
+        console = _interactive_console(140)
         format_rich(self._aws_finding_result(), console)
         out = console.export_text()
 
@@ -470,13 +475,13 @@ class TestRichOutput:
 
     def test_format_rich_threshold_99_is_narrow(self):
         """Width 99 (one below the threshold) drops the secondary Preview column."""
-        console = Console(record=True, force_terminal=True, width=99)
+        console = _interactive_console(99)
         format_rich(self._aws_finding_result(), console)
         assert "AKIA1234" not in console.export_text()
 
     def test_format_rich_threshold_100_is_wide(self):
         """Width 100 (exactly the threshold) shows the secondary Preview column."""
-        console = Console(record=True, force_terminal=True, width=100)
+        console = _interactive_console(100)
         format_rich(self._aws_finding_result(), console)
         assert "AKIA1234" in console.export_text()
 


### PR DESCRIPTION
## Summary

Make the active Rich wide-terminal layout assertions independent of the host terminals capture state.

## Changes

- Keep `format_rich` on Richs public `console.width` behavior.
- Construct fixed-width interactive test consoles with Richs controlled environment, so their configured width remains deterministic.
- Preserve the active wide, narrow, and threshold-100 assertions; no test is skipped or xfailed.

## Related issues

Part of #441; follows #593s re-enabling of the active width assertions.

## Testing

- [x] `uv run pytest tests/scanner/test_output.py --no-cov -q` — 48 passed
- [x] `uv run pytest -m "not integration" -q` — 3315 passed, 5 skipped, 1 xpassed
- [x] `uv run ruff check src tests`, `uv run ruff format --check .`, `uv run pyrefly check`, and `uv run bandit -r src -c pyproject.toml`

## Checklist

- [x] Active regression assertions cover the fixed-width behavior
- [x] No passing test was skipped or marked xfail
- [ ] Touched-file coverage confirmation pending CodeCov CI
- [x] No production behavior or binary version changed
- [x] Static checks are clean
- [x] No documentation change is needed for test-environment isolation

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates Rich output tests for configured console width handling.

- Adds a fixed-width interactive console helper for scanner output tests.
- Uses the helper in narrow, wide, and threshold layout assertions.
- Keeps coverage for fallback and non-interactive table behavior.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| tests/scanner/test_output.py | Adds a fixed-width interactive Rich console helper and applies it to width-sensitive scanner output tests. |

<sub>Reviews (2): Last reviewed commit: ["test(scanner): isolate Rich width tests ..."](https://github.com/jainal09/envdrift/commit/fe9c512c80ca80ebc8cd77b0f1d358facee5a174) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43209951)</sub>

<!-- /greptile_comment -->