### PR TITLE
fix(parser): mirror quoted and bare key semantics

### DIFF
--- a/src/envdrift/core/parser.py
+++ b/src/envdrift/core/parser.py
@@ -125,11 +125,32 @@ class EnvFile:
         return len(self.variables)
 
 
+@dataclass(frozen=True)
+class _KeyBinding:
+    """Lexed dotenv key and the raw value that follows it.
+
+    ``raw_value is None`` is a valid bare binding (``KEY`` without ``=``).
+    python-dotenv exposes those as ``None``, but pydantic-settings filters
+    them out before model validation; EnvDrift therefore consumes the full
+    binding without registering an ``EnvVar`` whose value the application
+    never receives (#573).
+    """
+
+    key: str | None
+    raw_value: str | None
+    consumed: int = 0
+    dropped: bool = False
+
+
 class EnvParser:
     """Parse .env files with multi-backend encryption awareness.
 
     Handles:
     - Standard KEY=value
+    - Single-quoted keys: ``'MY KEY'=value``; the key may span physical
+      lines exactly like python-dotenv. Bare bindings without ``=`` are
+      consumed but omitted because pydantic-settings filters their ``None``
+      values before model validation (#573).
     - Quoted values: KEY="value" or KEY='value'
     - dotenvx encrypted: KEY="encrypted:xxxx"
     - SOPS encrypted: KEY="ENC[AES256_GCM,data:...,iv:...,tag:...,type:str]"
@@ -185,6 +206,16 @@ class EnvParser:
     # .env), keeping the init→validate round-trip intact. Other callers keep the
     # strict pattern so their behaviour is unchanged.
     LENIENT_LINE_PATTERN = re.compile(r"^(?:export\s+)?([^\s=#]+)\s*=(.*)$")
+
+    # python-dotenv key lexer (#573). Quoted keys deliberately have no escape
+    # processing and may span physical lines; unquoted keys stop at ``=``,
+    # ``#``, or any whitespace. The existing LINE_PATTERN constants remain
+    # public/backward-compatible, while parse_string uses these smaller
+    # tokens so it can also recognize a binding with no ``=``.
+    EXPORT_PATTERN = re.compile(r"export[^\S\r\n]+")
+    UNQUOTED_KEY_PATTERN = re.compile(r"[^=\#\s]+")
+    STRICT_KEY_PATTERN = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+    BINDING_TAIL_PATTERN = re.compile(r"[^\S\r\n]*(?:#.*)?")
 
     # python-dotenv's quoted-value escape sets (dotenv/parser.py): decoded
     # inside double-/single-quoted values so `validate`/`diff` see exactly the
@@ -290,8 +321,10 @@ class EnvParser:
         env_file = EnvFile(path=Path())
         content, env_file.leading_bom = self._strip_leading_bom(content)
         lines = self.LINE_BOUNDARY_PATTERN.split(content)
-        pattern = self.LENIENT_LINE_PATTERN if lenient else self.LINE_PATTERN
-
+        # Includes bare bindings as ``None`` for sequential interpolation.
+        # EnvFile.variables intentionally contains only values the Pydantic
+        # dotenv source can pass to model validation (#573).
+        interpolation_values: dict[str, str | None] = {}
         index = 0
         while index < len(lines):
             line_num = index + 1
@@ -308,18 +341,29 @@ class EnvParser:
                 env_file.comments.append(line)
                 continue
 
-            # Parse KEY=value. Match the lstripped line — NOT the fully
-            # stripped one — so the RHS keeps its trailing whitespace: when a
-            # quote opens here and closes on a later line, python-dotenv keeps
-            # that whitespace inside the value (`CERT="abc   \nrest"` parses
-            # as `abc   \nrest`); single-line values strip it downstream.
-            match = pattern.match(original_line.lstrip())
-            if not match:
+            # Lex the key before the value. Unlike LINE_PATTERN, this accepts
+            # python-dotenv's single-quoted keys and consumes a quoted key
+            # across physical lines. That consumption is important even for
+            # bare bindings: interior ``K=1`` text belongs to the key and must
+            # never re-parse as a phantom assignment (#573).
+            binding = self._parse_key_binding(original_line, lines, index, lenient=lenient)
+            if binding is None:
+                continue
+            raw_lines = [original_line]
+            if binding.consumed:
+                raw_lines.extend(lines[index : index + binding.consumed])
+                index += binding.consumed
+            if binding.dropped or binding.key is None:
                 continue
 
-            key = match.group(1)
-            raw_value = match.group(2)
-            raw_lines = [original_line]
+            key = binding.key
+            if binding.raw_value is None:
+                # A later bare duplicate wins in dotenv_values (A=1; A ->
+                # A=None), and pydantic-settings then filters that None out.
+                interpolation_values[key] = None
+                env_file.variables.pop(key, None)
+                continue
+            raw_value = binding.raw_value
 
             # Quoted multiline continuation (#458): when the RHS opens a quote
             # that closes on a later physical line, the continuation lines are
@@ -345,7 +389,8 @@ class EnvParser:
             # the loader pydantic-settings uses — so validate/diff judge the
             # value the application receives, not the unexpanded literal.
             if "${" in value:
-                value = self._interpolate(value, env_file.variables)
+                value = self._interpolate(value, interpolation_values)
+            interpolation_values[key] = value
 
             # Determine encryption status and backend. Detection runs on the
             # interpolated value, so an alias of an encrypted variable
@@ -368,6 +413,73 @@ class EnvParser:
             env_file.variables[key] = env_var
 
         return env_file
+
+    def _parse_key_binding(
+        self, original_line: str, lines: list[str], start: int, *, lenient: bool
+    ) -> _KeyBinding | None:
+        """Lex one dotenv key, including quoted and bare forms (#573).
+
+        ``start`` points to the physical line after ``original_line``. A
+        single-quoted key follows python-dotenv's ``'([^']+)'`` token exactly:
+        it has no escape syntax, may contain newlines, and closes at the first
+        later quote. A malformed quoted key consumes through its close-quote
+        line before being dropped; an unterminated opener consumes only its
+        own line, matching python-dotenv's rest-of-line error recovery.
+
+        Bare bindings are returned with ``raw_value=None``. The caller skips
+        registration because pydantic-settings ignores python-dotenv's None
+        values, while still advancing over every physical line in the key.
+        """
+        text = original_line.lstrip()
+        export = self.EXPORT_PATTERN.match(text)
+        position = export.end() if export is not None else 0
+
+        if text[position : position + 1] == "'":
+            close = text.find("'", position + 1)
+            consumed = 0
+            close_line = text
+            if close != -1:
+                key = text[position + 1 : close]
+            else:
+                key_parts = [text[position + 1 :]]
+                for offset, next_line in enumerate(lines[start:], start=1):
+                    key_parts.append(next_line)
+                    close = next_line.find("'")
+                    if close != -1:
+                        consumed = offset
+                        close_line = next_line
+                        break
+                if close == -1:
+                    return _KeyBinding(None, None, dropped=True)
+                key_parts[-1] = key_parts[-1][:close]
+                key = "\n".join(key_parts)
+            if not key:
+                # ``'([^']+)'`` requires at least one character. dotenv's
+                # error path consumes only this physical line for ``''=v``.
+                return _KeyBinding(None, None, dropped=True)
+            tail = close_line[close + 1 :]
+            quoted = True
+        else:
+            match = self.UNQUOTED_KEY_PATTERN.match(text, position)
+            if match is None:
+                return None
+            key = match.group(0)
+            if not lenient and self.STRICT_KEY_PATTERN.fullmatch(key) is None:
+                return None
+            tail = text[match.end() :]
+            consumed = 0
+            quoted = False
+
+        tail_without_space = tail.lstrip()
+        if tail_without_space.startswith("="):
+            return _KeyBinding(key, tail_without_space[1:], consumed=consumed)
+        if self.BINDING_TAIL_PATTERN.fullmatch(tail) is not None:
+            return _KeyBinding(key, None, consumed=consumed)
+
+        # Once a quoted key spans lines, python-dotenv's error recovery has
+        # already advanced through the close-quote line. Preserve that
+        # consumption so its interior lines cannot become phantom variables.
+        return _KeyBinding(None, None, consumed=consumed, dropped=quoted)
 
     @staticmethod
     def _strip_leading_bom(content: str) -> tuple[str, bool]:
@@ -572,7 +684,7 @@ class EnvParser:
         """
         return escapes.sub(lambda match: self.ESCAPE_DECODE_TABLE[match.group(0)], value)
 
-    def _interpolate(self, value: str, parsed: dict[str, EnvVar]) -> str:
+    def _interpolate(self, value: str, parsed: dict[str, str | None]) -> str:
         """Expand ``${NAME}`` / ``${NAME:-default}`` like python-dotenv (#486).
 
         ``dotenv_values`` (the loader pydantic-settings wraps) resolves
@@ -591,9 +703,11 @@ class EnvParser:
 
         def resolve(match: re.Match[str]) -> str:
             name = match.group("name")
-            var = parsed.get(name)
-            if var is not None:
-                return var.value
+            if name in parsed:
+                # A present bare binding maps to None. python-dotenv treats it
+                # as an explicit empty interpolation value (even for ``:-``),
+                # shadowing a same-named process environment variable (#573).
+                return parsed[name] or ""
             default = match.group("default")
             return environ.get(name, default if default is not None else "")
 

--- a/tests/unit/test_parser_keys.py
+++ b/tests/unit/test_parser_keys.py
@@ -1,0 +1,125 @@
+"""Regression tests for #573: dotenv key lexing matches application behavior."""
+
+from __future__ import annotations
+
+from io import StringIO
+
+import pytest
+from dotenv import dotenv_values
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+from envdrift.core.parser import EnvParser
+
+
+def _parsed_values(content: str, *, lenient: bool = False) -> dict[str, str]:
+    parsed = EnvParser().parse_string(content, lenient=lenient)
+    return {name: var.value for name, var in parsed.variables.items()}
+
+
+def _pydantic_dotenv_values(content: str) -> dict[str, str]:
+    """Values pydantic-settings can pass on from python-dotenv.
+
+    ``dotenv_values`` exposes bare bindings as ``None``. Its Pydantic source
+    deliberately filters falsy entries before model validation, so EnvDrift's
+    public variable view omits bare bindings too.
+    """
+    return {
+        name: value
+        for name, value in dotenv_values(stream=StringIO(content)).items()
+        if value is not None
+    }
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        pytest.param("plain\nSET=value\n", id="bare-key"),
+        pytest.param("'MY KEY'=v\nNORMAL=x\n", id="quoted-key"),
+        pytest.param("'\nK=1\n'\nB=2\n", id="multiline-quoted-bare-key"),
+        pytest.param("'\nMY KEY\n'=value\nB=2\n", id="multiline-quoted-assigned-key"),
+        pytest.param("'\nK=1\nB=2\n", id="unterminated-key-recovers-after-opener"),
+        pytest.param("'\nK=1\n' junk\nB=2\n", id="junk-after-key-consumes-interior"),
+        pytest.param("''=ignored\nB=2\n", id="empty-quoted-key-is-invalid"),
+        pytest.param("export # comment\nB=2\n", id="export-without-key-is-ignored"),
+        pytest.param(
+            "export 'MY KEY' = value\nexport bare # note\nB=2\n",
+            id="export-quoted-and-bare",
+        ),
+        pytest.param("A=first\nA\nB=2\n", id="later-bare-duplicate-wins"),
+    ],
+)
+def test_key_binding_values_match_pydantic_dotenv_source(content):
+    assert _parsed_values(content) == _pydantic_dotenv_values(content)
+
+
+def test_quoted_key_is_unquoted_in_strict_and_lenient_modes():
+    content = "'MY KEY'=v\n"
+
+    assert _parsed_values(content) == {"MY KEY": "v"}
+    assert _parsed_values(content, lenient=True) == {"MY KEY": "v"}
+
+
+def test_multiline_quoted_key_metadata_covers_the_whole_binding():
+    content = "'\nMY KEY\n'=value\nAFTER=ok\n"
+
+    parsed = EnvParser().parse_string(content)
+    variable = parsed.variables["\nMY KEY\n"]
+
+    assert variable.line_number == 1
+    assert variable.raw_line == "'\nMY KEY\n'=value"
+    assert parsed.variables["AFTER"].line_number == 4
+
+
+def test_multiline_bare_key_does_not_create_phantom_assignments():
+    content = "'\nSECRET=not-a-binding\n'\nAFTER=ok\n"
+
+    parsed = EnvParser().parse_string(content)
+
+    assert set(parsed.variables) == {"AFTER"}
+    assert parsed.variables["AFTER"].line_number == 4
+
+
+def test_bare_key_shadows_process_environment_during_interpolation(monkeypatch):
+    monkeypatch.setenv("ENVDRIFT_573_BARE", "from-process")
+    content = (
+        "ENVDRIFT_573_BARE\nDEFAULTED=${ENVDRIFT_573_BARE:-fallback}\nPLAIN=${ENVDRIFT_573_BARE}\n"
+    )
+
+    assert (
+        _parsed_values(content)
+        == _pydantic_dotenv_values(content)
+        == {
+            "DEFAULTED": "",
+            "PLAIN": "",
+        }
+    )
+
+
+def test_later_bare_duplicate_removes_public_value_but_keeps_assignment_history():
+    parsed = EnvParser().parse_string("TOKEN=plaintext\nTOKEN\n")
+
+    assert parsed.variables == {}
+    assert [(var.name, var.value) for var in parsed.assignments] == [("TOKEN", "plaintext")]
+
+
+def test_real_pydantic_settings_loads_quoted_key_and_ignores_bare_key(tmp_path):
+    env_path = tmp_path / ".env"
+    env_path.write_text("plain\n'MY KEY'=v\nNORMAL=x\n", encoding="utf-8")
+
+    class Settings(BaseSettings):
+        model_config = SettingsConfigDict(
+            env_file=str(env_path), env_file_encoding="utf-8", extra="ignore"
+        )
+
+        plain: str = "default"
+        my_key: str = Field(alias="MY KEY")
+        NORMAL: str
+
+    loaded = Settings()
+    parsed = EnvParser().parse(env_path)
+
+    assert loaded.plain == "default"
+    assert loaded.my_key == parsed.variables["MY KEY"].value == "v"
+    assert loaded.NORMAL == parsed.variables["NORMAL"].value == "x"
+    assert "plain" not in parsed.variables


### PR DESCRIPTION
## Summary

Match python-dotenv's key lexer for single-quoted and bare bindings, including the multiline quoted-key case that could fabricate interior assignments.

The issue's bare-key scope was refined against the installed real stack: `dotenv_values()` exposes a bare binding as `None`, but pydantic-settings 2.14.2 filters it before model validation. EnvDrift now consumes and tracks that binding for correct duplicate/interpolation semantics without publishing an `EnvVar` the application never receives.

## Changes

- accept single-quoted keys in strict and lenient parsing, including keys spanning physical lines
- consume malformed or bare quoted-key bindings through the same physical line boundary as python-dotenv, preventing phantom variables
- retain bare keys as internal `None` interpolation state so they shadow process environment values
- make a later bare duplicate remove an earlier valued binding from the last-value-wins public view while retaining assignment history for safety checks
- add parity regressions against real python-dotenv and a real pydantic-settings model

## Related issues

Closes #573

## Testing

- [x] `uv run pytest -m "not integration"` — 3350 passed, 6 skipped, 1 xpassed
- [x] targeted parser/parity suite — 229 passed
- [x] deterministic 1,000-case key-lexer differential check against python-dotenv 1.2.2 — zero mismatches after Pydantic's `None` filtering
- [x] real pydantic-settings 2.14.2 dogfood for quoted, bare, and multiline quoted keys
- [ ] Full container/binary integration suite not run; this change is isolated to the in-process parser and has no external binary seam

## Checklist

See [CLAUDE.md](../CLAUDE.md) for the full conventions.

- [x] New/changed behavior has a real regression test (real python-dotenv and pydantic-settings, not mocks)
- [x] No passing test was disabled or xfailed
- [x] Touched parser has 99% coverage in the non-integration suite
- [x] No hardcoded binary versions introduced
- [x] `ruff check` / `ruff format` / full-project `pyrefly` / `bandit` clean
- [x] Parser behavior documentation updated in code; no user command or configuration syntax changed
- [x] No additional confirmed bug remains unfixed
- [x] No `FORCE_COLOR`-dependent output or `importlib.reload()` introduced

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jainal09/envdrift/pull/620?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dotenv parsing for quoted, multiline, unterminated, and bare keys.
  * Added support for `export`-prefixed bindings and more accurate handling of invalid or incomplete entries.
  * Fixed variable interpolation so bare bindings correctly override environment values.
  * Improved compatibility with Pydantic settings and python-dotenv behavior.

* **Tests**
  * Added comprehensive coverage for key parsing, interpolation, multiline values, duplicate bindings, and settings integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR aligns EnvDrift key parsing with python-dotenv and pydantic-settings behavior. The main changes are:

- Support for single-quoted keys in strict and lenient parsing.
- Multiline quoted-key consumption to avoid phantom assignments.
- Internal bare-key interpolation state with filtered public variables.
- Tests for quoted keys, bare keys, duplicates, interpolation, and pydantic-settings parity.

<h3>Confidence Score: 4/5</h3>

The changed parser flow looks mergeable after tightening malformed bare-line handling.

- Quoted and multiline key parsing is covered by targeted parity tests.
- Bare bindings now correctly shadow interpolation when the line is valid.
- Malformed bare-looking lines can also create internal shadow state.

src/envdrift/core/parser.py

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/envdrift/core/parser.py | Adds quoted-key lexing, bare-binding handling, and a separate interpolation state for parser parity. |
| tests/unit/test_parser_keys.py | Adds focused parser parity tests for quoted keys, bare keys, multiline keys, and pydantic-settings loading. |

<sub>Reviews (1): Last reviewed commit: ["fix(parser): mirror quoted and bare key ..."](https://github.com/jainal09/envdrift/commit/17353ee37f7e84dd7d94a937af5b7b97348f66bc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43491174)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->