### PR TITLE
fix(install): support Python launcher arguments

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -230,7 +230,9 @@ function Initialize-Venv {
     else {
         Write-Info "Creating virtual environment at $VenvDir"
         New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
-        & @script:PythonCmd -m venv $VenvDir
+        $pythonExe = $script:PythonCmd[0]
+        $pythonArgs = @($script:PythonCmd | Select-Object -Skip 1)
+        & $pythonExe @pythonArgs -m venv $VenvDir
         if ($LASTEXITCODE -ne 0) {
             Stop-WithError "Failed to create virtual environment"
         }

--- a/tests/unit/test_install_ps1.py
+++ b/tests/unit/test_install_ps1.py
@@ -1,4 +1,4 @@
-"""Regression tests for ``install.ps1`` Windows PowerShell 5.1 compatibility (#483).
+"""Regression tests for the ``install.ps1`` Windows execution contract (#483, #501).
 
 The documented install flow (``irm ... | iex``) runs in the OS-default Windows
 PowerShell 5.1 on every stock Windows box, so ``install.ps1`` must stay within
@@ -11,6 +11,9 @@ the 5.1 language/cmdlet surface:
   ``-Encoding ASCII``, mangling non-ASCII profile paths (``José`` -> ``Jos?``)
   into a dead wrapper. The wrapper must resolve the venv at runtime so it works
   for any user-profile path.
+- The py launcher is represented as a command plus a version selector. Splatting
+  both at the call-operator position joins them into one nonexistent executable;
+  the installer must invoke the executable and its arguments separately.
 
 These drive the *real* installer code under a real PowerShell engine — no
 re-implementation of the behavior under test. They are deliberately not marked
@@ -172,6 +175,38 @@ $ErrorActionPreference = 'SilentlyContinue'
 [Console]::Out.WriteLine("EAP_AFTER=$ErrorActionPreference")
 """
 
+# Runs the real Initialize-Venv with the same multi-element command shape used
+# for the py launcher. ``-X utf8`` is a valid interpreter-level option and lets
+# the test use CI's selected Python without assuming a particular py registration.
+# PIP_NO_INDEX makes the function's best-effort pip upgrade deterministic and
+# network-free after the venv has been created.
+_MULTI_ARG_PYTHON_HARNESS = """
+param([string]$ScriptPath, [string]$PythonExe, [string]$InstallDir)
+$ErrorActionPreference = 'Stop'
+$tokens = $null
+$errors = $null
+$ast = [System.Management.Automation.Language.Parser]::ParseFile(
+    $ScriptPath, [ref]$tokens, [ref]$errors)
+if ($errors.Count -gt 0) {
+    foreach ($e in $errors) { [Console]::Error.WriteLine($e.ToString()) }
+    exit 2
+}
+$functions = $ast.FindAll(
+    { param($n) $n -is [System.Management.Automation.Language.FunctionDefinitionAst] },
+    $true)
+foreach ($fn in $functions) {
+    . ([scriptblock]::Create($fn.Extent.Text))
+}
+$script:InstallDir = $InstallDir
+$script:VenvDir = Join-Path $InstallDir 'venv'
+$script:PythonCmd = @($PythonExe, '-X', 'utf8')
+$env:PIP_NO_INDEX = '1'
+$env:PIP_DISABLE_PIP_VERSION_CHECK = '1'
+Initialize-Venv
+if (-not (Test-Path $script:VenvPython)) { exit 3 }
+[Console]::Out.WriteLine("MULTI_ARG_PYTHON_OK")
+"""
+
 
 def _powershell() -> str | None:
     """Best available PowerShell: pwsh (7+) anywhere, else Windows PowerShell."""
@@ -313,6 +348,29 @@ def test_initialize_venv_restores_caller_error_action_preference(tmp_path: Path)
         "Initialize-Venv must restore the caller's $ErrorActionPreference "
         f"instead of hardcoding 'Stop':\n{proc.stdout}"
     )
+
+
+@requires_windows_powershell_51
+def test_initialize_venv_accepts_python_command_with_arguments(tmp_path: Path) -> None:
+    """Initialize-Venv must keep launcher arguments separate from its executable.
+
+    Find-Python stores the py-launcher fallback as ``@('py', '-3')``. Passing
+    that array directly to ``&`` joins it into a command name such as ``py -3``,
+    which does not exist and aborts py-launcher-only installs (#501).
+    """
+    install_dir = tmp_path / "multi-arg-python"
+    proc = _run_harness(
+        _windows_powershell_51() or "",
+        _MULTI_ARG_PYTHON_HARNESS,
+        tmp_path,
+        str(INSTALL_PS1),
+        sys.executable,
+        str(install_dir),
+    )
+    assert proc.returncode == 0, (
+        f"Initialize-Venv rejected a multi-part Python command:\n{proc.stdout}\n{proc.stderr}"
+    )
+    assert "MULTI_ARG_PYTHON_OK" in proc.stdout
 
 
 @requires_powershell


### PR DESCRIPTION
## Summary

- split the selected Python executable from its launcher arguments before invoking `venv`
- preserve both plain `python` commands and multi-part `py -3` / `py -3.X` fallbacks
- add a real Windows PowerShell 5.1 regression that drives `Initialize-Venv`

## Verification

- reproduced on pre-fix main under Windows PowerShell 5.1: a multi-part command was joined into one nonexistent executable
- verified the fix with the actual `py -3` launcher, creating a Python 3.14 venv under `C:\DBSW`
- `uv run ruff check src tests`
- `uv run ruff format --check .`
- `uv run pyrefly check`
- `uv run bandit -r src -c pyproject.toml`
- `uv run pytest -m 'not integration'` (3326 passed, 6 skipped, 541 deselected, 1 xpassed)
- rebased onto v10.16.8 and reran all static gates plus the focused installer suite

Full backend integration was not run because this changes only the Windows bootstrap script; the real Windows installer path was exercised directly.

Closes #501

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jainal09/envdrift/pull/610?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes Windows virtualenv creation when the selected Python command includes launcher arguments.

- Splits the Python executable from its launcher arguments before running `venv`.
- Keeps plain `python` commands and `py -3` style commands supported.
- Adds a Windows PowerShell 5.1 regression test for the real installer path.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| install.ps1 | Updates `Initialize-Venv` to invoke the Python executable and its launcher arguments separately. |
| tests/unit/test_install_ps1.py | Adds regression coverage for multi-part Python commands under Windows PowerShell 5.1. |

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/py-launcher..."](https://github.com/jainal09/envdrift/commit/a0788397cae5bec0275e0d9fe9e0207681bf3282) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43462648)</sub>

<!-- /greptile_comment -->