### PR TITLE
docs: align vault and monorepo config examples

### DIFF
--- a/docs/cli/sync.md
+++ b/docs/cli/sync.md
@@ -129,6 +129,12 @@ provider = "azure"  # azure | aws | hashicorp | gcp
 [vault.azure]
 vault_url = "https://my-keyvault.vault.azure.net/"
 
+[vault.aws]
+region = "us-east-1"
+
+[vault.hashicorp]
+url = "https://vault.example.com:8200"
+
 [vault.gcp]
 project_id = "my-gcp-project"
 

--- a/docs/guides/monorepo-setup.md
+++ b/docs/guides/monorepo-setup.md
@@ -296,14 +296,17 @@ envdrift diff services/api/.env.staging services/api/.env.production
 secret_name = "api-local-key"
 folder_path = "services/api"
 profile = "local"
-activate_to = "services/api/.env"
+activate_to = ".env"
 
 [[vault.sync.mappings]]
 secret_name = "web-local-key"
 folder_path = "services/web"
 profile = "local"
-activate_to = "services/web/.env"
+activate_to = ".env"
 ```
+
+`activate_to` is resolved relative to its mapping's `folder_path`, so `.env`
+above activates to `services/api/.env` or `services/web/.env` respectively.
 
 ```bash
 # Pull local development keys

--- a/docs/specs/integration-tests-spec.md
+++ b/docs/specs/integration-tests-spec.md
@@ -68,12 +68,18 @@ def localstack_aws():
 # docker-compose.test.yml
 services:
   vault:
-    image: hashicorp/vault:1.18
+    # Keep the image pin in sync with tests/docker-compose.test.yml.
+    image: hashicorp/vault:2.0
+    user: root
     ports:
       - "8200:8200"
     environment:
       - VAULT_DEV_ROOT_TOKEN_ID=test-root-token
       - VAULT_DEV_LISTEN_ADDRESS=0.0.0.0:8200
