### PR TITLE
fix(scanner): bound auto-install downloads

### DIFF
--- a/src/envdrift/install_integrity.py
+++ b/src/envdrift/install_integrity.py
@@ -33,11 +33,33 @@ INSECURE_SKIP_ENV = "ENVDRIFT_INSECURE_SKIP_CHECKSUM"
 #: Timeout (seconds) for fetching the checksums file.
 FETCH_TIMEOUT_SECONDS = 30.0
 
+#: Timeout (seconds) for downloading an executable or archive.  This must be
+#: passed per request: ``urlretrieve`` has no timeout argument and can block an
+#: auto-install forever after a server accepts the connection and stalls (#515).
+DOWNLOAD_TIMEOUT_SECONDS = 60.0
+
 _SHA256_HEX_RE = re.compile(r"^[0-9a-fA-F]{64}$")
 
 
 class ChecksumVerificationError(Exception):
     """A downloaded artifact could not be verified against published checksums."""
+
+
+def download_file(
+    url: str, destination: Path, *, timeout: float = DOWNLOAD_TIMEOUT_SECONDS
+) -> None:
+    """Stream ``url`` to ``destination`` with a bounded per-request timeout.
+
+    ``urlopen`` applies ``timeout`` to connection setup and every socket read.
+    Streaming avoids buffering an entire release archive in memory, while
+    leaving each caller responsible for its existing typed install error and
+    staging cleanup behavior.
+    """
+    with (
+        urllib.request.urlopen(url, timeout=timeout) as response,  # nosec B310
+        destination.open("wb") as output,
+    ):
+        shutil.copyfileobj(response, output)
 
 
 def verification_disabled() -> bool:

--- a/src/envdrift/integrations/dotenvx.py
+++ b/src/envdrift/integrations/dotenvx.py
@@ -25,6 +25,7 @@ from pathlib import Path
 from typing import ClassVar
 
 from envdrift.install_integrity import (
+    DOWNLOAD_TIMEOUT_SECONDS,
     ChecksumVerificationError,
     atomic_install,
     verify_download,
@@ -92,12 +93,6 @@ DOWNLOAD_URLS = {
     ("Windows", "AMD64"): _URL_TEMPLATES["windows_amd64"],
     ("Windows", "x86_64"): _URL_TEMPLATES["windows_amd64"],
 }
-
-# Per-request timeout (seconds) for the binary download. Passed directly to
-# urllib.request.urlopen so a connection that is accepted then stalls cannot
-# hang the auto-install path indefinitely. Using urlopen's timeout keeps the
-# bound local to this request instead of mutating process-global socket state.
-DOWNLOAD_TIMEOUT_SECONDS = 60
 
 _ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;?]*[ -/]*[@-~]")
 

--- a/src/envdrift/scanner/gitleaks.py
+++ b/src/envdrift/scanner/gitleaks.py
@@ -17,14 +17,15 @@ import subprocess  # nosec B404
 import tarfile
 import tempfile
 import time
