### PR TITLE
fix(scanner): discover non-ASCII Git paths

### DIFF
--- a/src/envdrift/scanner/native.py
+++ b/src/envdrift/scanner/native.py
@@ -494,10 +494,14 @@ class NativeScanner(ScannerBackend):
         files: set[Path] = set()
         directory = directory.resolve()
 
+        # ``-z`` keeps filenames byte-for-byte rather than applying Git's
+        # C-style quotepath escaping to non-ASCII or newline-containing paths.
+        # Every git invocation below therefore uses NUL-separated output.
+
         # Method 1: Get tracked files from git (fast - reads index)
         try:
             result = subprocess.run(  # nosec B603, B607
-                ["git", "ls-files"],
+                ["git", "ls-files", "-z"],
                 capture_output=True,
                 text=True,
                 encoding="utf-8",
@@ -509,7 +513,7 @@ class NativeScanner(ScannerBackend):
                 # Not a git repo or git error - use fallback
                 return self._collect_files_fallback(directory)
 
-            for rel_path in result.stdout.splitlines():
+            for rel_path in result.stdout.split("\0"):
                 if rel_path:
                     files.add(directory / rel_path)
 
@@ -521,7 +525,15 @@ class NativeScanner(ScannerBackend):
         # These are files developers might forget to encrypt before committing
         try:
             result = subprocess.run(  # nosec B603, B607
-                ["git", "ls-files", "--others", "--exclude-standard", "--", *_ENV_FILE_PATHSPECS],
+                [
+                    "git",
+                    "ls-files",
+                    "--others",
+                    "--exclude-standard",
+                    "-z",
+                    "--",
+                    *_ENV_FILE_PATHSPECS,
+                ],
                 capture_output=True,
                 text=True,
                 encoding="utf-8",
@@ -530,7 +542,7 @@ class NativeScanner(ScannerBackend):
                 timeout=30,
             )
             if result.returncode == 0:
-                for rel_path in result.stdout.splitlines():
+                for rel_path in result.stdout.split("\0"):
                     if rel_path and _is_env_file(rel_path):
                         files.add(directory / rel_path)
         except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
@@ -554,6 +566,7 @@ class NativeScanner(ScannerBackend):
                     "--others",
                     "--ignored",
                     "--exclude-standard",
+                    "-z",
                     "--",
                     *_ENV_FILE_PATHSPECS,
                 ],
@@ -565,7 +578,7 @@ class NativeScanner(ScannerBackend):
                 timeout=30,
             )
             if result.returncode == 0:
-                for rel_path in result.stdout.splitlines():
+                for rel_path in result.stdout.split("\0"):
                     if (
                         rel_path
                         and _is_env_file(rel_path)

--- a/src/envdrift/scanner/native.py
+++ b/src/envdrift/scanner/native.py
@@ -496,7 +496,8 @@ class NativeScanner(ScannerBackend):
 
         # ``-z`` keeps filenames byte-for-byte rather than applying Git's
         # C-style quotepath escaping to non-ASCII or newline-containing paths.
-        # Every git invocation below therefore uses NUL-separated output.
+        # ``surrogateescape`` round-trips any non-UTF-8 bytes into ``Path``;
+        # every git invocation below therefore uses NUL-separated output.
 
         # Method 1: Get tracked files from git (fast - reads index)
         try:
@@ -505,7 +506,7 @@ class NativeScanner(ScannerBackend):
                 capture_output=True,
                 text=True,
                 encoding="utf-8",
-                errors="replace",
+                errors="surrogateescape",
                 cwd=directory,
                 timeout=30,
             )
@@ -537,7 +538,7 @@ class NativeScanner(ScannerBackend):
                 capture_output=True,
                 text=True,
                 encoding="utf-8",
-                errors="replace",
+                errors="surrogateescape",
                 cwd=directory,
                 timeout=30,
             )
@@ -573,7 +574,7 @@ class NativeScanner(ScannerBackend):
                 capture_output=True,
                 text=True,
                 encoding="utf-8",
