### PR TITLE
docs: correct encryption and guard examples

### DIFF
--- a/docs/cli/encrypt.md
+++ b/docs/cli/encrypt.md
@@ -178,9 +178,9 @@ envdrift encrypt .env.production
 This will:
 
 1. Install dotenvx if `encryption.dotenvx.auto_install` is enabled
-2. Generate an ECIES (secp256k1) keypair, encrypt each sensitive value with the
-   public key (ECIES envelope around an AES-256-GCM payload), and rewrite the
-   file in place
+2. Generate an ECIES (secp256k1) keypair, encrypt every value with the public
+   key (ECIES envelope around an AES-256-GCM payload), and rewrite the file in
+   place
 3. Create `.env.keys` with the matching private key (never commit this!)
 
 ### Encrypt with SOPS
@@ -221,8 +221,8 @@ The `--check` option provides a detailed report:
 envdrift integrates with [dotenvx](https://dotenvx.com/) for encryption:
 
 1. **Encrypted format**: dotenvx uses ECIES (secp256k1 public-key encryption)
-   wrapping an AES-256-GCM payload. Each sensitive value is encrypted to the
-   project's public key and prefixed with `encrypted:`
+   wrapping an AES-256-GCM payload. Every value is encrypted to the project's
+   public key and prefixed with `encrypted:`
 2. **Key storage**: The matching private key lives in `.env.keys` (add to
    `.gitignore`); the public key is written into the encrypted file as
    `DOTENV_PUBLIC_KEY_<ENV>` so anyone can encrypt new values without the
@@ -234,11 +234,15 @@ Example encrypted file:
 ```bash
 #/-------------------[DOTENV_PUBLIC_KEY]--------------------/
 DOTENV_PUBLIC_KEY_PRODUCTION="03abc123..."
-DATABASE_URL="encrypted:BDQE1234567890abcdef..."
-API_KEY="encrypted:BDQEsecretkey123456..."
-DEBUG=false
+DATABASE_URL=encrypted:BDQE1234567890abcdef...
+API_KEY=encrypted:BDQEsecretkey123456...
+DEBUG=encrypted:BDQEfalse1234567890...
 #/----------------------------------------------------------/
 ```
+
+The sensitive-field detection below powers `--check` warnings; it does not make
+dotenvx encryption selective. For selective encryption, use
+[partial encryption](../guides/partial-encryption.md).
 
 ## How SOPS Encryption Works
 

--- a/docs/cli/encrypt.md
+++ b/docs/cli/encrypt.md
@@ -240,6 +240,9 @@ DEBUG=encrypted:BDQEfalse1234567890...
 #/----------------------------------------------------------/
 ```
 
+The pinned dotenvx binary quotes the public-key value but writes ciphertext
+values unquoted; the example preserves that generated format.
+
 The sensitive-field detection below powers `--check` warnings; it does not make
 dotenvx encryption selective. For selective encryption, use
 [partial encryption](../guides/partial-encryption.md).

--- a/docs/cli/guard.md
+++ b/docs/cli/guard.md
@@ -314,8 +314,9 @@ envdrift guard --ci --fail-on high
 Minimum severity to return a non-zero exit code in CI mode. Accepts
 `critical`, `high`, `medium`, or `low`. Any finding at or above the chosen
 threshold fails CI with that severity's exit code (see [Exit Codes](#exit-codes))
-— including `--fail-on low` on a LOW-only result (such as an unencrypted-file
-policy violation), which exits with code `4`, distinct from HIGH's code `2`.
+— including `--fail-on low` on a LOW-only result, which exits with code `4`,
+distinct from HIGH's code `2`. An unencrypted environment file is HIGH and exits
+with code `2` when it blocks the run.
 `INFO` findings are informational only and never fail CI.
 
 ```bash
@@ -433,9 +434,9 @@ incomplete scan and for operational errors:
 | :-- | :-- |
 | 0 | No blocking findings |
 | 1 | Critical findings |
-| 2 | High findings |
+| 2 | High findings (including unencrypted environment files) |
 | 3 | Medium findings |
-| 4 | Low findings (policy violations, e.g. unencrypted file) |
+| 4 | Low findings |
 | 5 | Scan incomplete: a selected scanner ran but failed |
 | 6 | Operational error (bad config, invalid path or flags) |
 

--- a/docs/cli/sync.md
+++ b/docs/cli/sync.md
@@ -296,8 +296,8 @@ Prompts for confirmation when values mismatch.
 
 ```text
 Value mismatch for myapp-key:
-  Local:  abc123def456...
-  Vault:  xyz789abc012...
+  Local:  <redacted len=64 sha=1a2b3c4d>
+  Vault:  <redacted len=64 sha=5e6f7a8b>
 Update local file with vault value? (y/N):
 ```
 
@@ -309,8 +309,8 @@ Reports differences without modifying files. Mismatches are reported as errors, 
 ```text
   x services/myapp - error
     Error: Local value differs from vault
-    Local:  abc123def456...
-    Vault:  xyz789abc012...
+    Local:  <redacted len=64 sha=1a2b3c4d>
+    Vault:  <redacted len=64 sha=5e6f7a8b>
 ```
 
 Every error row carries its reason. A missing local key is reported with a
@@ -328,7 +328,7 @@ Updates all mismatches without prompting. Creates backups before updating.
 
 ```text
   ~ services/myapp - updated
-    Backup: services/myapp/.env.keys.backup.20240115_143022
+    Backup: services/myapp/.env.keys.backup.20240115_143022_123456
 ```
 
 ## Output

--- a/docs/concepts/encryption-backends.md
+++ b/docs/concepts/encryption-backends.md
@@ -10,7 +10,7 @@ envdrift supports two encryption backends: **dotenvx** and **SOPS**. This page h
 | **Key storage** | `.env.keys` file | External KMS or age keys |
 | **Cloud KMS** | No (vault sync for key sharing) | Yes (native AWS/GCP/Azure KMS) |
 | **Team sharing** | Via envdrift vault sync | Via KMS permissions or key files |
-| **Partial encryption** | Yes | No |
+| **Partial encryption** | Via envdrift's split-file flow | No |
 | **Best for** | Small teams, simple setups | Enterprise, existing KMS infra |
 
 ## dotenvx
@@ -44,7 +44,8 @@ DEBUG=encrypted:BD2QpRf...
 
 - Simple setup, no external dependencies
 - Variable names remain readable while every value is encrypted
-- Consistent whole-file encryption with no accidental plaintext values
+- Whole-file encryption in the standard `encrypt` flow avoids accidental plaintext
+- A separate partial-encryption flow keeps selected values readable when needed
 - Works with envdrift's vault sync for team key sharing
 
 ### Disadvantages

--- a/docs/concepts/encryption-backends.md
+++ b/docs/concepts/encryption-backends.md
@@ -34,17 +34,17 @@ envdrift supports two encryption backends: **dotenvx** and **SOPS**. This page h
 
 ```bash
 # .env.production (encrypted)
-DOTENV_PUBLIC_KEY="034a5c..."
-DATABASE_URL="encrypted:BD7HQzb..."
-API_KEY="encrypted:BD9XKwm..."
-DEBUG=false  # Non-sensitive, not encrypted
+DOTENV_PUBLIC_KEY_PRODUCTION="034a5c..."
+DATABASE_URL=encrypted:BD7HQzb...
+API_KEY=encrypted:BD9XKwm...
+DEBUG=encrypted:BD2QpRf...
 ```
 
 ### Advantages
 
 - Simple setup, no external dependencies
-- Clear separation between encrypted and plain values
-- Easy to debug (can see which values are encrypted)
+- Variable names remain readable while every value is encrypted
+- Consistent whole-file encryption with no accidental plaintext values
 - Works with envdrift's vault sync for team key sharing
 
 ### Disadvantages

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -30,7 +30,7 @@ envdrift is built around three main ideas:
 │  ┌────────────────────┐      ┌────────────────────────────┐     │
 │  │ class Settings:    │      │ DATABASE_URL="encrypted:..." │    │
 │  │   DATABASE_URL: str│ ──── │ API_KEY="encrypted:..."      │    │
-│  │   API_KEY: str     │      │ DEBUG=false                  │    │
+│  │   API_KEY: str     │      │ DEBUG=encrypted:...          │    │
 │  │   DEBUG: bool      │      └────────────────────────────┘     │
 │  └────────────────────┘                                          │
 │                                                                  │

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -142,10 +142,10 @@ After encryption:
 
 ```bash
 # .env.prod (encrypted)
-DOTENV_PUBLIC_KEY="034a5c..."
-DATABASE_URL="encrypted:BD7HQzb..."
-API_KEY="encrypted:BD9XKwm..."
-DEBUG=false
+DOTENV_PUBLIC_KEY_PROD="034a5c..."
+DATABASE_URL=encrypted:BD7HQzb...
+API_KEY=encrypted:BD9XKwm...
+DEBUG=encrypted:BD2QpRf...
 ```
 
 The `DOTENV_PUBLIC_KEY*` line is a dotenvx artifact (a public key, not a

--- a/docs/guides/encryption.md
+++ b/docs/guides/encryption.md
@@ -103,13 +103,15 @@ Your `.gitignore` should include:
 DOTENV_PUBLIC_KEY_PRODUCTION="03abc123..."
 
 # .env.production
-DATABASE_URL="encrypted:BDQE1234567890abcdef..."
-API_KEY="encrypted:BDQEsecretkey123456..."
-DEBUG=false
+DATABASE_URL=encrypted:BDQE1234567890abcdef...
+API_KEY=encrypted:BDQEsecretkey123456...
+DEBUG=encrypted:BDQEfalse1234567890...
 #/----------------------------------------------------------/
 ```
 
-Note: Non-sensitive values like `DEBUG` remain plaintext.
+Dotenvx encrypts every value in the file, including non-secret configuration
+such as `DEBUG`. Use envdrift's [partial encryption](partial-encryption.md) flow
+when selected values must remain readable.
 
 ## SOPS Encrypted File Format
 

--- a/docs/support/faq.md
+++ b/docs/support/faq.md
@@ -142,11 +142,15 @@ class Settings(BaseSettings):
 Use Pydantic's nested model support:
 
 ```python
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
 class DatabaseSettings(BaseSettings):
     URL: str
     POOL_SIZE: int = 5
 
 class Settings(BaseSettings):
+    model_config = SettingsConfigDict(env_nested_delimiter="__")
+
     DATABASE: DatabaseSettings
 ```
 

--- a/src/envdrift/scanner/base.py
+++ b/src/envdrift/scanner/base.py
@@ -41,7 +41,7 @@ class FindingSeverity(Enum):
     - CRITICAL: Confirmed secret (high-confidence pattern match)
     - HIGH: Very likely a secret (strong pattern or high entropy)
     - MEDIUM: Possibly a secret (moderate confidence)
-    - LOW: Policy violation (e.g., unencrypted file)
+    - LOW: Low-confidence finding or minor policy violation
     - INFO: Informational only
     """
 

--- a/tests/integration/test_docs_recipes.py
+++ b/tests/integration/test_docs_recipes.py
@@ -1,4 +1,4 @@
-"""Live verification of the documented recipes corrected in #498.
+"""Live verification of the documented recipes corrected in #498 and #499.
 
 Each test runs the *corrected* documented command against the real envdrift CLI
 (subprocess) and the real ``dotenvx`` binary, and also proves the *old*
@@ -12,6 +12,8 @@ can't drift back to a recipe that dies at the moment a user needs it:
   ``rotate`` command, and its removed v1 command is a no-op.
 - ``docs/guides/monorepo-setup.md`` shared keys: ``DOTENV_KEYS_PATH`` is read by
   nothing; dotenvx's ``--env-keys-file`` flag and a symlink both work.
+- dotenvx whole-file encryption: even a non-secret ``DEBUG=false`` value is
+  encrypted and the public-key variable is environment-suffixed.
 
 No mocking of the behavior under test.
 """
@@ -81,6 +83,32 @@ def _encrypt_production(envdrift_cmd: list[str], cwd: Path, env: dict[str, str])
     assert "encrypted:" in encrypted
     assert _PLAIN_VALUE not in encrypted
     return match.group(1)
+
+
+def test_dotenvx_encryption_recipe_encrypts_every_value(
+    envdrift_cmd: list[str],
+    dotenvx_bin: str,
+    work_dir: Path,
+    integration_env: dict[str, str],
+) -> None:
+    """Dotenvx encrypts non-secret configuration as well as sensitive values (#499)."""
+    del dotenvx_bin  # The fixture guarantees the real pinned binary is on PATH.
+    (work_dir / ".env.production").write_text(
+        "DATABASE_URL=postgres://user:pass@example.test/app\n"
+        "API_KEY=example-api-key\n"
+        "DEBUG=false\n",
+        encoding="utf-8",
+    )
+
+    result = _run([*envdrift_cmd, "encrypt", ".env.production"], work_dir, integration_env)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+    encrypted = (work_dir / ".env.production").read_text(encoding="utf-8")
+    assert 'DOTENV_PUBLIC_KEY_PRODUCTION="' in encrypted
+    assert "DATABASE_URL=encrypted:" in encrypted
+    assert "API_KEY=encrypted:" in encrypted
+    assert "DEBUG=encrypted:" in encrypted
+    assert "DEBUG=false" not in encrypted
 
 
 def test_faq_ci_decrypt_recipe_round_trips(

--- a/tests/unit/test_docs_accuracy.py
+++ b/tests/unit/test_docs_accuracy.py
@@ -1,4 +1,4 @@
-"""Regression tests pinning user docs to real CLI/library behavior (#413).
+"""Regression tests pinning user docs to real CLI/library behavior (#413, #498, #499).
 
 These assert the *rendered* docs match what the code actually produces, so the
 docs can't drift back to the stale state the audit found:
@@ -26,6 +26,13 @@ Plus the #498 sweep — recipes/keys the shipped tools reject or ignore:
 - ``docs/reference/api.md`` must describe ``init()``'s real alias-everything
   behavior, not the stale skip-and-UserWarning contract.
 
+And the #499 sweep — examples that contradicted live library/CLI behavior:
+
+- the nested-settings FAQ must configure Pydantic's ``env_nested_delimiter``;
+- dotenvx examples must show every value encrypted and the suffixed public key;
+- sync mismatch previews must be redacted and backup names include microseconds;
+- guard docs must identify unencrypted environment files as HIGH / exit 2.
+
 They read the real files — no mocking of the behavior under test.
 """
 
@@ -50,6 +57,90 @@ def _read(name: str) -> str:
 
 def _read_docs_page(relpath: str) -> str:
     return (_DOCS_ROOT / relpath).read_text(encoding="utf-8")
+
+
+def test_faq_nested_settings_recipe_configures_delimiter(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The FAQ recipe must load DATABASE__* through Pydantic's real delimiter (#499)."""
+    from pydantic_settings import BaseSettings, SettingsConfigDict
+
+    class DatabaseSettings(BaseSettings):
+        URL: str
+        POOL_SIZE: int = 5
+
+    class Settings(BaseSettings):
+        model_config = SettingsConfigDict(env_nested_delimiter="__")
+
+        DATABASE: DatabaseSettings
+
+    monkeypatch.setenv("DATABASE__URL", "postgres://example.test/app")
+    monkeypatch.setenv("DATABASE__POOL_SIZE", "10")
+    settings = Settings()
+    assert settings.DATABASE.URL == "postgres://example.test/app"
+    assert settings.DATABASE.POOL_SIZE == 10
+
+    text = _read_docs_page("support/faq.md")
+    assert "from pydantic_settings import BaseSettings, SettingsConfigDict" in text
+    assert 'SettingsConfigDict(env_nested_delimiter="__")' in text
+
+
+@pytest.mark.parametrize(
+    ("relpath", "expected_debug"),
+    [
+        ("getting-started/quickstart.md", "DEBUG=encrypted:BD2QpRf..."),
+        ("guides/encryption.md", "DEBUG=encrypted:BDQEfalse1234567890..."),
+        ("concepts/encryption-backends.md", "DEBUG=encrypted:BD2QpRf..."),
+        ("concepts/index.md", "DEBUG=encrypted:..."),
+        ("cli/encrypt.md", "DEBUG=encrypted:BDQEfalse1234567890..."),
+    ],
+)
+def test_dotenvx_examples_encrypt_every_value(relpath: str, expected_debug: str) -> None:
+    """Every dotenvx example must encrypt DEBUG instead of teaching selectivity (#499)."""
+    text = _read_docs_page(relpath)
+    assert expected_debug in text, f"{relpath} must show dotenvx encrypting DEBUG"
+
+    if relpath in {"getting-started/quickstart.md", "concepts/encryption-backends.md"}:
+        assert not re.search(r"(?m)^DOTENV_PUBLIC_KEY=", text), (
+            f"{relpath} must suffix the dotenvx public-key name with the environment"
+        )
+
+
+def test_sync_examples_redact_values_and_show_collision_safe_backup_name() -> None:
+    """sync.md must mirror the redaction and microsecond backup contracts (#499)."""
+    from envdrift.sync.operations import redact_value
+
+    # Ground truth: real previews never contain plaintext and use this shape.
+    preview = redact_value("a" * 64)
+    assert preview is not None
+    assert re.fullmatch(r"<redacted len=64 sha=[0-9a-f]{8}>", preview)
+
+    text = _read("sync.md")
+    assert "abc123def456..." not in text
+    assert "xyz789abc012..." not in text
+    assert len(re.findall(r"Local:\s+<redacted len=64 sha=[0-9a-f]{8}>", text)) >= 2
+    assert len(re.findall(r"Vault:\s+<redacted len=64 sha=[0-9a-f]{8}>", text)) >= 2
+    assert re.search(r"\.env\.keys\.backup\.\d{8}_\d{6}_\d{6}", text)
+
+
+def test_guard_docs_classify_unencrypted_env_as_high(tmp_path: Path) -> None:
+    """guard.md must match the native rule's HIGH severity and exit 2 (#499)."""
+    from envdrift.scanner.base import FindingSeverity
+    from envdrift.scanner.native import NativeScanner
+
+    env_file = tmp_path / ".env"
+    env_file.write_text("FOO=bar\nGREETING=hello\n", encoding="utf-8")
+    result = NativeScanner().scan([tmp_path])
+    finding = next(f for f in result.findings if f.rule_id == "unencrypted-env-file")
+    assert finding.severity == FindingSeverity.HIGH
+
+    text = _read("guard.md")
+    assert "An unencrypted environment file is HIGH" in text
+    assert "| 2 | High findings (including unencrypted environment files) |" in text
+    assert "Low findings (policy violations, e.g. unencrypted file)" not in text
+
+    base_text = (_REPO_ROOT / "src" / "envdrift" / "scanner" / "base.py").read_text(
+        encoding="utf-8"
+    )
+    assert "LOW: Policy violation (e.g., unencrypted file)" not in base_text
 
 
 def test_decrypt_md_does_not_hardcode_dotenvx_version() -> None:

--- a/tests/unit/test_docs_accuracy.py
+++ b/tests/unit/test_docs_accuracy.py
@@ -103,6 +103,15 @@ def test_dotenvx_examples_encrypt_every_value(relpath: str, expected_debug: str)
             f"{relpath} must suffix the dotenvx public-key name with the environment"
         )
 
+    if relpath == "concepts/encryption-backends.md":
+        assert "| **Partial encryption** | Via envdrift's split-file flow | No |" in text
+        assert "Whole-file encryption in the standard `encrypt` flow" in text
+
+    if relpath == "cli/encrypt.md":
+        assert re.search(
+            r"quotes the public-key value but writes ciphertext\s+values unquoted", text
+        )
+
 
 def test_sync_examples_redact_values_and_show_collision_safe_backup_name() -> None:
     """sync.md must mirror the redaction and microsecond backup contracts (#499)."""


### PR DESCRIPTION
## Summary

- correct dotenvx examples across five docs to show whole-file encryption, environment-suffixed public keys, and the real generated quoting format
- distinguish the standard whole-file encrypt flow from envdrift's separate split-file partial-encryption flow
- make the nested-settings FAQ configure Pydantic's `env_nested_delimiter`
- update sync mismatch previews to the real redacted form and backup names to microsecond precision
- align guard prose and the severity docstring with the real HIGH / exit-2 unencrypted-file rule
- add doc-contract tests plus a real pinned-dotenvx regression

Current-main triage found that `docs/cli/index.md` already lists guard exit code 4, so this PR deliberately leaves that resolved sub-item unchanged.

## Verification

- dogfooded encryption with pinned dotenvx 2.4.1 after #611: `DEBUG=false` became unquoted `DEBUG=encrypted:...` while the public-key value remained quoted
- dogfooded `guard --native-only`: an unencrypted `.env` reported HIGH and exited 2
- reproduced the Pydantic nested-settings failure without the delimiter and success with it
- `uv run ruff check src tests`
- `uv run ruff format --check .`
- `uv run pyrefly check`
- `uv run bandit -r src -c pyproject.toml`
- `make lint-docs`
- `uv run pytest -m 'not integration'` (3334 passed, 6 skipped, 542 deselected, 1 xpassed)
- `uv run pytest tests/integration/test_docs_recipes.py -q` with pinned dotenvx 2.4.1 (6 passed)
- focused review-fix checks: 25 passed

The full backend integration matrix was not run locally because runtime behavior is unchanged; the relevant real-binary integration file was run in full.

Closes #499
