### PR TITLE
fix(partial): detect quoted ciphertext with comments

### DIFF
--- a/docs/guides/partial-encryption.md
+++ b/docs/guides/partial-encryption.md
@@ -122,6 +122,8 @@ envdrift push --env production
 - An empty or comment-only `.secret` file is refused ("Nothing to encrypt") instead
   of letting dotenvx scaffold placeholder secrets into it. The same applies to
   secrets-only files.
+- A quoted encrypted value may retain a normal inline comment, such as
+  `API_KEY="encrypted:..." # rotated`; it is still recognized as encrypted.
 - When **both** the `.clear` and `.secret` files are missing, `push` errors out and
   leaves the existing combined file untouched instead of overwriting it with an
   empty scaffold.

--- a/src/envdrift/core/partial_encryption.py
+++ b/src/envdrift/core/partial_encryption.py
@@ -225,6 +225,35 @@ def _is_quote_wrapped(v: str) -> bool:
     return len(v) >= 2 and v[0] in ('"', "'") and v[-1] == v[0]
 
 
+def _strip_inline_comment_after_quoted_value(value: str) -> str:
+    """Drop a trailing comment after one complete dotenv-quoted value.
+
+    A comment is removable only when nothing but optional whitespace and a
+    ``#`` comment follows the closing quote. Keeping any other suffix makes the
+    whole value non-quoted, so malformed assignments remain fail-closed.
+    """
+    if not value or value[0] not in ('"', "'"):
+        return value
+
+    quote = value[0]
+    escaped = False
+    for index, char in enumerate(value[1:], start=1):
+        if escaped:
+            escaped = False
+            continue
+        if char == "\\":
+            escaped = True
+            continue
+        if char != quote:
+            continue
+
+        suffix = value[index + 1 :].strip()
+        if not suffix or suffix.startswith("#"):
+            return value[: index + 1]
+        return value
+    return value
+
+
 def _unquote_value(value: str) -> str:
     """Strip surrounding whitespace and a single layer of matching quotes.
 
@@ -235,6 +264,7 @@ def _unquote_value(value: str) -> str:
     surrounding whitespace must be removed first.
     """
     v = value.strip()
+    v = _strip_inline_comment_after_quoted_value(v)
     if _is_quote_wrapped(v):
         v = v[1:-1].strip()
     return v

--- a/tests/unit/test_partial_encryption_sops.py
+++ b/tests/unit/test_partial_encryption_sops.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from envdrift.config import PartialEncryptionEnvironmentConfig
 from envdrift.core.partial_encryption import combine_files, push_partial_encryption
 
@@ -33,6 +35,27 @@ def test_has_plaintext_secret_value_fully_encrypted_is_false(tmp_path: Path):
         'DB_PASS="encrypted:def..."\n'
     )
     assert has_plaintext_secret_value(f) is False
+
+
+@pytest.mark.parametrize(
+    ("line", "has_plaintext"),
+    [
+        ('API_KEY="encrypted:abc..." # rotated 2026-06', False),
+        ("DB_PASS='ENC[AES256_GCM,data:abc]' # rotated", False),
+        ('API_KEY="plaintext-value" # rotated', True),
+        ('API_KEY="encrypted:abc..." trailing-text', True),
+    ],
+)
+def test_has_plaintext_secret_value_quoted_value_with_suffix(
+    tmp_path: Path, line: str, has_plaintext: bool
+):
+    """Only an inline comment after quoted ciphertext is safe to trim (#578)."""
+    from envdrift.core.partial_encryption import has_plaintext_secret_value
+
+    f = tmp_path / ".env.secret"
+    f.write_text(line + "\n", encoding="utf-8")
+
+    assert has_plaintext_secret_value(f) is has_plaintext
 
 
 def test_has_plaintext_secret_value_mixed_is_true(tmp_path: Path):


### PR DESCRIPTION
## Summary

Partial-encryption status checks now recognize a ciphertext value when a valid dotenv inline comment follows its closing quote. This prevents an already-encrypted `.secret` value from being misreported as plaintext.

## Changes

- Strip a trailing comment only after a complete, matching quoted value.
- Preserve malformed or non-comment suffixes as plaintext/fail-closed.
- Cover dotenvx and SOPS ciphertext forms, a plaintext value, and a malformed suffix.
- Document the supported quoted-ciphertext comment form.

## Related issues

Closes #578

## Testing

- [x] Focused partial-encryption tests: 87 passed, 2 skipped.
- [x] Full non-integration suite: 3319 passed, 5 skipped, 537 deselected, 1 xpassed.
- [x] Full integration suite with Docker test services and real dotenvx v2: 497 passed, 37 skipped, 3325 deselected, 3 xfailed.
- [x] `ruff check`, `ruff format --check`, `pyrefly check`, and `bandit` clean.
- [x] `make lint-docs` clean.
- [x] Dogfooded the reported line with python-dotenv; it parses to the bare ciphertext value.

## Checklist

- [x] New behavior has a real filesystem regression test; no mocks.
- [x] No passing test was disabled and no xfail/skip was added.
- [x] Touched code has 95% line coverage in the full non-integration suite.
- [x] No hardcoded binary version was added to product code.
- [x] Docs updated for the behavior change.
- [x] No pre-existing bug was found beyond #578.
- [x] No FORCE_COLOR-dependent assertion or package reload was added.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jainal09/envdrift/pull/595?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recognition of encrypted values when quoted assignments include trailing inline comments.
  * Preserved fail-safe handling when quoted values contain non-comment trailing text.

* **Documentation**
  * Clarified safety guarantees for encrypted values with inline comments.

* **Tests**
  * Added coverage for quoted encrypted and plaintext values with comments or trailing content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates partial-encryption checks for quoted ciphertext with inline comments. The main changes are:

- Adds comment stripping after a complete quoted value.
- Keeps malformed quoted values with non-comment suffixes classified as plaintext.
- Adds focused tests for dotenvx, SOPS, plaintext, and malformed suffix cases.
- Documents the quoted ciphertext comment form.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/envdrift/core/partial_encryption.py | Adds a narrow helper that strips inline comments only after a complete quoted value before ciphertext detection. |
| tests/unit/test_partial_encryption_sops.py | Adds regression tests for quoted ciphertext with comments and malformed suffix handling. |
| docs/guides/partial-encryption.md | Documents that quoted encrypted values can keep normal inline comments. |

<sub>Reviews (1): Last reviewed commit: ["fix(partial): detect quoted ciphertext w..."](https://github.com/jainal09/envdrift/commit/96ae8bc0f6f1afc849383b557008058d278c04d1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43317891)</sub>

<!-- /greptile_comment -->