+      - VAULT_ADDR=http://0.0.0.0:8200
+      # Current images do not ship setcap; dev mode does not need mlock.
+      - SKIP_SETCAP=true
+      - VAULT_DISABLE_MLOCK=true
     cap_add:
       - IPC_LOCK
 ```

--- a/tests/unit/test_docs_accuracy.py
+++ b/tests/unit/test_docs_accuracy.py
@@ -33,6 +33,13 @@ And the #499 sweep — examples that contradicted live library/CLI behavior:
 - sync mismatch previews must be redacted and backup names include microseconds;
 - guard docs must identify unencrypted environment files as HIGH / exit 2.
 
+And current configuration-example contracts from #441/#619:
+
+- the integration spec's Vault container must match the tested Compose image
+  and the runtime flags that let that image start;
+- profile ``activate_to`` paths are relative to ``folder_path``;
+- the sync configuration example covers all four supported vault providers.
+
 They read the real files — no mocking of the behavior under test.
 """
 
@@ -128,6 +135,63 @@ def test_sync_examples_redact_values_and_show_collision_safe_backup_name() -> No
     assert len(re.findall(r"Local:\s+<redacted len=64 sha=[0-9a-f]{8}>", text)) >= 2
     assert len(re.findall(r"Vault:\s+<redacted len=64 sha=[0-9a-f]{8}>", text)) >= 2
     assert re.search(r"\.env\.keys\.backup\.\d{8}_\d{6}_\d{6}", text)
+
+
+def test_integration_spec_vault_service_matches_test_stack() -> None:
+    """The prose Compose example must track the real tested Vault service (#619)."""
+    spec = _read_docs_page("specs/integration-tests-spec.md")
+    compose = (_REPO_ROOT / "tests" / "docker-compose.test.yml").read_text(encoding="utf-8")
+    image_pattern = r"image:\s*hashicorp/vault:([^\s#]+)"
+
+    spec_image = re.search(image_pattern, spec)
+    compose_image = re.search(image_pattern, compose)
+    assert spec_image is not None, "integration spec has no pinned HashiCorp Vault image"
+    assert compose_image is not None, "test Compose stack has no pinned HashiCorp Vault image"
+    assert spec_image.group(1) == compose_image.group(1)
+    for setting in (
+        "user: root",
+        "VAULT_ADDR=http://0.0.0.0:8200",
+        "SKIP_SETCAP=true",
+        "VAULT_DISABLE_MLOCK=true",
+    ):
+        assert setting in compose, f"tested Vault stack no longer contains {setting!r}"
+        assert setting in spec, f"integration spec must mirror tested Vault setting {setting!r}"
+
+
+def test_monorepo_profile_activation_example_is_folder_relative(tmp_path: Path) -> None:
+    """The documented activate_to value must not repeat folder_path (#441)."""
+    from envdrift.cli_commands.sync import _maybe_activate_profile
+    from envdrift.sync.config import ServiceMapping
+
+    service = tmp_path / "services" / "api"
+    service.mkdir(parents=True)
+    source = service / ".env.local"
+    source.write_text("APP_ENV=local\n", encoding="utf-8")
+    mapping = ServiceMapping(
+        secret_name="api-local-key",
+        folder_path=service,
+        profile="local",
+        activate_to=Path(".env"),
+    )
+
+    assert _maybe_activate_profile(mapping, source, "local") == "activated"
+    assert (service / ".env").read_text(encoding="utf-8") == "APP_ENV=local\n"
+
+    text = _read_docs_page("guides/monorepo-setup.md")
+    assert 'activate_to = "services/api/.env"' not in text
+    assert 'activate_to = "services/web/.env"' not in text
+    assert text.count('activate_to = ".env"') >= 2
+    assert "resolved relative to its mapping's `folder_path`" in text
+
+
+def test_sync_config_example_covers_every_supported_vault_provider() -> None:
+    """sync.md must mirror the four provider blocks in the real scaffold (#441)."""
+    from envdrift.config import EXAMPLE_CONFIG
+
+    text = _read("sync.md")
+    for section in ("[vault.azure]", "[vault.aws]", "[vault.hashicorp]", "[vault.gcp]"):
+        assert section in EXAMPLE_CONFIG, f"canonical config no longer contains {section}"
+        assert section in text, f"sync.md configuration example omits {section}"
 
 
 def test_guard_docs_classify_unencrypted_env_as_high(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Groups three closely related stale configuration examples into one accuracy PR instead of separate documentation-only PRs.

## Changes

- align the integration-test Vault example with the tested Vault 2.0 Compose service and required startup settings
- correct monorepo profile activation paths to be relative to folder_path
- show all four supported vault-provider blocks in the primary sync configuration example
- add regression tests that compare the documentation with the real Compose stack, activation behavior, and canonical config scaffold

## Related issues

Closes #619
Partial #441 (monorepo activate_to and sync provider-example findings; the tracker remains open)

## Testing

- [x] uv run pytest -m "not integration" — 3358 passed, 6 skipped, 542 deselected, 1 xpassed
- [x] uv run pytest -q tests/unit/test_docs_accuracy.py — 27 passed
- [x] make lint-docs — 61 Markdown files, 0 errors
- [x] uv run mkdocs build --strict

## Checklist

- [x] New/changed behavior has a real regression test using live project behavior/configuration
- [x] No tests were skipped or xfailed by this change
- [x] Touched files keep at least 80% coverage
- [x] No hardcoded managed binary versions were introduced
- [x] ruff check / ruff format / pyrefly / bandit clean
- [x] Documentation updated
- [x] Pre-existing findings are linked above
- [x] No FORCE_COLOR-dependent output or importlib.reload() changes

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jainal09/envdrift/pull/624?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates stale documentation examples and adds tests to keep them aligned.

- Sync docs now show all four supported vault provider blocks.
- Monorepo docs now show `activate_to` paths relative to `folder_path`.
- The integration-test spec now mirrors the tested Vault 2.0 container settings.
- Doc accuracy tests now cover these examples against live config and test-stack behavior.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/cli/sync.md | Adds AWS and HashiCorp vault provider examples that match the canonical config scaffold. |
| docs/guides/monorepo-setup.md | Updates monorepo activation examples to use folder-relative `activate_to` paths. |
| docs/specs/integration-tests-spec.md | Updates the Vault Compose example to match the tested Vault 2.0 startup settings. |
| tests/unit/test_docs_accuracy.py | Adds doc accuracy tests for vault providers, activation paths, and Vault Compose settings. |

<sub>Reviews (1): Last reviewed commit: ["docs: align vault and monorepo config ex..."](https://github.com/jainal09/envdrift/commit/bfbc3695b42f89875ed1e72adc6e36d10a9224fb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43493853)</sub>

<!-- /greptile_comment -->