### PR TITLE
test(release): distinguish external reusable workflow refs

### DIFF
--- a/tests/unit/test_release_workflows.py
+++ b/tests/unit/test_release_workflows.py
@@ -70,6 +70,15 @@ def _step_uses(workflow: dict[Any, Any]) -> list[str]:
     return refs
 
 
+def _local_reusable_workflow_name(reference: str) -> str | None:
+    """Return a same-repository reusable-workflow filename, if any."""
+    path = reference.split("@", 1)[0]
+    prefix = "./.github/workflows/"
+    if not path.startswith(prefix):
+        return None
+    return path.rsplit("/", 1)[-1]
+
+
 def test_vscode_release_runs_tests_unmasked() -> None:
     """The vscode release build must let test failures fail the release (#495).
 
@@ -171,10 +180,10 @@ def test_release_tags_have_exactly_one_trigger_path() -> None:
             called = job.get("uses")
             if not called:
                 continue
-            called_file = called.split("@", 1)[0].rsplit("/", 1)[-1]
-            if not (_WORKFLOWS / called_file).is_file():
-                # Reusable workflow from another repository — no local
-                # push-tags trigger to double-fire.
+            called_file = _local_reusable_workflow_name(called)
+            if called_file is None or not (_WORKFLOWS / called_file).is_file():
+                # External reusable workflow, or a missing local file — no
+                # local push-tags trigger to double-fire.
                 continue
             called_workflow = _load_workflow(called_file)
             push = _triggers(called_workflow).get("push") or {}
@@ -184,6 +193,17 @@ def test_release_tags_have_exactly_one_trigger_path() -> None:
                 "run twice and race the release assets (#495). Keep exactly one "
                 "trigger path per tag."
             )
+
+
+def test_external_reusable_workflow_is_not_confused_by_matching_basename() -> None:
+    """Only ``./`` references are local, even when an external basename matches (#582)."""
+    assert _local_reusable_workflow_name("./.github/workflows/vscode-release.yml@main") == (
+        "vscode-release.yml"
+    )
+    assert (
+        _local_reusable_workflow_name("example-org/example/.github/workflows/vscode-release.yml@v1")
+        is None
+    )
 
 
 def test_release_workflows_define_per_tag_concurrency() -> None:


### PR DESCRIPTION
## Summary

Release-workflow validation now distinguishes same-repository reusable workflows from external ones before resolving a local filename. An external workflow with the same basename as a local workflow can no longer be checked against the wrong file.

## Changes

- Recognize local reusable workflows only when their reference starts with `./.github/workflows/`.
- Add regression coverage for an external reference that collides with `vscode-release.yml`.

## Related issues

Closes #582

## Testing

- [x] Focused release-workflow tests: 7 passed.
- [x] Full non-integration suite: 3320 passed, 5 skipped, 537 deselected, 1 xpassed.
- [x] `ruff check`, `ruff format --check`, `pyrefly check`, and `bandit` clean.
- [x] Dogfooded the prior basename extraction: an external `.../vscode-release.yml@v1` resolved to the local basename; the new locality check rejects it.

## Checklist

- [x] New regression test covers the external/local basename collision without mocks.
- [x] No passing test was disabled and no xfail/skip was added.
- [x] No product code changed; test coverage is exercised by the focused and full suites.
- [x] No hardcoded binary version was added.
- [x] Docs are not needed: no user-facing workflow behavior changed.
- [x] No newly discovered pre-existing bug.
- [x] No FORCE_COLOR-dependent assertion or package reload was added.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jainal09/envdrift/pull/598?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR tightens release-workflow test handling for reusable workflow references.

- Adds a helper that only treats `./.github/workflows/` references as local reusable workflows.
- Updates the release tag trigger test to skip external workflow references before checking local files.
- Adds a test for an external workflow reference whose basename matches a local workflow.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- The changed helper matches the documented local reusable workflow form used by GitHub Actions.
- The missing-local-file skip behavior is unchanged from the previous test logic.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| tests/unit/test_release_workflows.py | The test helper now distinguishes local reusable workflows from external references, with coverage for basename collisions. |

<sub>Reviews (1): Last reviewed commit: ["test(release): distinguish external reus..."](https://github.com/jainal09/envdrift/commit/05ce157ce77d27d074f6cd9c7c51166d040a0b43) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43324298)</sub>

<!-- /greptile_comment -->