### PR TITLE
fix(scanner): avoid Git metadata false positives

### DIFF
--- a/src/envdrift/scanner/git_secrets.py
+++ b/src/envdrift/scanner/git_secrets.py
@@ -516,8 +516,13 @@ class GitSecretsScanner(ScannerBackend):
                     # Scan entire git history
                     result = self._run_git_secrets(["--scan-history"], cwd)
                 else:
-                    # Scan specific files or directory
-                    args = ["--scan", "-r"] + scan_paths
+                    # ``--no-index`` recurses through the requested paths but
+                    # excludes Git metadata. ``-r .`` scans ``.git/config``,
+                    # where modern git-secrets stores its own literal Bedrock
+                    # pattern, producing a false positive (#581). Unlike
+                    # ``--untracked``, this keeps ignored user files (such as
+                    # ``.env``) in the scanner's scope.
+                    args = ["--scan", "--no-index", *scan_paths]
                     result = self._run_git_secrets(args, cwd)
 
                 # Parse output.

--- a/tests/integration/test_scanner_git_tools.py
+++ b/tests/integration/test_scanner_git_tools.py
@@ -258,10 +258,6 @@ class TestGitSecretsRealBinary:
         assert len(result.findings) >= 1, "git-secrets finding (emitted on stderr) was not captured"
         assert any("aws" in f.rule_id for f in result.findings)
 
-    @pytest.mark.xfail(
-        strict=False,
-        reason="git-secrets scans its registered Bedrock pattern in .git/config (see #581)",
-    )
     def test_scan_clean_repo_has_no_findings(self, scanner_test_env):
         """scan() of a repo without secrets yields no findings and no error."""
         work_dir = scanner_test_env["work_dir"]
@@ -273,6 +269,35 @@ class TestGitSecretsRealBinary:
 
         assert result.error is None
         assert result.findings == []
+
+    def test_scan_detects_ignored_secret_file(self, scanner_test_env):
+        """An ignored dotenv file remains in scope when Git metadata is excluded (#581)."""
+        work_dir = scanner_test_env["work_dir"]
+        self._init_repo_with_aws_patterns(work_dir)
+        (work_dir / ".gitignore").write_text(".env\n")
+        (work_dir / ".env").write_text("AWS_KEY=AKIAZ9Q8W7E6R5T4Y3U2\n")
+
+        scanner = GitSecretsScanner(auto_install=False, register_aws=True)
+        result = scanner.scan([work_dir])
+
+        assert result.error is None
+        assert any(f.file_path == (work_dir / ".env").resolve() for f in result.findings)
+
+    def test_scan_detects_ignored_nested_secret_file(self, scanner_test_env):
+        """Recursive scanning retains ignored nested files when Git metadata is excluded (#581)."""
+        work_dir = scanner_test_env["work_dir"]
+        self._init_repo_with_aws_patterns(work_dir)
+        nested_dir = work_dir / "sub" / "deep"
+        nested_dir.mkdir(parents=True)
+        (work_dir / ".gitignore").write_text("sub/\n")
+        secret_file = nested_dir / "secrets.env"
+        secret_file.write_text("AWS_KEY=AKIAZ9Q8W7E6R5T4Y3U2\n")
+
+        scanner = GitSecretsScanner(auto_install=False, register_aws=True)
+        result = scanner.scan([work_dir])
+
+        assert result.error is None
+        assert any(f.file_path == secret_file.resolve() for f in result.findings)
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Summary

GitSecretsScanner no longer scans `.git/config`, where newer git-secrets stores its own literal Bedrock pattern. A clean repository with AWS patterns registered therefore remains clean, while ignored user dotenv files stay in scan scope.

## Changes

- Use git-secrets `--no-index` mode instead of raw recursive `-r .` scanning.
- Re-enable the real-binary clean-repository regression test for #581.
- Add a real-binary regression proving an ignored `.env` secret is still detected.

## Related issues

Closes #581

## Testing

- [x] Real git-secrets regression class: 3 passed.
- [x] Scanner unit module: 90 passed.
- [x] Full non-integration suite: 3319 passed, 5 skipped, 538 deselected, 1 xpassed.
- [x] Full integration suite with Docker test services and real dotenvx v2: 499 passed, 37 skipped, 3325 deselected, 2 xfailed.
- [x] `ruff check`, `ruff format --check`, `pyrefly check`, and `bandit` clean.
- [x] Dogfooded current git-secrets: `--scan -r .` flagged `.git/config`; `--scan --no-index .` stayed clean and still detected an ignored nested leak.

## Checklist

- [x] New behavior has real git-secrets binary regression coverage; no mocks.
- [x] No passing test was disabled; this re-enables the #581 regression test.
- [x] Touched production file has 99% line coverage in the full non-integration suite.
- [x] No hardcoded binary version was added to product code.
- [x] Docs are not needed: the documented user workflow is unchanged and ignored user files remain scanned.
- [x] No newly discovered pre-existing bug; #582 was already independently tracked.
- [x] No FORCE_COLOR-dependent assertion or package reload was added.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jainal09/envdrift/pull/597?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes the Git secrets scanner to avoid false positives from Git metadata.

- Switches the git-secrets scan command to `--no-index`.
- Keeps ignored dotenv files in scan scope.
- Re-enables the clean-repository real-binary test.
- Adds real-binary tests for ignored root and nested secret files.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/envdrift/scanner/git_secrets.py | Updates the git-secrets invocation so Git metadata is excluded while ignored user files remain scanned. |
| tests/integration/test_scanner_git_tools.py | Adds real-binary coverage for clean repositories and ignored root and nested secret files. |

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/git-secrets..."](https://github.com/jainal09/envdrift/commit/493ba8e4a82a3407b2d95b7ea1947c873b477430) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43323196)</sub>

<!-- /greptile_comment -->