-                errors="replace",
+                errors="surrogateescape",
                 cwd=directory,
                 timeout=30,
             )

--- a/src/envdrift/scanner/output.py
+++ b/src/envdrift/scanner/output.py
@@ -9,9 +9,10 @@ This module provides multiple output formats for scan results:
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
-from urllib.parse import quote
+from urllib.parse import quote_from_bytes
 
 from rich.console import Console
 from rich.panel import Panel
@@ -336,19 +337,25 @@ def _sarif_artifact_location(file_path: PurePath, srcroot: PurePath) -> dict[str
 
     Both arguments must be absolute. A path under ``srcroot`` becomes a
     srcroot-relative URI with forward slashes — on Windows too, per SARIF
-    2.1.0 §3.4.4 — tagged with ``uriBaseId: SRCROOT``, percent-encoded so a
-    space, ``#`` or non-ASCII character still yields a valid RFC 3986
-    URI-reference (§3.4.3), matching the ``as_uri()`` fallback's encoding. A
-    path outside the source root cannot be expressed relative to it, so it
-    falls back to an absolute ``file://`` URI with no base id (an absolute
-    URI under a base id is contradictory and Code Scanning drops such
-    alerts — #489).
+    2.1.0 §3.4.4 — tagged with ``uriBaseId: SRCROOT`` and percent-encoded so
+    a space, ``#``, non-ASCII character, or arbitrary POSIX pathname byte
+    still yields a valid RFC 3986 URI-reference (§3.4.3), matching the
+    ``as_uri()`` fallback's encoding. A path outside the source root cannot
+    be expressed relative to it, so it falls back to an absolute ``file://``
+    URI with no base id (an absolute URI under a base id is contradictory and
+    Code Scanning drops such alerts — #489).
     """
     try:
         relative = file_path.relative_to(srcroot)
     except ValueError:
         return {"uri": file_path.as_uri()}
-    return {"uri": quote(relative.as_posix()), "uriBaseId": _SRCROOT_BASE_ID}
+    # ``Path`` can contain surrogate-escaped POSIX pathname bytes.  Encoding
+    # via ``os.fsencode`` preserves those bytes before URI percent-encoding;
+    # ``quote(str)`` would strictly UTF-8 encode and reject the surrogate.
+    return {
+        "uri": quote_from_bytes(os.fsencode(relative.as_posix())),
+        "uriBaseId": _SRCROOT_BASE_ID,
+    }
 
 
 def _resolved_finding_path(file_path: Path) -> Path:

--- a/tests/integration/test_guard_sarif_correctness_e2e.py
+++ b/tests/integration/test_guard_sarif_correctness_e2e.py
@@ -189,15 +189,17 @@ class TestSarifRelativeUris:
         assert "sub%20dir/.env" in uris, f"expected a percent-encoded URI, got {sorted(uris)}"
         assert not any(" " in uri for uri in uris), "raw spaces are invalid in URI-references"
 
-    @pytest.mark.xfail(
-        strict=False,
-        reason="native discovery drops non-ASCII paths: git ls-files quotepath output "
-        "is not unquoted (see #576)",
-    )
     def test_non_ascii_path_is_discovered_and_percent_encoded(self, scratch_repo: Path) -> None:
-        """A finding in a non-ASCII directory must be discovered and emitted as a
-        UTF-8 percent-encoded URI. The emitter side is unit-tested and correct;
-        discovery currently drops the file before it ever reaches SARIF (#576)."""
+        """A non-ASCII path must survive Git quotepath discovery into SARIF (#576)."""
+        git_path = shutil.which("git")
+        assert git_path is not None
+        subprocess.run(
+            [git_path, "config", "core.quotepath", "true"],
+            cwd=str(scratch_repo),
+            check=True,
+            capture_output=True,
+            timeout=60,
+        )
         non_ascii = scratch_repo / "sécrets"
         non_ascii.mkdir()
         (non_ascii / ".env").write_text(f"TOKEN={_AWS_KEY_TWO}\n", encoding="utf-8")

--- a/tests/integration/test_guard_sarif_correctness_e2e.py
+++ b/tests/integration/test_guard_sarif_correctness_e2e.py
@@ -213,6 +213,41 @@ class TestSarifRelativeUris:
             f"finding in a non-ASCII directory was not reported, got {sorted(uris)}"
         )
 
+    @pytest.mark.skipif(os.name == "nt", reason="Windows filenames cannot contain arbitrary bytes")
+    def test_non_utf8_path_is_discovered_and_percent_encoded(self, scratch_repo: Path) -> None:
+        """Raw Git pathname bytes must survive discovery and SARIF emission (#576)."""
+        git_path = shutil.which("git")
+        assert git_path is not None
+        subprocess.run(
+            [git_path, "config", "core.quotepath", "true"],
+            cwd=str(scratch_repo),
+            check=True,
+            capture_output=True,
+            timeout=60,
+        )
+        raw_directory_name = os.fsdecode(b"secrets-\xe9")
+        env_file = scratch_repo / raw_directory_name / ".env"
+        env_file.parent.mkdir()
+        env_file.write_text(f"TOKEN={_AWS_KEY_TWO}\n", encoding="utf-8")
+        subprocess.run(
+            [git_path, "add", str(env_file.relative_to(scratch_repo))],
+            cwd=str(scratch_repo),
+            check=True,
+            capture_output=True,
+            timeout=60,
+        )
+
+        result = _run_envdrift(_SARIF_ARGS, cwd=scratch_repo)
+        assert result.returncode == 1, result.stderr
+        sarif = _parse_sarif(result)
+
+        locations = _artifact_uris(sarif)
+        raw_byte_locations = [
+            location for location in locations if location["uri"] == "secrets-%E9/.env"
+        ]
+        assert raw_byte_locations, f"raw-byte path was not reported, got {locations}"
+        assert all(location["uriBaseId"] == "SRCROOT" for location in raw_byte_locations)
+
 
 class TestSarifFingerprints:
     """Two distinct secrets on one line must never share a fingerprint."""

--- a/tests/scanner/test_native.py
+++ b/tests/scanner/test_native.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path, PureWindowsPath
 
 import pytest
@@ -101,6 +102,30 @@ class TestNativeScannerInternals:
 
         assert files == expected
         assert all("-z" in cmd for cmd in calls)
+
+    @pytest.mark.skipif(os.name == "nt", reason="Windows filenames cannot contain arbitrary bytes")
+    def test_collect_files_round_trips_non_utf8_git_paths(self, tmp_path: Path):
+        """Raw Git pathname bytes must map back to the file on disk (#576)."""
+        import shutil
+        import subprocess
+
+        if shutil.which("git") is None:
+            pytest.skip("git not available")
+
+        def git(*args: str) -> None:
+            subprocess.run(["git", *args], cwd=tmp_path, check=True, capture_output=True)
+
+        git("init")
+        git("config", "core.quotepath", "true")
+        raw_directory_name = os.fsdecode(b"secrets-\xff")
+        env_file = tmp_path / raw_directory_name / ".env"
+        env_file.parent.mkdir()
+        env_file.write_bytes(b"TOKEN=secret\n")
+        git("add", "-A")
+
+        collected = NativeScanner()._collect_files(tmp_path)
+
+        assert env_file in collected
 
     def test_collect_files_includes_gitignored_env_secret(self, tmp_path: Path):
         """A gitignored, untracked, plaintext .env secret must still be collected.

--- a/tests/scanner/test_native.py
+++ b/tests/scanner/test_native.py
@@ -71,8 +71,8 @@ class TestNativeScannerInternals:
         monkeypatch.setattr(Path, "rglob", raise_permission)
         assert scanner._collect_files(tmp_path) == []
 
-    def test_collect_files_sorts_git_results(self, tmp_path: Path, monkeypatch):
-        """Git-based collection returns deterministically sorted results."""
+    def test_collect_files_sorts_nul_delimited_git_results(self, tmp_path: Path, monkeypatch):
+        """Git collection uses NUL output so quoted or newline-containing paths stay intact (#576)."""
         import subprocess
 
         scanner = NativeScanner()
@@ -81,12 +81,14 @@ class TestNativeScannerInternals:
         (tmp_path / "b.txt").touch()
         (tmp_path / ".env.a").touch()
         (tmp_path / ".env.z").touch()
+        calls: list[list[str]] = []
 
         def mock_run(cmd, **kwargs):
+            calls.append(cmd)
             if cmd[:2] == ["git", "ls-files"] and "--others" not in cmd:
-                return subprocess.CompletedProcess(cmd, 0, stdout="b.txt\na.txt\n", stderr="")
+                return subprocess.CompletedProcess(cmd, 0, stdout="b.txt\0a.txt\0", stderr="")
             if cmd[:2] == ["git", "ls-files"] and "--others" in cmd:
-                return subprocess.CompletedProcess(cmd, 0, stdout=".env.z\n.env.a\n", stderr="")
+                return subprocess.CompletedProcess(cmd, 0, stdout=".env.z\0.env.a\0", stderr="")
             return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="")
 
         monkeypatch.setattr(subprocess, "run", mock_run)
@@ -98,6 +100,7 @@ class TestNativeScannerInternals:
         )
 
         assert files == expected
+        assert all("-z" in cmd for cmd in calls)
 
     def test_collect_files_includes_gitignored_env_secret(self, tmp_path: Path):
         """A gitignored, untracked, plaintext .env secret must still be collected.


### PR DESCRIPTION
## Summary

Native scanner discovery now consumes NUL-delimited `git ls-files` output so Git quotepath escaping cannot turn non-ASCII `.env` paths into nonexistent literal paths.

## Changes

- Request `-z` output for tracked, untracked, and gitignored discovery passes.
- Parse Git output by NUL rather than physical lines.
- Re-enable the real CLI/SARIF regression test and force `core.quotepath=true`.
- Cover the NUL-delimited collection contract in native-scanner unit tests.

## Related issues

Closes #576

## Validation

- `ruff check src tests`, `ruff format --check .`, `pyrefly check`, and `bandit -r src -c pyproject.toml`
- Full non-integration suite: 3320 passed, 5 skipped, 540 deselected, 1 xpassed
- Full integration suite: 503 passed, 37 skipped, 3326 deselected
- SARIF real-CLI module: 11 passed

## Checklist

- [x] Includes a real behavioral regression test.
- [x] Re-enables the #576 test; no passing test was skipped or xfailed.
- [x] Documentation is not needed because this fixes internal discovery behavior without changing the user-facing workflow.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jainal09/envdrift/pull/601?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of files with non-ASCII characters and unusual names during environment scanning.
  * Prevented Git path formatting from causing files to be missed.
  * Preserved deterministic file ordering across scans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes native scanner discovery for Git paths that Git would otherwise quote or expose as raw bytes.

- Uses NUL-delimited `git ls-files` output for tracked, untracked, and ignored discovery.
- Decodes Git path output with `surrogateescape` so raw pathname bytes round-trip.
- Percent-encodes SARIF artifact URIs from filesystem bytes.
- Adds end-to-end and scanner tests for non-ASCII and non-UTF-8 paths.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/envdrift/scanner/native.py | Git discovery now preserves raw path bytes and parses file lists by NUL separators. |
| src/envdrift/scanner/output.py | SARIF artifact URIs now encode filesystem bytes, including surrogate-escaped path components. |
| tests/integration/test_guard_sarif_correctness_e2e.py | End-to-end SARIF tests now cover quoted non-ASCII paths and raw non-UTF-8 path bytes. |
| tests/scanner/test_native.py | Native scanner tests now cover NUL-delimited Git output and byte-preserving path collection. |

<sub>Reviews (3): Last reviewed commit: ["fix(sarif): preserve raw Git path bytes"](https://github.com/jainal09/envdrift/commit/731672009b454840500963ceeaaef7756239019c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43400851)</sub>

<!-- /greptile_comment -->