-import urllib.request
 import zipfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from envdrift.install_integrity import (
+    DOWNLOAD_TIMEOUT_SECONDS,
     ChecksumVerificationError,
     atomic_install,
+    download_file,
     verify_download,
 )
 from envdrift.scanner.base import (
@@ -259,7 +260,7 @@ class GitleaksInstaller:
 
             # Download
             try:
-                urllib.request.urlretrieve(url, archive_path)  # nosec B310
+                download_file(url, archive_path, timeout=DOWNLOAD_TIMEOUT_SECONDS)
             except Exception as e:
                 raise GitleaksInstallError(f"Download failed: {e}") from e
 

--- a/src/envdrift/scanner/infisical.py
+++ b/src/envdrift/scanner/infisical.py
@@ -17,14 +17,15 @@ import subprocess  # nosec B404
 import tarfile
 import tempfile
 import time
-import urllib.request
 import zipfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from envdrift.install_integrity import (
+    DOWNLOAD_TIMEOUT_SECONDS,
     ChecksumVerificationError,
     atomic_install,
+    download_file,
     verify_download,
 )
 from envdrift.scanner.base import (
@@ -199,7 +200,7 @@ class InfisicalInstaller:
 
             # Download
             try:
-                urllib.request.urlretrieve(url, archive_path)  # nosec B310
+                download_file(url, archive_path, timeout=DOWNLOAD_TIMEOUT_SECONDS)
             except Exception as e:
                 raise InfisicalInstallError(f"Download failed: {e}") from e
 

--- a/src/envdrift/scanner/talisman.py
+++ b/src/envdrift/scanner/talisman.py
@@ -18,11 +18,15 @@ import stat
 import subprocess  # nosec B404
 import tempfile
 import time
-import urllib.request
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar
 
-from envdrift.install_integrity import ChecksumVerificationError, verify_download
+from envdrift.install_integrity import (
+    DOWNLOAD_TIMEOUT_SECONDS,
+    ChecksumVerificationError,
+    download_file,
+    verify_download,
+)
 from envdrift.scanner.base import (
     FindingSeverity,
     ScanFinding,
@@ -234,7 +238,7 @@ class TalismanInstaller:
         staging_path = target_path.parent / (target_path.name + ".download")
         try:
             try:
-                urllib.request.urlretrieve(url, staging_path)  # nosec B310
+                download_file(url, staging_path, timeout=DOWNLOAD_TIMEOUT_SECONDS)
             except Exception as e:
                 raise TalismanInstallError(f"Download failed: {e}") from e
 

--- a/src/envdrift/scanner/trivy.py
+++ b/src/envdrift/scanner/trivy.py
@@ -17,15 +17,16 @@ import subprocess  # nosec B404
 import tarfile
 import tempfile
 import time
-import urllib.request
 import zipfile
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from envdrift.install_integrity import (
+    DOWNLOAD_TIMEOUT_SECONDS,
     ChecksumVerificationError,
     atomic_install,
+    download_file,
     verify_download,
 )
 from envdrift.scanner.base import (
@@ -209,7 +210,7 @@ class TrivyInstaller:
 
             # Download
             try:
-                urllib.request.urlretrieve(url, archive_path)  # nosec B310
+                download_file(url, archive_path, timeout=DOWNLOAD_TIMEOUT_SECONDS)
             except Exception as e:
                 raise TrivyInstallError(f"Download failed: {e}") from e
 

--- a/src/envdrift/scanner/trufflehog.py
+++ b/src/envdrift/scanner/trufflehog.py
@@ -22,14 +22,15 @@ import subprocess  # nosec B404
 import tarfile
 import tempfile
 import time
-import urllib.request
 import zipfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from envdrift.install_integrity import (
+    DOWNLOAD_TIMEOUT_SECONDS,
     ChecksumVerificationError,
     atomic_install,
+    download_file,
     verify_download,
 )
 from envdrift.scanner.base import (
@@ -256,7 +257,7 @@ class TrufflehogInstaller:
 
             # Download
             try:
-                urllib.request.urlretrieve(url, archive_path)  # nosec B310
+                download_file(url, archive_path, timeout=DOWNLOAD_TIMEOUT_SECONDS)
             except Exception as e:
                 raise TrufflehogInstallError(f"Download failed: {e}") from e
 

--- a/tests/integration/test_guard_sarif_correctness_e2e.py
+++ b/tests/integration/test_guard_sarif_correctness_e2e.py
@@ -19,6 +19,7 @@ realistic literal ever appears in the repository (GitHub push protection).
 
 from __future__ import annotations
 
+import errno
 import json
 import os
 import shutil
@@ -227,7 +228,12 @@ class TestSarifRelativeUris:
         )
         raw_directory_name = os.fsdecode(b"secrets-\xe9")
         env_file = scratch_repo / raw_directory_name / ".env"
-        env_file.parent.mkdir()
+        try:
+            env_file.parent.mkdir()
+        except OSError as exc:
+            if exc.errno == errno.EILSEQ:
+                pytest.skip("filesystem does not support non-UTF-8 filename bytes")
+            raise
         env_file.write_text(f"TOKEN={_AWS_KEY_TWO}\n", encoding="utf-8")
         subprocess.run(
             [git_path, "add", str(env_file.relative_to(scratch_repo))],

--- a/tests/scanner/test_gitleaks.py
+++ b/tests/scanner/test_gitleaks.py
@@ -309,13 +309,12 @@ class TestGitleaksInstaller:
         monkeypatch.setattr(installer, "get_checksums_url", lambda: checksums_url)
         monkeypatch.setattr(platform, "system", lambda: "Linux")
 
-        def fake_urlretrieve(_url: str, filename: str):
+        def fake_download(_url: str, filename: Path, **_kwargs) -> None:
             shutil.copy2(archive_path, filename)
-            return filename, None
 
         monkeypatch.setattr(
-            "envdrift.scanner.gitleaks.urllib.request.urlretrieve",
-            fake_urlretrieve,
+            "envdrift.scanner.gitleaks.download_file",
+            fake_download,
         )
 
         target_path = tmp_path / "bin" / "gitleaks"
@@ -336,13 +335,12 @@ class TestGitleaksInstaller:
         monkeypatch.setattr(installer, "get_checksums_url", lambda: checksums_url)
         monkeypatch.setattr(platform, "system", lambda: "Windows")
 
-        def fake_urlretrieve(_url: str, filename: str):
+        def fake_download(_url: str, filename: Path, **_kwargs) -> None:
             shutil.copy2(archive_path, filename)
-            return filename, None
 
         monkeypatch.setattr(
-            "envdrift.scanner.gitleaks.urllib.request.urlretrieve",
-            fake_urlretrieve,
+            "envdrift.scanner.gitleaks.download_file",
+            fake_download,
         )
 
         target_path = tmp_path / "bin" / "gitleaks.exe"

--- a/tests/scanner/test_infisical.py
+++ b/tests/scanner/test_infisical.py
@@ -669,14 +669,14 @@ class TestInfisicalInstallerInstall:
     """Tests for InfisicalInstaller.install method."""
 
     @patch("envdrift.scanner.infisical.get_infisical_path")
-    @patch("urllib.request.urlretrieve")
+    @patch("envdrift.scanner.infisical.download_file")
     @patch("envdrift.scanner.platform_utils.platform.system", return_value="Linux")
     @patch("envdrift.scanner.platform_utils.platform.machine", return_value="x86_64")
     def test_install_success(
         self,
         mock_machine: MagicMock,
         mock_system: MagicMock,
-        mock_urlretrieve: MagicMock,
+        mock_download_file: MagicMock,
         mock_get_path: MagicMock,
         tmp_path: Path,
     ):
@@ -690,14 +690,14 @@ class TestInfisicalInstallerInstall:
 
         checksums_path = tmp_path / "stub-checksums.txt"
 
-        def fake_download(url: str, dest: str) -> None:
+        def fake_download(url: str, dest: str, **_kwargs) -> None:
             with tarfile.open(dest, "w:gz") as tar:
                 info = tarfile.TarInfo(name="infisical")
                 info.size = 4
                 tar.addfile(info, io.BytesIO(b"fake"))
             write_checksums_for(Path(dest), checksums_path, url.rsplit("/", 1)[-1])
 
-        mock_urlretrieve.side_effect = fake_download
+        mock_download_file.side_effect = fake_download
 
         installer = InfisicalInstaller()
         with patch.object(
@@ -711,34 +711,34 @@ class TestInfisicalInstallerInstall:
         assert target_path.exists()
 
     @patch("envdrift.scanner.infisical.get_infisical_path")
-    @patch("urllib.request.urlretrieve")
+    @patch("envdrift.scanner.infisical.download_file")
     @patch("envdrift.scanner.platform_utils.platform.system", return_value="Linux")
     @patch("envdrift.scanner.platform_utils.platform.machine", return_value="x86_64")
     def test_install_download_failure(
         self,
         mock_machine: MagicMock,
         mock_system: MagicMock,
-        mock_urlretrieve: MagicMock,
+        mock_download_file: MagicMock,
         mock_get_path: MagicMock,
         tmp_path: Path,
     ):
         """Test installation failure on download error."""
         mock_get_path.return_value = tmp_path / "infisical"
-        mock_urlretrieve.side_effect = Exception("Network error")
+        mock_download_file.side_effect = Exception("Network error")
 
         installer = InfisicalInstaller()
         with pytest.raises(InfisicalInstallError, match="Download failed"):
             installer.install()
 
     @patch("envdrift.scanner.infisical.get_infisical_path")
-    @patch("urllib.request.urlretrieve")
+    @patch("envdrift.scanner.infisical.download_file")
     @patch("envdrift.scanner.platform_utils.platform.system", return_value="Linux")
     @patch("envdrift.scanner.platform_utils.platform.machine", return_value="x86_64")
     def test_install_binary_not_found_in_archive(
         self,
         mock_machine: MagicMock,
         mock_system: MagicMock,
-        mock_urlretrieve: MagicMock,
+        mock_download_file: MagicMock,
         mock_get_path: MagicMock,
         tmp_path: Path,
     ):
@@ -749,14 +749,14 @@ class TestInfisicalInstallerInstall:
         mock_get_path.return_value = tmp_path / "infisical"
         checksums_path = tmp_path / "stub-checksums.txt"
 
-        def fake_download(url: str, dest: str) -> None:
+        def fake_download(url: str, dest: str, **_kwargs) -> None:
             with tarfile.open(dest, "w:gz") as tar:
                 info = tarfile.TarInfo(name="other_file.txt")
                 info.size = 4
                 tar.addfile(info, io.BytesIO(b"test"))
             write_checksums_for(Path(dest), checksums_path, url.rsplit("/", 1)[-1])
 
-        mock_urlretrieve.side_effect = fake_download
+        mock_download_file.side_effect = fake_download
 
         installer = InfisicalInstaller()
         with (

--- a/tests/scanner/test_infisical.py
+++ b/tests/scanner/test_infisical.py
@@ -690,7 +690,7 @@ class TestInfisicalInstallerInstall:
 
         checksums_path = tmp_path / "stub-checksums.txt"
 
-        def fake_download(url: str, dest: str, **_kwargs) -> None:
+        def fake_download(url: str, dest: Path, **_kwargs) -> None:
             with tarfile.open(dest, "w:gz") as tar:
                 info = tarfile.TarInfo(name="infisical")
                 info.size = 4
@@ -749,7 +749,7 @@ class TestInfisicalInstallerInstall:
         mock_get_path.return_value = tmp_path / "infisical"
         checksums_path = tmp_path / "stub-checksums.txt"
 
-        def fake_download(url: str, dest: str, **_kwargs) -> None:
+        def fake_download(url: str, dest: Path, **_kwargs) -> None:
             with tarfile.open(dest, "w:gz") as tar:
                 info = tarfile.TarInfo(name="other_file.txt")
                 info.size = 4

--- a/tests/scanner/test_native.py
+++ b/tests/scanner/test_native.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import errno
 import os
 from pathlib import Path, PureWindowsPath
 
@@ -119,7 +120,12 @@ class TestNativeScannerInternals:
         git("config", "core.quotepath", "true")
         raw_directory_name = os.fsdecode(b"secrets-\xff")
         env_file = tmp_path / raw_directory_name / ".env"
-        env_file.parent.mkdir()
+        try:
+            env_file.parent.mkdir()
+        except OSError as exc:
+            if exc.errno == errno.EILSEQ:
+                pytest.skip("filesystem does not support non-UTF-8 filename bytes")
+            raise
         env_file.write_bytes(b"TOKEN=secret\n")
         git("add", "-A")
 

--- a/tests/scanner/test_talisman.py
+++ b/tests/scanner/test_talisman.py
@@ -650,7 +650,7 @@ class TestTalismanInstallerInstall:
 
         checksums_path = tmp_path / "stub-checksums.txt"
 
-        def fake_download(url: str, dest: str, **_kwargs) -> None:
+        def fake_download(url: str, dest: Path, **_kwargs) -> None:
             # Create a fake binary file
             Path(dest).write_bytes(b"fake binary content")
             write_checksums_for(Path(dest), checksums_path, url.rsplit("/", 1)[-1])

--- a/tests/scanner/test_talisman.py
+++ b/tests/scanner/test_talisman.py
@@ -636,26 +636,26 @@ class TestTalismanInstallerDownload:
 class TestTalismanInstallerInstall:
     """Tests for TalismanInstaller.install method."""
 
-    @patch("urllib.request.urlretrieve")
+    @patch("envdrift.scanner.talisman.download_file")
     @patch("envdrift.scanner.platform_utils.platform.system", return_value="Linux")
     @patch("envdrift.scanner.platform_utils.platform.machine", return_value="x86_64")
     def test_install_success(
         self,
         mock_machine: MagicMock,
         mock_system: MagicMock,
-        mock_urlretrieve: MagicMock,
+        mock_download_file: MagicMock,
         tmp_path: Path,
     ):
         """Test successful installation."""
 
         checksums_path = tmp_path / "stub-checksums.txt"
 
-        def fake_download(url: str, dest: str) -> None:
+        def fake_download(url: str, dest: str, **_kwargs) -> None:
             # Create a fake binary file
             Path(dest).write_bytes(b"fake binary content")
             write_checksums_for(Path(dest), checksums_path, url.rsplit("/", 1)[-1])
 
-        mock_urlretrieve.side_effect = fake_download
+        mock_download_file.side_effect = fake_download
 
         with (
             patch(
@@ -674,18 +674,18 @@ class TestTalismanInstallerInstall:
             assert result == tmp_path / "talisman"
             assert (tmp_path / "talisman").exists()
 
-    @patch("urllib.request.urlretrieve")
+    @patch("envdrift.scanner.talisman.download_file")
     @patch("envdrift.scanner.platform_utils.platform.system", return_value="Linux")
     @patch("envdrift.scanner.platform_utils.platform.machine", return_value="x86_64")
     def test_install_download_failure(
         self,
         mock_machine: MagicMock,
         mock_system: MagicMock,
-        mock_urlretrieve: MagicMock,
+        mock_download_file: MagicMock,
         tmp_path: Path,
     ):
         """Test installation failure on download error."""
-        mock_urlretrieve.side_effect = Exception("Network error")
+        mock_download_file.side_effect = Exception("Network error")
 
         with patch(
             "envdrift.scanner.talisman.get_talisman_path",

--- a/tests/scanner/test_trivy.py
+++ b/tests/scanner/test_trivy.py
@@ -621,14 +621,14 @@ class TestTrivyInstallerInstall:
     """Tests for TrivyInstaller.install method."""
 
     @patch("envdrift.scanner.trivy.get_trivy_path")
-    @patch("urllib.request.urlretrieve")
+    @patch("envdrift.scanner.trivy.download_file")
     @patch("envdrift.scanner.platform_utils.platform.system", return_value="Linux")
     @patch("envdrift.scanner.platform_utils.platform.machine", return_value="x86_64")
     def test_install_success(
         self,
         mock_machine: MagicMock,
         mock_system: MagicMock,
-        mock_urlretrieve: MagicMock,
+        mock_download_file: MagicMock,
         mock_get_path: MagicMock,
         tmp_path: Path,
     ):
@@ -642,7 +642,7 @@ class TestTrivyInstallerInstall:
 
         checksums_path = tmp_path / "stub-checksums.txt"
 
-        def fake_download(url: str, dest: str) -> None:
+        def fake_download(url: str, dest: str, **_kwargs) -> None:
             # Create a fake tar.gz with trivy binary
             with tarfile.open(dest, "w:gz") as tar:
                 info = tarfile.TarInfo(name="trivy")
@@ -650,7 +650,7 @@ class TestTrivyInstallerInstall:
                 tar.addfile(info, io.BytesIO(b"fake"))
             write_checksums_for(Path(dest), checksums_path, url.rsplit("/", 1)[-1])
 
-        mock_urlretrieve.side_effect = fake_download
+        mock_download_file.side_effect = fake_download
 
         installer = TrivyInstaller()
         with patch.object(
@@ -664,34 +664,34 @@ class TestTrivyInstallerInstall:
         assert target_path.exists()
 
     @patch("envdrift.scanner.trivy.get_trivy_path")
-    @patch("urllib.request.urlretrieve")
+    @patch("envdrift.scanner.trivy.download_file")
     @patch("envdrift.scanner.platform_utils.platform.system", return_value="Linux")
     @patch("envdrift.scanner.platform_utils.platform.machine", return_value="x86_64")
     def test_install_download_failure(
         self,
         mock_machine: MagicMock,
         mock_system: MagicMock,
-        mock_urlretrieve: MagicMock,
+        mock_download_file: MagicMock,
         mock_get_path: MagicMock,
         tmp_path: Path,
     ):
         """Test installation failure on download error."""
         mock_get_path.return_value = tmp_path / "trivy"
-        mock_urlretrieve.side_effect = Exception("Network error")
+        mock_download_file.side_effect = Exception("Network error")
 
         installer = TrivyInstaller()
         with pytest.raises(TrivyInstallError, match="Download failed"):
             installer.install()
 
     @patch("envdrift.scanner.trivy.get_trivy_path")
-    @patch("urllib.request.urlretrieve")
+    @patch("envdrift.scanner.trivy.download_file")
     @patch("envdrift.scanner.platform_utils.platform.system", return_value="Linux")
     @patch("envdrift.scanner.platform_utils.platform.machine", return_value="x86_64")
     def test_install_binary_not_found_in_archive(
         self,
         mock_machine: MagicMock,
         mock_system: MagicMock,
-        mock_urlretrieve: MagicMock,
+        mock_download_file: MagicMock,
         mock_get_path: MagicMock,
         tmp_path: Path,
     ):
@@ -703,7 +703,7 @@ class TestTrivyInstallerInstall:
 
         checksums_path = tmp_path / "stub-checksums.txt"
 
-        def fake_download(url: str, dest: str) -> None:
+        def fake_download(url: str, dest: str, **_kwargs) -> None:
             # Create a tar.gz without trivy binary
             with tarfile.open(dest, "w:gz") as tar:
                 info = tarfile.TarInfo(name="other_file.txt")
@@ -711,7 +711,7 @@ class TestTrivyInstallerInstall:
                 tar.addfile(info, io.BytesIO(b"test"))
             write_checksums_for(Path(dest), checksums_path, url.rsplit("/", 1)[-1])
 
-        mock_urlretrieve.side_effect = fake_download
+        mock_download_file.side_effect = fake_download
 
         installer = TrivyInstaller()
         with (

--- a/tests/scanner/test_trivy.py
+++ b/tests/scanner/test_trivy.py
@@ -642,7 +642,7 @@ class TestTrivyInstallerInstall:
 
         checksums_path = tmp_path / "stub-checksums.txt"
 
-        def fake_download(url: str, dest: str, **_kwargs) -> None:
+        def fake_download(url: str, dest: Path, **_kwargs) -> None:
             # Create a fake tar.gz with trivy binary
             with tarfile.open(dest, "w:gz") as tar:
                 info = tarfile.TarInfo(name="trivy")
@@ -703,7 +703,7 @@ class TestTrivyInstallerInstall:
 
         checksums_path = tmp_path / "stub-checksums.txt"
 
-        def fake_download(url: str, dest: str, **_kwargs) -> None:
+        def fake_download(url: str, dest: Path, **_kwargs) -> None:
             # Create a tar.gz without trivy binary
             with tarfile.open(dest, "w:gz") as tar:
                 info = tarfile.TarInfo(name="other_file.txt")

--- a/tests/scanner/test_trufflehog.py
+++ b/tests/scanner/test_trufflehog.py
@@ -256,13 +256,12 @@ class TestTrufflehogInstaller:
         monkeypatch.setattr(installer, "get_checksums_url", lambda: checksums_url)
         monkeypatch.setattr(platform, "system", lambda: "Linux")
 
-        def fake_urlretrieve(_url: str, filename: str):
+        def fake_download(_url: str, filename: Path, **_kwargs) -> None:
             shutil.copy2(archive_path, filename)
-            return filename, None
 
         monkeypatch.setattr(
-            "envdrift.scanner.trufflehog.urllib.request.urlretrieve",
-            fake_urlretrieve,
+            "envdrift.scanner.trufflehog.download_file",
+            fake_download,
         )
 
         target_path = tmp_path / "bin" / "trufflehog"
@@ -283,13 +282,12 @@ class TestTrufflehogInstaller:
         monkeypatch.setattr(installer, "get_checksums_url", lambda: checksums_url)
         monkeypatch.setattr(platform, "system", lambda: "Windows")
 
-        def fake_urlretrieve(_url: str, filename: str):
+        def fake_download(_url: str, filename: Path, **_kwargs) -> None:
             shutil.copy2(archive_path, filename)
-            return filename, None
 
         monkeypatch.setattr(
-            "envdrift.scanner.trufflehog.urllib.request.urlretrieve",
-            fake_urlretrieve,
+            "envdrift.scanner.trufflehog.download_file",
+            fake_download,
         )
 
         target_path = tmp_path / "bin" / "trufflehog.exe"

--- a/tests/unit/coverage/test_cov_scanner_gitleaks.py
+++ b/tests/unit/coverage/test_cov_scanner_gitleaks.py
@@ -85,16 +85,16 @@ class TestDownloadAndExtractErrors:
     """Error branches in download_and_extract (lines 249-250, 260, 272)."""
 
     def test_download_failure_wrapped_in_install_error(self, tmp_path: Path, monkeypatch):
-        """A urlretrieve failure is wrapped in GitleaksInstallError (lines 249-250)."""
+        """A bounded-download failure is wrapped in GitleaksInstallError."""
         installer = GitleaksInstaller(version="8.30.0")
         monkeypatch.setattr(
             installer, "get_download_url", lambda: "https://example.com/gitleaks.tar.gz"
         )
 
-        def boom(_url, _filename):
+        def boom(_url, _filename, **_kwargs):
             raise OSError("network down")
 
-        monkeypatch.setattr("envdrift.scanner.gitleaks.urllib.request.urlretrieve", boom)
+        monkeypatch.setattr("envdrift.scanner.gitleaks.download_file", boom)
 
         with pytest.raises(GitleaksInstallError, match="Download failed: network down"):
             installer.download_and_extract(tmp_path / "bin" / "gitleaks")
@@ -108,14 +108,11 @@ class TestDownloadAndExtractErrors:
 
         checksums_path = tmp_path / "stub-checksums.txt"
 
-        def fake_urlretrieve(_url, filename):
+        def fake_download(_url, filename, **_kwargs):
             Path(filename).write_bytes(b"junk")
             write_checksums_for(Path(filename), checksums_path, "gitleaks.rar")
-            return filename, None
 
-        monkeypatch.setattr(
-            "envdrift.scanner.gitleaks.urllib.request.urlretrieve", fake_urlretrieve
-        )
+        monkeypatch.setattr("envdrift.scanner.gitleaks.download_file", fake_download)
         monkeypatch.setattr(
             installer, "get_checksums_url", lambda: checksums_path.resolve().as_uri()
         )
@@ -140,13 +137,10 @@ class TestDownloadAndExtractErrors:
         )
         monkeypatch.setattr(platform, "system", lambda: "Linux")
 
-        def fake_urlretrieve(_url, filename):
+        def fake_download(_url, filename, **_kwargs):
             Path(filename).write_bytes(archive.read_bytes())
-            return filename, None
 
-        monkeypatch.setattr(
-            "envdrift.scanner.gitleaks.urllib.request.urlretrieve", fake_urlretrieve
-        )
+        monkeypatch.setattr("envdrift.scanner.gitleaks.download_file", fake_download)
         checksums_url = write_checksums_for(
             archive, tmp_path / "stub-checksums.txt", "gitleaks.tar.gz"
         )

--- a/tests/unit/coverage/test_cov_scanner_infisical.py
+++ b/tests/unit/coverage/test_cov_scanner_infisical.py
@@ -78,7 +78,7 @@ class TestDownloadAndExtractBranches:
 
         checksums_path = tmp_path / "stub-checksums.txt"
 
-        def fake_download(url: str, dest: str, **_kwargs) -> None:
+        def fake_download(url: str, dest: Path, **_kwargs) -> None:
             with zipfile.ZipFile(dest, "w") as zf:
                 zf.writestr("infisical.exe", "binary-bytes")
             write_checksums_for(Path(dest), checksums_path, url.rsplit("/", 1)[-1])
@@ -110,7 +110,7 @@ class TestDownloadAndExtractBranches:
         mock_url.return_value = "https://example.test/infisical_x_linux.bz2"
         checksums_path = tmp_path / "stub-checksums.txt"
 
-        def fake_download(url: str, dest: str, **_kwargs) -> None:
+        def fake_download(url: str, dest: Path, **_kwargs) -> None:
             Path(dest).write_bytes(b"x")
             write_checksums_for(Path(dest), checksums_path, url.rsplit("/", 1)[-1])
 

--- a/tests/unit/coverage/test_cov_scanner_infisical.py
+++ b/tests/unit/coverage/test_cov_scanner_infisical.py
@@ -61,12 +61,12 @@ class TestDownloadAndExtractBranches:
     """Cover the zip and unknown-archive branches of download_and_extract."""
 
     @patch("envdrift.scanner.infisical.platform.system", return_value="Windows")
-    @patch("urllib.request.urlretrieve")
+    @patch("envdrift.scanner.infisical.download_file")
     @patch.object(InfisicalInstaller, "get_download_url")
     def test_zip_archive_branch(
         self,
         mock_url: MagicMock,
-        mock_urlretrieve: MagicMock,
+        mock_download_file: MagicMock,
         mock_system: MagicMock,
         tmp_path: Path,
     ):
@@ -78,12 +78,12 @@ class TestDownloadAndExtractBranches:
 
         checksums_path = tmp_path / "stub-checksums.txt"
 
-        def fake_download(url: str, dest: str) -> None:
+        def fake_download(url: str, dest: str, **_kwargs) -> None:
             with zipfile.ZipFile(dest, "w") as zf:
                 zf.writestr("infisical.exe", "binary-bytes")
             write_checksums_for(Path(dest), checksums_path, url.rsplit("/", 1)[-1])
 
-        mock_urlretrieve.side_effect = fake_download
+        mock_download_file.side_effect = fake_download
 
         installer = InfisicalInstaller(version="x")
         with patch.object(
@@ -96,12 +96,12 @@ class TestDownloadAndExtractBranches:
         assert target.exists()
         assert target.read_text() == "binary-bytes"
 
-    @patch("urllib.request.urlretrieve")
+    @patch("envdrift.scanner.infisical.download_file")
     @patch.object(InfisicalInstaller, "get_download_url")
     def test_unknown_archive_format_raises(
         self,
         mock_url: MagicMock,
-        mock_urlretrieve: MagicMock,
+        mock_download_file: MagicMock,
         tmp_path: Path,
     ):
         """An unrecognized archive extension raises (line 200)."""
@@ -110,11 +110,11 @@ class TestDownloadAndExtractBranches:
         mock_url.return_value = "https://example.test/infisical_x_linux.bz2"
         checksums_path = tmp_path / "stub-checksums.txt"
 
-        def fake_download(url: str, dest: str) -> None:
+        def fake_download(url: str, dest: str, **_kwargs) -> None:
             Path(dest).write_bytes(b"x")
             write_checksums_for(Path(dest), checksums_path, url.rsplit("/", 1)[-1])
 
-        mock_urlretrieve.side_effect = fake_download
+        mock_download_file.side_effect = fake_download
 
         installer = InfisicalInstaller(version="x")
         with (

--- a/tests/unit/coverage/test_cov_scanner_trivy.py
+++ b/tests/unit/coverage/test_cov_scanner_trivy.py
@@ -55,7 +55,7 @@ class TestDownloadAndExtractArchiveTypes:
 
         checksums_path = tmp_path / "stub-checksums.txt"
 
-        def fake_download(url: str, dest: str, **_kwargs) -> None:
+        def fake_download(url: str, dest: Path, **_kwargs) -> None:
             import zipfile
 
             with zipfile.ZipFile(dest, "w") as zf:
@@ -89,7 +89,7 @@ class TestDownloadAndExtractArchiveTypes:
         """An archive with an unrecognized extension raises TrivyInstallError."""
         checksums_path = tmp_path / "stub-checksums.txt"
 
-        def fake_download(url: str, dest: str, **_kwargs) -> None:
+        def fake_download(url: str, dest: Path, **_kwargs) -> None:
             Path(dest).write_bytes(b"x")
             write_checksums_for(Path(dest), checksums_path, url.rsplit("/", 1)[-1])
 

--- a/tests/unit/coverage/test_cov_scanner_trivy.py
+++ b/tests/unit/coverage/test_cov_scanner_trivy.py
@@ -48,21 +48,21 @@ class TestDownloadUrlTemplateFallback:
 class TestDownloadAndExtractArchiveTypes:
     """Cover the zip and unknown-archive branches in download_and_extract."""
 
-    @patch("urllib.request.urlretrieve")
-    def test_zip_archive_branch(self, mock_urlretrieve: MagicMock, tmp_path: Path):
+    @patch("envdrift.scanner.trivy.download_file")
+    def test_zip_archive_branch(self, mock_download_file: MagicMock, tmp_path: Path):
         """A .zip download routes through _extract_zip and installs the binary."""
         target = tmp_path / "out" / "trivy.exe"
 
         checksums_path = tmp_path / "stub-checksums.txt"
 
-        def fake_download(url: str, dest: str) -> None:
+        def fake_download(url: str, dest: str, **_kwargs) -> None:
             import zipfile
 
             with zipfile.ZipFile(dest, "w") as zf:
                 zf.writestr("trivy.exe", "binary-bytes")
             write_checksums_for(Path(dest), checksums_path, url.rsplit("/", 1)[-1])
 
-        mock_urlretrieve.side_effect = fake_download
+        mock_download_file.side_effect = fake_download
 
         installer = TrivyInstaller(version="0.58.0")
         # Force a windows .zip URL regardless of host platform.
@@ -84,16 +84,16 @@ class TestDownloadAndExtractArchiveTypes:
         assert target.exists()
         assert target.read_text() == "binary-bytes"
 
-    @patch("urllib.request.urlretrieve")
-    def test_unknown_archive_format_raises(self, mock_urlretrieve: MagicMock, tmp_path: Path):
+    @patch("envdrift.scanner.trivy.download_file")
+    def test_unknown_archive_format_raises(self, mock_download_file: MagicMock, tmp_path: Path):
         """An archive with an unrecognized extension raises TrivyInstallError."""
         checksums_path = tmp_path / "stub-checksums.txt"
 
-        def fake_download(url: str, dest: str) -> None:
+        def fake_download(url: str, dest: str, **_kwargs) -> None:
             Path(dest).write_bytes(b"x")
             write_checksums_for(Path(dest), checksums_path, url.rsplit("/", 1)[-1])
 
-        mock_urlretrieve.side_effect = fake_download
+        mock_download_file.side_effect = fake_download
         installer = TrivyInstaller()
         with (
             patch.object(

--- a/tests/unit/test_download_integrity.py
+++ b/tests/unit/test_download_integrity.py
@@ -20,6 +20,7 @@ import socket
 import sys
 import tarfile
 import threading
+import time
 from functools import partial
 from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
@@ -80,6 +81,46 @@ def file_server(tmp_path: Path):
         server.shutdown()
         thread.join(timeout=5)
         server.server_close()
+
+
+@pytest.fixture
+def stall_server():
+    """Accept one HTTP connection but withhold its response for a bounded time.
+
+    The forced close makes a regression fail quickly instead of leaving a CI
+    worker blocked forever if a caller stops passing its per-request timeout.
+    """
+    server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    server.bind(("127.0.0.1", 0))
+    server.listen(1)
+    server.settimeout(0.1)
+    accepted = threading.Event()
+    release = threading.Event()
+
+    def serve() -> None:
+        try:
+            while not release.is_set():
+                try:
+                    connection, _ = server.accept()
+                except TimeoutError:
+                    continue
+                with connection:
+                    accepted.set()
+                    release.wait(timeout=3)
+                return
+        finally:
+            server.close()
+
+    thread = threading.Thread(target=serve, daemon=True)
+    thread.start()
+    try:
+        yield SimpleNamespace(
+            base_url=f"http://127.0.0.1:{server.getsockname()[1]}", accepted=accepted
+        )
+    finally:
+        release.set()
+        thread.join(timeout=5)
 
 
 def _sha256_bytes(data: bytes) -> str:
@@ -147,6 +188,16 @@ SCANNER_CASES = [
     pytest.param(trufflehog_mod, "Trufflehog", "trufflehog", id="trufflehog"),
     pytest.param(trivy_mod, "Trivy", "trivy", id="trivy"),
     pytest.param(infisical_mod, "Infisical", "infisical", id="infisical"),
+]
+
+TIMEOUT_SCANNER_CASES = [
+    pytest.param(gitleaks_mod, "Gitleaks", "gitleaks", "download_and_extract", id="gitleaks"),
+    pytest.param(
+        trufflehog_mod, "Trufflehog", "trufflehog", "download_and_extract", id="trufflehog"
+    ),
+    pytest.param(trivy_mod, "Trivy", "trivy", "download_and_extract", id="trivy"),
+    pytest.param(infisical_mod, "Infisical", "infisical", "download_and_extract", id="infisical"),
+    pytest.param(talisman_mod, "Talisman", "talisman", "download_binary", id="talisman"),
 ]
 
 
@@ -255,6 +306,32 @@ class TestScannerAutoInstallIntegrity:
         )
         leftovers = [p.name for p in target.parent.iterdir() if p.name != target.name]
         assert leftovers == [], f"staging file(s) left behind: {leftovers}"
+
+
+@pytest.mark.parametrize(("mod", "prefix", "tool", "method"), TIMEOUT_SCANNER_CASES)
+def test_scanner_download_stall_uses_bounded_timeout(
+    mod, prefix, tool, method, stall_server, tmp_path: Path, monkeypatch
+):
+    """An accepted-but-stalled release request fails promptly for every scanner (#515)."""
+    timeout = 0.25
+    monkeypatch.setattr(mod, "DOWNLOAD_TIMEOUT_SECONDS", timeout)
+
+    installer = getattr(mod, f"{prefix}Installer")()
+    monkeypatch.setattr(
+        installer,
+        "get_download_url",
+        lambda: f"{stall_server.base_url}/release-artifact",
+    )
+    install_error = getattr(mod, f"{prefix}InstallError")
+    target = tmp_path / "bin" / _exe(tool)
+
+    started = time.monotonic()
+    with pytest.raises(install_error, match="Download failed"):
+        getattr(installer, method)(target)
+    elapsed = time.monotonic() - started
+
+    assert stall_server.accepted.wait(0.5), "the installer never reached the release server"
+    assert elapsed < 1.5, f"download ignored its {timeout}s per-request timeout ({elapsed:.2f}s)"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Scanner auto-install downloads now use a shared, streaming `urlopen` helper with a per-request timeout, so an accepted-but-stalled release server cannot hang installation indefinitely.

## Changes

- Replace unbounded `urlretrieve` in gitleaks, trufflehog, trivy, infisical, and talisman installers.
- Share the 60-second download timeout through download-integrity utilities.
- Preserve typed installer errors and existing checksum/staging behavior.
- Add real local accept-then-stall coverage for all five installers.

## Related issues

Closes #515

## Validation

- Static: Ruff, formatting, Pyrefly, Bandit
- Focused scanner/integrity tests: 363 passed, 4 skipped
- Full non-integration suite: 3326 passed, 5 skipped, 541 deselected, 1 xpassed
- Full integration suite: 504 passed, 37 skipped, 3332 deselected

## Checklist

- [x] Real behavioral regression coverage for all affected installers.
- [x] No passing test was skipped or xfailed.
- [x] Documentation is not needed: this fixes bounded internal transfer behavior without changing the CLI workflow.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jainal09/envdrift/pull/606?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Scanner auto-install downloads now have a 60-second timeout, preventing stalled connections from hanging indefinitely.
  * Improved consistency and reliability across supported scanner binary and archive downloads.

* **Tests**
  * Added coverage verifying stalled downloads fail within the configured timeout.
  * Updated installation tests for the standardized download behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bounds scanner auto-install downloads so stalled release servers do not hang installs. The main changes are:

- A shared streaming download helper with a 60-second request timeout.
- Updated gitleaks, trufflehog, trivy, infisical, and talisman installers.
- Shared timeout usage for dotenvx.
- Socket-stall tests for the affected scanner installers.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/envdrift/install_integrity.py | Adds the shared download timeout constant and streaming download helper. |
| src/envdrift/scanner/gitleaks.py | Moves archive download to the shared bounded helper. |
| src/envdrift/scanner/trufflehog.py | Moves archive download to the shared bounded helper. |
| src/envdrift/scanner/trivy.py | Moves archive download to the shared bounded helper. |
| src/envdrift/scanner/infisical.py | Moves archive download to the shared bounded helper. |
| src/envdrift/scanner/talisman.py | Moves direct binary download to the shared bounded helper. |
| tests/unit/test_download_integrity.py | Adds stalled-download coverage for the five scanner installers. |

<sub>Reviews (3): Last reviewed commit: ["test(scanner): align download mock types"](https://github.com/jainal09/envdrift/commit/5180a3df8dfa34671301bf35cd4ef7a6ac9e778e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43460300)</sub>

<!-- /greptile_comment -->