### PR TITLE
refactor(cli): decompose vault commands

### DIFF
--- a/src/envdrift/cli.py
+++ b/src/envdrift/cli.py
@@ -21,7 +21,7 @@ from envdrift.cli_commands.partial import pull_cmd as pull_partial_cmd
 from envdrift.cli_commands.partial import push as push_cmd
 from envdrift.cli_commands.sync import lock, pull, sync
 from envdrift.cli_commands.validate import validate
-from envdrift.cli_commands.vault import vault_pull, vault_push
+from envdrift.cli_commands.vault import VAULT_PULL_HELP, VAULT_PUSH_HELP, vault_pull, vault_push
 from envdrift.cli_commands.version import version as version_cmd
 
 
@@ -91,8 +91,8 @@ app.command()(hook)
 app.command()(sync)
 app.command()(pull)
 app.command()(lock)
-app.command("vault-push")(vault_push)
-app.command("vault-pull")(vault_pull)
+app.command("vault-push", help=VAULT_PUSH_HELP)(vault_push)
+app.command("vault-pull", help=VAULT_PULL_HELP)(vault_pull)
 app.command()(version_cmd)
 
 # Partial encryption commands

--- a/src/envdrift/cli_commands/vault.py
+++ b/src/envdrift/cli_commands/vault.py
@@ -1,4 +1,4 @@
-"""Vault operations for envdrift."""
+"""Vault CLI command definitions."""
 
 from __future__ import annotations
 
@@ -7,749 +7,230 @@ from typing import Annotated
 
 import typer
 
-from envdrift.env_files import resolve_custom_env_file, resolve_mapping_env_file
-from envdrift.output.rich import console, print_error, print_success, print_warning
+from envdrift.cli_commands.vault_helpers import (
+    VaultPullRequest,
+    VaultPushRequest,
+    execute_vault_pull,
+    execute_vault_push,
+)
 
+VAULT_PUSH_HELP = """Push encryption keys from local .env.keys files to cloud vaults.
 
-def _resolve_vault_settings(
-    config: Path | None,
-    provider: str | None,
-    vault_url: str | None,
-    region: str | None,
-    project_id: str | None,
-) -> tuple[str, str | None, str | None, str | None]:
-    """Resolve the effective vault provider/url/region/project-id.
+This is the reverse of `envdrift sync` - uploads local keys to vault.
 
-    Merges explicit CLI flags with the ``[vault]`` section of an
-    ``envdrift.toml``/``pyproject.toml`` (flags win). Exits the CLI with a
-    user-facing error when the config exists but cannot be loaded, when the
-    provider is missing, or when a provider-specific requirement is unmet
-    (azure/hashicorp need ``--vault-url``; gcp needs ``--project-id``).
+Three modes:
 
-    Shared by ``vault-push`` (single-service mode) and ``vault-pull`` so the two
-    commands stay byte-for-byte consistent.
-    """
-    from envdrift.config import ConfigLoadError, ConfigNotFoundError, find_config, load_config
+1. From .env.keys file (Single Service):
+   envdrift vault-push ./services/soak soak-machine --env soak
 
-    envdrift_config = None
-    config_path = config if config is not None else find_config()
-    if config_path is not None:
-        try:
-            envdrift_config = load_config(config_path)
-        except (ConfigNotFoundError, ConfigLoadError) as e:
-            # These were silently suppressed; the user was then told to
-            # "configure in envdrift.toml" — the very file whose parse error
-            # was being hidden (#491). Report the real failure instead.
-            print_error(str(e))
-            raise typer.Exit(code=1) from None
+2. Direct value:
+   envdrift vault-push --direct soak-machine "DOTENV_PRIVATE_KEY_SOAK=abc123..."
 
-    vault_config = getattr(envdrift_config, "vault", None)
+3. All Services (from config):
+   envdrift vault-push --all
 
-    effective_provider = provider or getattr(vault_config, "provider", None)
-    if not effective_provider:
-        print_error("Vault provider required. Use --provider or configure in envdrift.toml")
-        raise typer.Exit(code=1)
+Examples:
+    # Push from .env.keys (reads DOTENV_PRIVATE_KEY_SOAK)
+    envdrift vault-push ./services/soak soak-machine --env soak -p azure --vault-url https://myvault.vault.azure.net/
 
-    effective_vault_url = vault_url
-    if effective_vault_url is None and vault_config:
-        if effective_provider == "azure":
-            effective_vault_url = getattr(vault_config, "azure_vault_url", None)
-        elif effective_provider == "hashicorp":
-            effective_vault_url = getattr(vault_config, "hashicorp_url", None)
+    # Push direct value
+    envdrift vault-push --direct soak-machine "DOTENV_PRIVATE_KEY_SOAK=abc..." -p azure --vault-url https://myvault.vault.azure.net/
 
-    effective_region = region
-    if effective_region is None and vault_config:
-        effective_region = getattr(vault_config, "aws_region", None)
+    # Push all missing secrets defined in config
+    envdrift vault-push --all
 
-    effective_project_id = project_id
-    if effective_project_id is None and vault_config:
-        effective_project_id = getattr(vault_config, "gcp_project_id", None)
+    # Push all secrets, overwriting existing ones
+    envdrift vault-push --all --force
 
-    if effective_provider in ("azure", "hashicorp") and not effective_vault_url:
-        print_error(f"--vault-url required for {effective_provider}")
-        raise typer.Exit(code=1)
-    if effective_provider == "gcp" and not effective_project_id:
-        print_error("--project-id required for gcp")
-        raise typer.Exit(code=1)
+    # Push all without encrypting (when files are already encrypted)
+    envdrift vault-push --all --skip-encrypt
+"""
 
-    return effective_provider, effective_vault_url, effective_region, effective_project_id
+VAULT_PULL_HELP = """Pull a single encryption key from a cloud vault into a local .env.keys file.
 
+This is the config-free inverse of `envdrift vault-push` (single-service mode):
+it fetches one secret, writes the DOTENV_PRIVATE_KEY_<ENV> key into
+`<folder>/.env.keys`, and (by default) decrypts the matching `.env.<env>` file
+so a single command onboards a developer with no TOML required.
 
-def _build_authenticated_client(
-    provider: str,
-    vault_url: str | None,
-    region: str | None,
-    project_id: str | None,
-):
-    """Create and authenticate a vault client for the given effective settings.
+Modes:
 
-    Exits the CLI with a user-facing error on a missing optional dependency
-    (``ImportError``), an unsupported provider or bad configuration
-    (``ValueError``), or an authentication failure (``VaultError``).
-    """
-    from envdrift.vault import VaultError, get_vault_client
+1. Pull key and decrypt (default):
+   envdrift vault-pull ./services/soak soak-machine --env soak -p azure --vault-url https://myvault.vault.azure.net/
 
-    try:
-        vault_client_config: dict[str, str | None] = {}
-        if provider == "azure":
-            vault_client_config["vault_url"] = vault_url
-        elif provider == "aws":
-            vault_client_config["region"] = region or "us-east-1"
-        elif provider == "hashicorp":
-            vault_client_config["url"] = vault_url
-        elif provider == "gcp":
-            vault_client_config["project_id"] = project_id
+2. Pull key only (skip decryption):
+   envdrift vault-pull ./services/soak soak-machine --env soak --no-decrypt -p azure --vault-url https://myvault.vault.azure.net/
 
-        client = get_vault_client(provider, **vault_client_config)
-        client.authenticate()
-    except ImportError as e:
-        print_error(str(e))
-        raise typer.Exit(code=1) from None
-    except ValueError as e:
-        print_error(f"Invalid vault configuration: {e}")
-        raise typer.Exit(code=1) from None
-    except VaultError as e:
-        print_error(f"Vault authentication failed: {e}")
-        raise typer.Exit(code=1) from None
+Provider/URL/region/project-id may be omitted when they are configured in the
+`[vault]` section of an envdrift.toml/pyproject.toml.
 
-    return client
+Examples:
+    # Azure
+    envdrift vault-pull . my-app-key --env production -p azure --vault-url https://myvault.vault.azure.net/
+
+    # AWS
+    envdrift vault-pull . my-app-key --env production -p aws --region us-east-1
+
+    # GCP
+    envdrift vault-pull . my-app-key --env production -p gcp --project-id my-gcp-project
+
+    # HashiCorp
+    envdrift vault-pull . my-app-key --env production -p hashicorp --vault-url https://vault.example.com:8200
+"""
+
+_PushFolder = Annotated[
+    Path | None,
+    typer.Argument(help="Service folder containing .env.keys file"),
+]
+_PushSecretName = Annotated[
+    str | None,
+    typer.Argument(help="Name of the secret in the vault"),
+]
+_PushEnvironment = Annotated[
+    str | None,
+    typer.Option(
+        "--env",
+        "-e",
+        help=(
+            "Required (single-service mode): environment suffix that selects which "
+            "DOTENV_PRIVATE_KEY_<ENV> key is read from .env.keys "
+            "(e.g., 'soak' -> DOTENV_PRIVATE_KEY_SOAK)"
+        ),
+    ),
+]
+_DirectOption = Annotated[
+    bool,
+    typer.Option(
+        "--direct",
+        help="Push a direct key-value pair (use with positional args: secret-name value)",
+    ),
+]
+_AllServicesOption = Annotated[
+    bool,
+    typer.Option(
+        "--all",
+        help="Push all secrets defined in sync config (skipping existing unless --force)",
+    ),
+]
+_ForceOption = Annotated[
+    bool,
+    typer.Option("--force", "-f", help="Push all secrets even if they already exist"),
+]
+_SkipEncryptOption = Annotated[
+    bool,
+    typer.Option("--skip-encrypt", help="Skip encryption step, only push keys to vault"),
+]
+_ConfigOption = Annotated[
+    Path | None,
+    typer.Option("--config", "-c", help="Path to sync config file"),
+]
+_PullConfigOption = Annotated[
+    Path | None,
+    typer.Option("--config", "-c", help="Path to envdrift.toml config file"),
+]
+_ProviderOption = Annotated[
+    str | None,
+    typer.Option("--provider", "-p", help="Vault provider: azure, aws, hashicorp, gcp"),
+]
+_VaultUrlOption = Annotated[
+    str | None,
+    typer.Option("--vault-url", help="Vault URL (Azure Key Vault or HashiCorp Vault)"),
+]
+_RegionOption = Annotated[
+    str | None,
+    typer.Option("--region", help="AWS region (default: us-east-1)"),
+]
+_ProjectIdOption = Annotated[
+    str | None,
+    typer.Option("--project-id", help="GCP project ID (Secret Manager)"),
+]
+_PullFolder = Annotated[
+    Path,
+    typer.Argument(help="Service folder to write the fetched .env.keys file into"),
+]
+_PullSecretName = Annotated[str, typer.Argument(help="Name of the secret in the vault")]
+_PullEnvironment = Annotated[
+    str,
+    typer.Option(
+        "--env",
+        "-e",
+        help=(
+            "Required: environment suffix that names the key written to .env.keys "
+            "(e.g., 'soak' -> DOTENV_PRIVATE_KEY_SOAK). Also selects which "
+            ".env.<env> file is decrypted unless --no-decrypt is used."
+        ),
+    ),
+]
+_NoDecryptOption = Annotated[
+    bool,
+    typer.Option(
+        "--no-decrypt",
+        help="Only write the key to .env.keys; do not decrypt the .env.<env> file",
+    ),
+]
+_EnvFileOption = Annotated[
+    Path | None,
+    typer.Option("--env-file", help="Custom env filename to decrypt, relative to FOLDER"),
+]
 
 
 def vault_push(
-    folder: Annotated[
-        Path | None,
-        typer.Argument(help="Service folder containing .env.keys file"),
-    ] = None,
-    secret_name: Annotated[
-        str | None,
-        typer.Argument(help="Name of the secret in the vault"),
-    ] = None,
-    env: Annotated[
-        str | None,
-        typer.Option(
-            "--env",
-            "-e",
-            help=(
-                "Required (single-service mode): environment suffix that selects which "
-                "DOTENV_PRIVATE_KEY_<ENV> key is read from .env.keys "
-                "(e.g., 'soak' -> DOTENV_PRIVATE_KEY_SOAK)"
-            ),
-        ),
-    ] = None,
-    direct: Annotated[
-        bool,
-        typer.Option(
-            "--direct",
-            help="Push a direct key-value pair (use with positional args: secret-name value)",
-        ),
-    ] = False,
-    all_services: Annotated[
-        bool,
-        typer.Option(
-            "--all",
-            help="Push all secrets defined in sync config (skipping existing unless --force)",
-        ),
-    ] = False,
-    force: Annotated[
-        bool,
-        typer.Option("--force", "-f", help="Push all secrets even if they already exist"),
-    ] = False,
-    skip_encrypt: Annotated[
-        bool,
-        typer.Option("--skip-encrypt", help="Skip encryption step, only push keys to vault"),
-    ] = False,
-    config: Annotated[
-        Path | None,
-        typer.Option("--config", "-c", help="Path to sync config file"),
-    ] = None,
-    provider: Annotated[
-        str | None,
-        typer.Option("--provider", "-p", help="Vault provider: azure, aws, hashicorp, gcp"),
-    ] = None,
-    vault_url: Annotated[
-        str | None,
-        typer.Option("--vault-url", help="Vault URL (Azure Key Vault or HashiCorp Vault)"),
-    ] = None,
-    region: Annotated[
-        str | None,
-        typer.Option("--region", help="AWS region (default: us-east-1)"),
-    ] = None,
-    project_id: Annotated[
-        str | None,
-        typer.Option("--project-id", help="GCP project ID (Secret Manager)"),
-    ] = None,
+    folder: _PushFolder = None,
+    secret_name: _PushSecretName = None,
+    env: _PushEnvironment = None,
+    direct: _DirectOption = False,
+    all_services: _AllServicesOption = False,
+    force: _ForceOption = False,
+    skip_encrypt: _SkipEncryptOption = False,
+    config: _ConfigOption = None,
+    provider: _ProviderOption = None,
+    vault_url: _VaultUrlOption = None,
+    region: _RegionOption = None,
+    project_id: _ProjectIdOption = None,
 ) -> None:
-    """
-    Push encryption keys from local .env.keys files to cloud vaults.
-
-    This is the reverse of `envdrift sync` - uploads local keys to vault.
-
-    Three modes:
-
-    1. From .env.keys file (Single Service):
-       envdrift vault-push ./services/soak soak-machine --env soak
-
-    2. Direct value:
-       envdrift vault-push --direct soak-machine "DOTENV_PRIVATE_KEY_SOAK=abc123..."
-
-    3. All Services (from config):
-       envdrift vault-push --all
-
-    Examples:
-        # Push from .env.keys (reads DOTENV_PRIVATE_KEY_SOAK)
-        envdrift vault-push ./services/soak soak-machine --env soak -p azure --vault-url https://myvault.vault.azure.net/
-
-        # Push direct value
-        envdrift vault-push --direct soak-machine "DOTENV_PRIVATE_KEY_SOAK=abc..." -p azure --vault-url https://myvault.vault.azure.net/
-
-        # Push all missing secrets defined in config
-        envdrift vault-push --all
-
-        # Push all secrets, overwriting existing ones
-        envdrift vault-push --all --force
-
-        # Push all without encrypting (when files are already encrypted)
-        envdrift vault-push --all --skip-encrypt
-    """
-    from envdrift.sync.operations import EnvKeysFile
-    from envdrift.vault import VaultError
-    from envdrift.vault.base import SecretNotFoundError
-
-    # Validate --skip-encrypt is only used with --all
-    if skip_encrypt and not all_services:
-        print_warning("--skip-encrypt is only applicable with --all mode, ignoring")
-
-    # Validate --force is only used with --all
-    if force and not all_services:
-        print_warning("--force is only applicable with --all mode, ignoring")
-
-    # --all mode implementation
-    if all_services:
-        from envdrift.cli_commands.encryption_helpers import (
-            build_sops_encrypt_kwargs,
-            is_encrypted_content,
-            resolve_encryption_backend,
-        )
-        from envdrift.cli_commands.sync import load_sync_config_and_client
-        from envdrift.encryption import (
-            EncryptionBackendError,
-            EncryptionNotFoundError,
-            EncryptionProvider,
-            detect_encryption_provider,
-        )
-        from envdrift.integrations.dotenvx import dotenvx_filename_needs_normalization
-
-        # Load sync config and client
-        sync_config, client, effective_provider, _, _, _ = load_sync_config_and_client(
-            config_file=config,
+    """Push encryption keys from local files to a configured cloud vault."""
+    execute_vault_push(
+        VaultPushRequest(
+            folder=folder,
+            secret_name=secret_name,
+            environment=env,
+            direct=direct,
+            all_services=all_services,
+            force=force,
+            skip_encrypt=skip_encrypt,
+            config=config,
             provider=provider,
             vault_url=vault_url,
             region=region,
             project_id=project_id,
         )
-
-        # Authenticate the vault client
-        try:
-            client.authenticate()
-        except VaultError as e:
-            print_error(str(e))
-            raise typer.Exit(code=1) from None
-
-        from envdrift.config import ConfigLoadError, ConfigNotFoundError
-
-        try:
-            encryption_backend, backend_provider, encryption_config = resolve_encryption_backend(
-                config
-            )
-        except (ConfigNotFoundError, ConfigLoadError) as e:
-            # resolve_encryption_backend no longer falls back to dotenvx on a
-            # broken config (#491); surface the loader's message verbatim.
-            print_error(str(e))
-            raise typer.Exit(code=1) from None
-        except ValueError as e:
-            print_error(f"Unsupported encryption backend: {e}")
-            raise typer.Exit(code=1) from None
-
-        if not encryption_backend.is_installed():
-            print_error(f"{encryption_backend.name} is not installed")
-            console.print(encryption_backend.install_instructions())
-            raise typer.Exit(code=1)
-
-        sops_encrypt_kwargs = {}
-        if backend_provider == EncryptionProvider.SOPS:
-            sops_encrypt_kwargs = build_sops_encrypt_kwargs(encryption_config)
-
-        console.print("[bold]Vault Push All[/bold]")
-        console.print(f"Provider: {effective_provider}")
-        console.print(f"Services: {len(sync_config.mappings)}")
-        if force:
-            console.print("[dim]Force: overwrite existing secrets (--force)[/dim]")
-        if skip_encrypt:
-            console.print("[dim]Encryption: skipped (--skip-encrypt)[/dim]")
-        console.print()
-
-        pushed_count = 0
-        skipped_count = 0
-        error_count = 0
-        dotenvx_mismatch = False
-
-        for mapping in sync_config.mappings:
-            try:
-                detection = resolve_mapping_env_file(mapping)
-                if detection.status == "folder_not_found":
-                    # A missing mapping folder is a broken config (typo'd
-                    # folder_path), not a "No .env file found" skip: reporting
-                    # it as a skip with Errors: 0 let a key-backup CI job go
-                    # green having pushed nothing (#488).
-                    print_error(
-                        f"Error processing {mapping.folder_path}: folder does not "
-                        "exist or is not a directory (check folder_path in your sync config)"
-                    )
-                    error_count += 1
-                    continue
-                env_file = (
-                    detection.path
-                    if detection.path is not None
-                    else mapping.folder_path / f".env.{mapping.effective_environment}"
-                )
-                effective_environment = detection.environment or mapping.effective_environment
-
-                # Check if the secret exists in vault BEFORE any file mutation
-                # (encrypt/normalize), so a skipped push leaves the working tree
-                # untouched (#347). This needs only `force` and the secret name,
-                # both independent of the encrypt/normalize block below.
-                if not force:
-                    try:
-                        client.get_secret(mapping.secret_name)
-                        # If successful, secret exists
-                        console.print(
-                            f"[dim]Skipped[/dim] {mapping.folder_path}: "
-                            f"Secret '{mapping.secret_name}' already exists"
-                        )
-                        skipped_count += 1
-                        continue
-                    except SecretNotFoundError:
-                        # Secret missing, proceed to push
-                        pass
-                    except VaultError as e:
-                        print_error(f"Vault error checking {mapping.secret_name}: {e}")
-                        error_count += 1
-                        continue
-
-                if not skip_encrypt:
-                    if detection.status != "found" or detection.path is None:
-                        missing_description = (
-                            f"{env_file.name} file" if mapping.env_file is not None else ".env file"
-                        )
-                        console.print(
-                            f"[dim]Skipped[/dim] {mapping.folder_path}: "
-                            f"No {missing_description} found"
-                        )
-                        skipped_count += 1
-                        continue
-
-                # Check encryption (unless --skip-encrypt)
-                if not skip_encrypt:
-                    content = env_file.read_text()
-                    if not is_encrypted_content(backend_provider, encryption_backend, content):
-                        detected_provider = detect_encryption_provider(env_file)
-                        if detected_provider and detected_provider != backend_provider:
-                            if (
-                                detected_provider == EncryptionProvider.DOTENVX
-                                and backend_provider != EncryptionProvider.DOTENVX
-                            ):
-                                print_error(
-                                    f"{env_file}: encrypted with dotenvx, "
-                                    f"but config uses {backend_provider.value}"
-                                )
-                                error_count += 1
-                                dotenvx_mismatch = True
-                                continue
-                            console.print(
-                                f"[dim]Skipped[/dim] {mapping.folder_path}: "
-                                f"Encrypted with {detected_provider.value}, "
-                                f"config uses {backend_provider.value}"
-                            )
-                            skipped_count += 1
-                            continue
-
-                        console.print(f"Encrypting {env_file} with {encryption_backend.name}...")
-                        try:
-                            result = encryption_backend.encrypt(env_file, **sops_encrypt_kwargs)
-                            if not result.success:
-                                print_error(result.message)
-                                error_count += 1
-                                continue
-                        except (EncryptionNotFoundError, EncryptionBackendError) as e:
-                            print_error(f"Failed to encrypt {env_file}: {e}")
-                            error_count += 1
-                            continue
-
-                    # Normalize dotenvx metadata for custom filenames so the vault
-                    # key name stays canonical (DOTENV_*_<environment>). This runs
-                    # whether we just encrypted the file or it was already encrypted
-                    # by a prior run, so the canonical key always exists below. It
-                    # applies to any non-canonical filename — configured (env_file)
-                    # or auto-detected (e.g. postgresql.env) — since dotenvx derives
-                    # its key name from the filename.
-                    if (
-                        backend_provider == EncryptionProvider.DOTENVX
-                        and dotenvx_filename_needs_normalization(env_file, effective_environment)
-                    ):
-                        from envdrift.integrations.dotenvx import normalize_dotenvx_metadata
-
-                        normalize_dotenvx_metadata(
-                            env_file,
-                            mapping.folder_path / (sync_config.env_keys_filename or ".env.keys"),
-                            effective_environment,
-                        )
-
-                # Read key to push
-                env_keys_path = mapping.folder_path / (sync_config.env_keys_filename or ".env.keys")
-                if not env_keys_path.exists():
-                    print_error(f"Skipped {mapping.folder_path}: .env.keys not found")
-                    error_count += 1
-                    continue
-
-                env_keys = EnvKeysFile(env_keys_path)
-                key_name = f"DOTENV_PRIVATE_KEY_{effective_environment.upper()}"
-                key_value = env_keys.read_key(key_name)
-
-                if not key_value:
-                    print_error(f"Skipped {mapping.folder_path}: {key_name} not found in keys file")
-                    error_count += 1
-                    continue
-
-                actual_value = f"{key_name}={key_value}"
-
-                # Push
-                client.set_secret(mapping.secret_name, actual_value)
-                print_success(f"Pushed {mapping.secret_name}")
-                pushed_count += 1
-
-            except (VaultError, OSError, ValueError) as e:
-                print_error(f"Error processing {mapping.folder_path}: {e}")
-                error_count += 1
-
-        console.print()
-        console.print(
-            f"Done. Pushed: {pushed_count}, Skipped: {skipped_count}, Errors: {error_count}"
-        )
-        # Exit non-zero on any per-mapping failure (not just dotenvx mismatch) so
-        # CI/automation can detect a partially-failed bulk push (#353).
-        if dotenvx_mismatch or error_count > 0:
-            raise typer.Exit(code=1)
-        return
-
-    # Normal/Direct mode preamble: resolve effective provider settings (shared
-    # with vault-pull).
-    (
-        effective_provider,
-        effective_vault_url,
-        effective_region,
-        effective_project_id,
-    ) = _resolve_vault_settings(config, provider, vault_url, region, project_id)
-
-    # Handle direct mode
-    if direct:
-        if not folder or not secret_name:
-            print_error("Direct mode requires: envdrift vault-push --direct <secret-name> <value>")
-            raise typer.Exit(code=1)
-        # In direct mode, folder is actually the secret name, secret_name is the value
-        actual_secret_name = str(folder)
-        actual_value = secret_name
-    else:
-        # Normal mode: read from .env.keys
-        if not folder or not secret_name or not env:
-            print_error(
-                "Required: envdrift vault-push <folder> <secret-name> --env <environment> (or use --all)"
-            )
-            raise typer.Exit(code=1)
-
-        # Read the key from .env.keys
-        env_keys_path = folder / ".env.keys"
-        if not env_keys_path.exists():
-            print_error(f"File not found: {env_keys_path}")
-            raise typer.Exit(code=1)
-
-        env_keys = EnvKeysFile(env_keys_path)
-        key_name = f"DOTENV_PRIVATE_KEY_{env.upper()}"
-        # Same OSError/ValueError boundary as --all mode: .env.keys may be a
-        # directory (IsADirectoryError) or hold non-UTF-8 bytes
-        # (UnicodeDecodeError); both must surface as a clean one-line error,
-        # not a raw Rich traceback (#487).
-        try:
-            key_value = env_keys.read_key(key_name)
-        except (OSError, ValueError) as e:
-            print_error(f"Cannot read {env_keys_path}: {e}")
-            raise typer.Exit(code=1) from None
-
-        if not key_value:
-            print_error(f"Key '{key_name}' not found in {env_keys_path}")
-            raise typer.Exit(code=1)
-
-        actual_secret_name = secret_name
-        actual_value = f"{key_name}={key_value}"
-
-    # Create vault client (shared with vault-pull)
-    client = _build_authenticated_client(
-        effective_provider, effective_vault_url, effective_region, effective_project_id
     )
-
-    # Push the secret
-    try:
-        result = client.set_secret(actual_secret_name, actual_value)
-        print_success(f"Pushed secret '{actual_secret_name}' to {effective_provider} vault")
-        if result.version:
-            console.print(f"  Version: {result.version}")
-    except VaultError as e:
-        print_error(f"Failed to push secret: {e}")
-        raise typer.Exit(code=1) from None
 
 
 def vault_pull(
-    folder: Annotated[
-        Path,
-        typer.Argument(help="Service folder to write the fetched .env.keys file into"),
-    ],
-    secret_name: Annotated[
-        str,
-        typer.Argument(help="Name of the secret in the vault"),
-    ],
-    env: Annotated[
-        str,
-        typer.Option(
-            "--env",
-            "-e",
-            help=(
-                "Required: environment suffix that names the key written to .env.keys "
-                "(e.g., 'soak' -> DOTENV_PRIVATE_KEY_SOAK). Also selects which "
-                ".env.<env> file is decrypted unless --no-decrypt is used."
-            ),
-        ),
-    ],
-    config: Annotated[
-        Path | None,
-        typer.Option("--config", "-c", help="Path to envdrift.toml config file"),
-    ] = None,
-    provider: Annotated[
-        str | None,
-        typer.Option("--provider", "-p", help="Vault provider: azure, aws, hashicorp, gcp"),
-    ] = None,
-    vault_url: Annotated[
-        str | None,
-        typer.Option("--vault-url", help="Vault URL (Azure Key Vault or HashiCorp Vault)"),
-    ] = None,
-    region: Annotated[
-        str | None,
-        typer.Option("--region", help="AWS region (default: us-east-1)"),
-    ] = None,
-    project_id: Annotated[
-        str | None,
-        typer.Option("--project-id", help="GCP project ID (Secret Manager)"),
-    ] = None,
-    no_decrypt: Annotated[
-        bool,
-        typer.Option(
-            "--no-decrypt",
-            help="Only write the key to .env.keys; do not decrypt the .env.<env> file",
-        ),
-    ] = False,
-    env_file: Annotated[
-        Path | None,
-        typer.Option(
-            "--env-file",
-            help="Custom env filename to decrypt, relative to FOLDER",
-        ),
-    ] = None,
+    folder: _PullFolder,
+    secret_name: _PullSecretName,
+    env: _PullEnvironment,
+    config: _PullConfigOption = None,
+    provider: _ProviderOption = None,
+    vault_url: _VaultUrlOption = None,
+    region: _RegionOption = None,
+    project_id: _ProjectIdOption = None,
+    no_decrypt: _NoDecryptOption = False,
+    env_file: _EnvFileOption = None,
 ) -> None:
-    """
-    Pull a single encryption key from a cloud vault into a local .env.keys file.
-
-    This is the config-free inverse of `envdrift vault-push` (single-service mode):
-    it fetches one secret, writes the DOTENV_PRIVATE_KEY_<ENV> key into
-    `<folder>/.env.keys`, and (by default) decrypts the matching `.env.<env>` file
-    so a single command onboards a developer with no TOML required.
-
-    Modes:
-
-    1. Pull key and decrypt (default):
-       envdrift vault-pull ./services/soak soak-machine --env soak -p azure --vault-url https://myvault.vault.azure.net/
-
-    2. Pull key only (skip decryption):
-       envdrift vault-pull ./services/soak soak-machine --env soak --no-decrypt -p azure --vault-url https://myvault.vault.azure.net/
-
-    Provider/URL/region/project-id may be omitted when they are configured in the
-    `[vault]` section of an envdrift.toml/pyproject.toml.
-
-    Examples:
-        # Azure
-        envdrift vault-pull . my-app-key --env production -p azure --vault-url https://myvault.vault.azure.net/
-
-        # AWS
-        envdrift vault-pull . my-app-key --env production -p aws --region us-east-1
-
-        # GCP
-        envdrift vault-pull . my-app-key --env production -p gcp --project-id my-gcp-project
-
-        # HashiCorp
-        envdrift vault-pull . my-app-key --env production -p hashicorp --vault-url https://vault.example.com:8200
-    """
-    from envdrift.sync.operations import EnvKeysFile
-    from envdrift.vault import VaultError
-    from envdrift.vault.base import SecretNotFoundError
-    from envdrift.vault.keymaterial import KeyMaterialError, extract_key_material
-
-    # Validate the target folder before any vault round-trip (#487): a typo'd
-    # or non-directory FOLDER must fail fast with a clean error instead of
-    # being silently created (or crashing with a raw OSError traceback) after
-    # the secret was already fetched.
-    if not folder.exists():
-        print_error(f"Folder not found: {folder}")
-        raise typer.Exit(code=1)
-    if not folder.is_dir():
-        print_error(f"Not a directory: {folder}")
-        raise typer.Exit(code=1)
-
-    # Resolve effective provider settings + build an authenticated client
-    # (shared with vault-push single-service mode).
-    (
-        effective_provider,
-        effective_vault_url,
-        effective_region,
-        effective_project_id,
-    ) = _resolve_vault_settings(config, provider, vault_url, region, project_id)
-    client = _build_authenticated_client(
-        effective_provider, effective_vault_url, effective_region, effective_project_id
+    """Pull an encryption key from a cloud vault and optionally decrypt its env file."""
+    execute_vault_pull(
+        VaultPullRequest(
+            folder=folder,
+            secret_name=secret_name,
+            environment=env,
+            config=config,
+            provider=provider,
+            vault_url=vault_url,
+            region=region,
+            project_id=project_id,
+            no_decrypt=no_decrypt,
+            env_file=env_file,
+        )
     )
-
-    # Fetch the secret
-    try:
-        secret = client.get_secret(secret_name)
-    except SecretNotFoundError:
-        # Name the AWS region that was searched (#487): with --region omitted
-        # the CLI silently defaults to us-east-1, making the classic
-        # wrong-region mistake undiagnosable from a region-free message.
-        region_note = ""
-        if effective_provider == "aws":
-            client_region = getattr(client, "region", None)
-            if client_region:
-                region_note = f" (region {client_region})"
-        print_error(f"Secret '{secret_name}' not found in {effective_provider} vault{region_note}")
-        raise typer.Exit(code=1) from None
-    except VaultError as e:
-        print_error(f"Failed to fetch secret: {e}")
-        raise typer.Exit(code=1) from None
-
-    key_name = f"DOTENV_PRIVATE_KEY_{env.upper()}"
-
-    # Normalize + shape-validate the stored value through the shared parser used
-    # by the sync engine and lock --verify-vault (#356, #480): quoted/whitespace-
-    # wrapped values, JSON key/value documents, and multi-line .env.keys blobs
-    # are reduced to the bare key; binary payloads and unusable shapes fail
-    # loudly here instead of corrupting .env.keys under a success banner.
-    try:
-        key_value, stored_suffix = extract_key_material(secret, env)
-    except KeyMaterialError as e:
-        print_error(f"Cannot install secret as a dotenvx key: {e}")
-        raise typer.Exit(code=1) from None
-
-    # Fail fast on env-prefix mismatch: e.g. pulling --env production a secret
-    # that was pushed --env staging would otherwise silently store the staging
-    # key under the production name and fail later with an opaque crypto error.
-    if stored_suffix is not None and stored_suffix.upper() != env.upper():
-        print_error(
-            f"Secret holds 'DOTENV_PRIVATE_KEY_{stored_suffix.upper()}' but --env {env} "
-            f"expects '{key_name}'. "
-            f"Re-run with --env matching the environment the secret was pushed for "
-            f"(or push the secret under the correct environment)."
-        )
-        raise typer.Exit(code=1)
-
-    # Write the key into <folder>/.env.keys. Same OSError/ValueError boundary
-    # as vault-push (#487): the destination may be unwritable
-    # (PermissionError), a directory (IsADirectoryError), or an existing
-    # non-UTF-8 file (UnicodeDecodeError on the preserve-content read).
-    env_keys_path = folder / ".env.keys"
-    env_keys = EnvKeysFile(env_keys_path)
-    try:
-        env_keys.write_key(key_name, key_value, environment=env)
-    except (OSError, ValueError) as e:
-        print_error(f"Cannot write {env_keys_path}: {e}")
-        raise typer.Exit(code=1) from None
-
-    print_success(f"Pulled '{secret_name}' -> {key_name} written to {env_keys_path}")
-
-    # Optionally decrypt the matching .env.<env> file (true one-command onboarding)
-    if no_decrypt:
-        return
-
-    try:
-        target_env_file = (
-            resolve_custom_env_file(folder, env_file)
-            if env_file is not None
-            else folder / f".env.{env}"
-        )
-    except ValueError as e:
-        print_error(f"Invalid --env-file: {e}")
-        raise typer.Exit(code=1) from None
-    if not target_env_file.exists():
-        console.print(f"[dim]Key written; no {target_env_file} found to decrypt.[/dim]")
-        return
-
-    from envdrift.cli_commands.encryption_helpers import resolve_encryption_backend
-    from envdrift.encryption import (
-        EncryptionBackendError,
-        EncryptionNotFoundError,
-        EncryptionProvider,
-    )
-
-    # resolve_encryption_backend only honours `config` when it has a `.toml`
-    # suffix; a config path without that suffix is silently ignored here (falls
-    # back to auto-discovery) even though the vault settings above did load it.
-    # Warn so the inconsistency isn't silent.
-    if config is not None and config.suffix.lower() != ".toml":
-        print_warning(
-            f"--config {config} has no .toml suffix; it is used for vault settings "
-            f"but ignored when selecting the encryption backend (auto-detected instead)."
-        )
-
-    from envdrift.config import ConfigLoadError, ConfigNotFoundError
-
-    try:
-        encryption_backend, backend_provider, _ = resolve_encryption_backend(config)
-    except (ConfigNotFoundError, ConfigLoadError) as e:
-        # resolve_encryption_backend no longer falls back to dotenvx on a
-        # broken config (#491); surface the loader's message verbatim.
-        print_error(str(e))
-        raise typer.Exit(code=1) from None
-    except ValueError as e:
-        print_error(f"Unsupported encryption backend: {e}")
-        raise typer.Exit(code=1) from None
-
-    if not encryption_backend.is_installed():
-        print_error(f"{encryption_backend.name} is not installed")
-        console.print(encryption_backend.install_instructions())
-        raise typer.Exit(code=1)
-
-    if backend_provider == EncryptionProvider.DOTENVX and env_file is not None:
-        from envdrift.integrations.dotenvx import normalize_dotenvx_metadata
-
-        normalize_dotenvx_metadata(target_env_file, env_keys_path, env)
-
-    try:
-        # Point the backend at the .env.keys we just wrote so decryption works
-        # even when FOLDER is not the current working directory (monorepo usage).
-        result = encryption_backend.decrypt(
-            target_env_file.resolve(),
-            keys_file=env_keys_path.resolve(),
-        )
-    except (EncryptionNotFoundError, EncryptionBackendError) as e:
-        print_error(f"Failed to decrypt {target_env_file}: {e}")
-        raise typer.Exit(code=1) from None
-
-    if not result.success:
-        print_error(f"Failed to decrypt {target_env_file}: {result.message}")
-        raise typer.Exit(code=1)
-
-    print_success(f"Decrypted {target_env_file}")

--- a/src/envdrift/cli_commands/vault.py
+++ b/src/envdrift/cli_commands/vault.py
@@ -8,6 +8,7 @@ from typing import Annotated
 import typer
 
 from envdrift.cli_commands.vault_helpers import (
+    VaultConnectionOptions,
     VaultPullRequest,
     VaultPushRequest,
     execute_vault_pull,
@@ -198,11 +199,13 @@ def vault_push(
             all_services=all_services,
             force=force,
             skip_encrypt=skip_encrypt,
-            config=config,
-            provider=provider,
-            vault_url=vault_url,
-            region=region,
-            project_id=project_id,
+            connection=VaultConnectionOptions(
+                config=config,
+                provider=provider,
+                vault_url=vault_url,
+                region=region,
+                project_id=project_id,
+            ),
         )
     )
 
@@ -225,11 +228,13 @@ def vault_pull(
             folder=folder,
             secret_name=secret_name,
             environment=env,
-            config=config,
-            provider=provider,
-            vault_url=vault_url,
-            region=region,
-            project_id=project_id,
+            connection=VaultConnectionOptions(
+                config=config,
+                provider=provider,
+                vault_url=vault_url,
+                region=region,
+                project_id=project_id,
+            ),
             no_decrypt=no_decrypt,
             env_file=env_file,
         )

--- a/src/envdrift/cli_commands/vault_helpers.py
+++ b/src/envdrift/cli_commands/vault_helpers.py
@@ -180,14 +180,21 @@ def build_authenticated_client(settings: VaultSettings) -> VaultClient:
 
 def execute_vault_push(request: VaultPushRequest) -> None:
     """Validate push-mode flags and dispatch bulk or single-service execution."""
-    if request.skip_encrypt and not request.all_services:
-        print_warning("--skip-encrypt is only applicable with --all mode, ignoring")
-    if request.force and not request.all_services:
-        print_warning("--force is only applicable with --all mode, ignoring")
+    _warn_ignored_push_flags(request)
     if request.all_services:
         _push_all_services(request)
         return
     _push_single_secret(request)
+
+
+def _warn_ignored_push_flags(request: VaultPushRequest) -> None:
+    """Warn when bulk-only flags are present in single-service mode."""
+    if request.all_services:
+        return
+    if request.skip_encrypt:
+        print_warning("--skip-encrypt is only applicable with --all mode, ignoring")
+    if request.force:
+        print_warning("--force is only applicable with --all mode, ignoring")
 
 
 def _load_bulk_vault(

--- a/src/envdrift/cli_commands/vault_helpers.py
+++ b/src/envdrift/cli_commands/vault_helpers.py
@@ -1,0 +1,711 @@
+"""Execution helpers for the vault CLI commands."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import typer
+
+from envdrift.env_files import EnvFileDetection, resolve_custom_env_file, resolve_mapping_env_file
+from envdrift.output.rich import console, print_error, print_success, print_warning
+
+if TYPE_CHECKING:
+    from envdrift.encryption import EncryptionProvider
+    from envdrift.encryption.base import EncryptionBackend
+    from envdrift.sync.config import ServiceMapping, SyncConfig
+    from envdrift.vault.base import SecretValue, VaultClient
+
+
+@dataclass(frozen=True)
+class VaultSettings:
+    """Effective vault provider settings after CLI/config resolution."""
+
+    provider: str
+    vault_url: str | None
+    region: str | None
+    project_id: str | None
+
+
+@dataclass(frozen=True)
+class VaultPushRequest:
+    """Parsed inputs for a vault-push invocation."""
+
+    folder: Path | None
+    secret_name: str | None
+    environment: str | None
+    direct: bool
+    all_services: bool
+    force: bool
+    skip_encrypt: bool
+    config: Path | None
+    provider: str | None
+    vault_url: str | None
+    region: str | None
+    project_id: str | None
+
+
+@dataclass(frozen=True)
+class VaultPullRequest:
+    """Parsed inputs for a vault-pull invocation."""
+
+    folder: Path
+    secret_name: str
+    environment: str
+    config: Path | None
+    provider: str | None
+    vault_url: str | None
+    region: str | None
+    project_id: str | None
+    no_decrypt: bool
+    env_file: Path | None
+
+
+@dataclass(frozen=True)
+class _BulkPushContext:
+    sync_config: SyncConfig
+    client: VaultClient
+    vault_provider: str
+    backend: EncryptionBackend
+    backend_provider: EncryptionProvider
+    sops_kwargs: dict[str, Any]
+    force: bool
+    skip_encrypt: bool
+
+
+@dataclass
+class _PushStats:
+    pushed: int = 0
+    skipped: int = 0
+    errors: int = 0
+    dotenvx_mismatch: bool = False
+
+
+@dataclass(frozen=True)
+class _PushTarget:
+    mapping: ServiceMapping
+    detection: EnvFileDetection
+    env_file: Path
+    environment: str
+
+
+def _load_vault_config(config: Path | None) -> Any | None:
+    """Load discovered or explicit config, failing loudly on invalid files."""
+    from envdrift.config import ConfigLoadError, ConfigNotFoundError, find_config, load_config
+
+    config_path = config if config is not None else find_config()
+    if config_path is None:
+        return None
+    try:
+        return load_config(config_path)
+    except (ConfigNotFoundError, ConfigLoadError) as e:
+        print_error(str(e))
+        raise typer.Exit(code=1) from None
+
+
+def _provider_vault_url(
+    provider: str,
+    explicit_url: str | None,
+    vault_config: Any | None,
+) -> str | None:
+    """Resolve provider-specific URL, preserving explicit CLI precedence."""
+    if explicit_url is not None or vault_config is None:
+        return explicit_url
+    if provider == "azure":
+        return getattr(vault_config, "azure_vault_url", None)
+    if provider == "hashicorp":
+        return getattr(vault_config, "hashicorp_url", None)
+    return None
+
+
+def _validate_vault_settings(settings: VaultSettings) -> None:
+    """Reject missing provider-specific settings with CLI-facing errors."""
+    if settings.provider in ("azure", "hashicorp") and not settings.vault_url:
+        print_error(f"--vault-url required for {settings.provider}")
+        raise typer.Exit(code=1)
+    if settings.provider == "gcp" and not settings.project_id:
+        print_error("--project-id required for gcp")
+        raise typer.Exit(code=1)
+
+
+def resolve_vault_settings(
+    config: Path | None,
+    provider: str | None,
+    vault_url: str | None,
+    region: str | None,
+    project_id: str | None,
+) -> VaultSettings:
+    """Merge CLI flags with the config's vault settings and validate them."""
+    envdrift_config = _load_vault_config(config)
+    vault_config = getattr(envdrift_config, "vault", None)
+    effective_provider = provider or getattr(vault_config, "provider", None)
+    if not effective_provider:
+        print_error("Vault provider required. Use --provider or configure in envdrift.toml")
+        raise typer.Exit(code=1)
+
+    settings = VaultSettings(
+        provider=effective_provider,
+        vault_url=_provider_vault_url(effective_provider, vault_url, vault_config),
+        region=region or getattr(vault_config, "aws_region", None),
+        project_id=project_id or getattr(vault_config, "gcp_project_id", None),
+    )
+    _validate_vault_settings(settings)
+    return settings
+
+
+def _vault_client_kwargs(settings: VaultSettings) -> dict[str, str | None]:
+    """Build provider-specific client keyword arguments."""
+    if settings.provider == "azure":
+        return {"vault_url": settings.vault_url}
+    if settings.provider == "aws":
+        return {"region": settings.region or "us-east-1"}
+    if settings.provider == "hashicorp":
+        return {"url": settings.vault_url}
+    if settings.provider == "gcp":
+        return {"project_id": settings.project_id}
+    return {}
+
+
+def build_authenticated_client(settings: VaultSettings) -> VaultClient:
+    """Create and authenticate a vault client for effective settings."""
+    from envdrift.vault import VaultError, get_vault_client
+
+    try:
+        client = get_vault_client(settings.provider, **_vault_client_kwargs(settings))
+        client.authenticate()
+    except ImportError as e:
+        print_error(str(e))
+        raise typer.Exit(code=1) from None
+    except ValueError as e:
+        print_error(f"Invalid vault configuration: {e}")
+        raise typer.Exit(code=1) from None
+    except VaultError as e:
+        print_error(f"Vault authentication failed: {e}")
+        raise typer.Exit(code=1) from None
+    return client
+
+
+def execute_vault_push(request: VaultPushRequest) -> None:
+    """Validate push-mode flags and dispatch bulk or single-service execution."""
+    if request.skip_encrypt and not request.all_services:
+        print_warning("--skip-encrypt is only applicable with --all mode, ignoring")
+    if request.force and not request.all_services:
+        print_warning("--force is only applicable with --all mode, ignoring")
+    if request.all_services:
+        _push_all_services(request)
+        return
+    _push_single_secret(request)
+
+
+def _load_bulk_push_context(request: VaultPushRequest) -> _BulkPushContext:
+    """Load sync, vault, and encryption dependencies for bulk push."""
+    from envdrift.cli_commands.encryption_helpers import (
+        build_sops_encrypt_kwargs,
+        resolve_encryption_backend,
+    )
+    from envdrift.cli_commands.sync import load_sync_config_and_client
+    from envdrift.config import ConfigLoadError, ConfigNotFoundError
+    from envdrift.encryption import EncryptionProvider
+    from envdrift.vault import VaultError
+
+    sync_config, client, vault_provider, _, _, _ = load_sync_config_and_client(
+        config_file=request.config,
+        provider=request.provider,
+        vault_url=request.vault_url,
+        region=request.region,
+        project_id=request.project_id,
+    )
+    try:
+        client.authenticate()
+    except VaultError as e:
+        print_error(str(e))
+        raise typer.Exit(code=1) from None
+
+    try:
+        backend, backend_provider, encryption_config = resolve_encryption_backend(request.config)
+    except (ConfigNotFoundError, ConfigLoadError) as e:
+        print_error(str(e))
+        raise typer.Exit(code=1) from None
+    except ValueError as e:
+        print_error(f"Unsupported encryption backend: {e}")
+        raise typer.Exit(code=1) from None
+
+    if not backend.is_installed():
+        print_error(f"{backend.name} is not installed")
+        console.print(backend.install_instructions())
+        raise typer.Exit(code=1)
+    sops_kwargs = (
+        build_sops_encrypt_kwargs(encryption_config)
+        if backend_provider == EncryptionProvider.SOPS
+        else {}
+    )
+    return _BulkPushContext(
+        sync_config=sync_config,
+        client=client,
+        vault_provider=vault_provider,
+        backend=backend,
+        backend_provider=backend_provider,
+        sops_kwargs=sops_kwargs,
+        force=request.force,
+        skip_encrypt=request.skip_encrypt,
+    )
+
+
+def _print_bulk_push_header(context: _BulkPushContext) -> None:
+    """Render the bulk-push execution summary."""
+    console.print("[bold]Vault Push All[/bold]")
+    console.print(f"Provider: {context.vault_provider}")
+    console.print(f"Services: {len(context.sync_config.mappings)}")
+    if context.force:
+        console.print("[dim]Force: overwrite existing secrets (--force)[/dim]")
+    if context.skip_encrypt:
+        console.print("[dim]Encryption: skipped (--skip-encrypt)[/dim]")
+    console.print()
+
+
+def _push_all_services(request: VaultPushRequest) -> None:
+    """Push every configured mapping and report aggregate status."""
+    context = _load_bulk_push_context(request)
+    _print_bulk_push_header(context)
+    stats = _PushStats()
+    for mapping in context.sync_config.mappings:
+        _push_mapping(context, mapping, stats)
+    console.print()
+    console.print(f"Done. Pushed: {stats.pushed}, Skipped: {stats.skipped}, Errors: {stats.errors}")
+    if stats.dotenvx_mismatch or stats.errors > 0:
+        raise typer.Exit(code=1)
+
+
+def _resolve_push_target(mapping: ServiceMapping, stats: _PushStats) -> _PushTarget | None:
+    """Resolve a mapping's env file and reject broken folder paths."""
+    detection = resolve_mapping_env_file(mapping)
+    if detection.status == "folder_not_found":
+        print_error(
+            f"Error processing {mapping.folder_path}: folder does not exist or is not a "
+            "directory (check folder_path in your sync config)"
+        )
+        stats.errors += 1
+        return None
+    env_file = (
+        detection.path
+        if detection.path is not None
+        else mapping.folder_path / f".env.{mapping.effective_environment}"
+    )
+    return _PushTarget(
+        mapping=mapping,
+        detection=detection,
+        env_file=env_file,
+        environment=detection.environment or mapping.effective_environment,
+    )
+
+
+def _skip_existing_secret(
+    context: _BulkPushContext,
+    target: _PushTarget,
+    stats: _PushStats,
+) -> bool:
+    """Skip an existing secret before any local file mutation."""
+    from envdrift.vault import VaultError
+    from envdrift.vault.base import SecretNotFoundError
+
+    if context.force:
+        return False
+    try:
+        context.client.get_secret(target.mapping.secret_name)
+    except SecretNotFoundError:
+        return False
+    except VaultError as e:
+        print_error(f"Vault error checking {target.mapping.secret_name}: {e}")
+        stats.errors += 1
+        return True
+    console.print(
+        f"[dim]Skipped[/dim] {target.mapping.folder_path}: "
+        f"Secret '{target.mapping.secret_name}' already exists"
+    )
+    stats.skipped += 1
+    return True
+
+
+def _skip_missing_env_file(target: _PushTarget, stats: _PushStats) -> bool:
+    """Report a missing file when encryption is required."""
+    if target.detection.status == "found" and target.detection.path is not None:
+        return False
+    missing_description = (
+        f"{target.env_file.name} file" if target.mapping.env_file is not None else ".env file"
+    )
+    console.print(
+        f"[dim]Skipped[/dim] {target.mapping.folder_path}: No {missing_description} found"
+    )
+    stats.skipped += 1
+    return True
+
+
+def _handle_provider_mismatch(
+    context: _BulkPushContext,
+    target: _PushTarget,
+    detected_provider: EncryptionProvider,
+    stats: _PushStats,
+) -> bool:
+    """Report cross-backend ciphertext and stop processing the mapping."""
+    from envdrift.encryption import EncryptionProvider
+
+    if detected_provider == context.backend_provider:
+        return False
+    if (
+        detected_provider == EncryptionProvider.DOTENVX
+        and context.backend_provider != EncryptionProvider.DOTENVX
+    ):
+        print_error(
+            f"{target.env_file}: encrypted with dotenvx, "
+            f"but config uses {context.backend_provider.value}"
+        )
+        stats.errors += 1
+        stats.dotenvx_mismatch = True
+        return True
+    console.print(
+        f"[dim]Skipped[/dim] {target.mapping.folder_path}: "
+        f"Encrypted with {detected_provider.value}, config uses {context.backend_provider.value}"
+    )
+    stats.skipped += 1
+    return True
+
+
+def _encrypt_target(
+    context: _BulkPushContext,
+    target: _PushTarget,
+    stats: _PushStats,
+) -> bool:
+    """Encrypt one plaintext target, returning whether processing may continue."""
+    from envdrift.encryption import EncryptionBackendError, EncryptionNotFoundError
+
+    console.print(f"Encrypting {target.env_file} with {context.backend.name}...")
+    try:
+        result = context.backend.encrypt(target.env_file, **context.sops_kwargs)
+    except (EncryptionNotFoundError, EncryptionBackendError) as e:
+        print_error(f"Failed to encrypt {target.env_file}: {e}")
+        stats.errors += 1
+        return False
+    if not result.success:
+        print_error(result.message)
+        stats.errors += 1
+        return False
+    return True
+
+
+def _normalize_mapping_metadata(context: _BulkPushContext, target: _PushTarget) -> None:
+    """Canonicalize dotenvx metadata for custom env filenames."""
+    from envdrift.encryption import EncryptionProvider
+    from envdrift.integrations.dotenvx import (
+        dotenvx_filename_needs_normalization,
+        normalize_dotenvx_metadata,
+    )
+
+    if context.backend_provider != EncryptionProvider.DOTENVX:
+        return
+    if not dotenvx_filename_needs_normalization(target.env_file, target.environment):
+        return
+    normalize_dotenvx_metadata(
+        target.env_file,
+        target.mapping.folder_path / (context.sync_config.env_keys_filename or ".env.keys"),
+        target.environment,
+    )
+
+
+def _ensure_encrypted(
+    context: _BulkPushContext,
+    target: _PushTarget,
+    stats: _PushStats,
+) -> bool:
+    """Ensure a target uses the configured backend, then normalize its metadata."""
+    from envdrift.cli_commands.encryption_helpers import is_encrypted_content
+    from envdrift.encryption import detect_encryption_provider
+
+    content = target.env_file.read_text()
+    if not is_encrypted_content(context.backend_provider, context.backend, content):
+        detected_provider = detect_encryption_provider(target.env_file)
+        if detected_provider and _handle_provider_mismatch(
+            context, target, detected_provider, stats
+        ):
+            return False
+        if not _encrypt_target(context, target, stats):
+            return False
+    _normalize_mapping_metadata(context, target)
+    return True
+
+
+def _mapping_secret_value(
+    context: _BulkPushContext,
+    target: _PushTarget,
+    stats: _PushStats,
+) -> str | None:
+    """Read the canonical private key value for one mapping."""
+    from envdrift.sync.operations import EnvKeysFile
+
+    env_keys_path = target.mapping.folder_path / (
+        context.sync_config.env_keys_filename or ".env.keys"
+    )
+    if not env_keys_path.exists():
+        print_error(f"Skipped {target.mapping.folder_path}: .env.keys not found")
+        stats.errors += 1
+        return None
+    key_name = f"DOTENV_PRIVATE_KEY_{target.environment.upper()}"
+    key_value = EnvKeysFile(env_keys_path).read_key(key_name)
+    if not key_value:
+        print_error(f"Skipped {target.mapping.folder_path}: {key_name} not found in keys file")
+        stats.errors += 1
+        return None
+    return f"{key_name}={key_value}"
+
+
+def _push_mapping(
+    context: _BulkPushContext,
+    mapping: ServiceMapping,
+    stats: _PushStats,
+) -> None:
+    """Process one bulk-push mapping without leaking per-service failures."""
+    from envdrift.vault import VaultError
+
+    try:
+        target = _resolve_push_target(mapping, stats)
+        if target is None or _skip_existing_secret(context, target, stats):
+            return
+        if not context.skip_encrypt:
+            if _skip_missing_env_file(target, stats):
+                return
+            if not _ensure_encrypted(context, target, stats):
+                return
+        value = _mapping_secret_value(context, target, stats)
+        if value is None:
+            return
+        context.client.set_secret(mapping.secret_name, value)
+        print_success(f"Pushed {mapping.secret_name}")
+        stats.pushed += 1
+    except (VaultError, OSError, ValueError) as e:
+        print_error(f"Error processing {mapping.folder_path}: {e}")
+        stats.errors += 1
+
+
+def _single_push_value(request: VaultPushRequest) -> tuple[str, str]:
+    """Resolve the secret name/value for direct or .env.keys mode."""
+    if request.direct:
+        if not request.folder or not request.secret_name:
+            print_error("Direct mode requires: envdrift vault-push --direct <secret-name> <value>")
+            raise typer.Exit(code=1)
+        return str(request.folder), request.secret_name
+    return _file_push_value(request)
+
+
+def _file_push_value(request: VaultPushRequest) -> tuple[str, str]:
+    """Read one private key from a service's .env.keys file."""
+    from envdrift.sync.operations import EnvKeysFile
+
+    if not request.folder or not request.secret_name or not request.environment:
+        print_error(
+            "Required: envdrift vault-push <folder> <secret-name> --env <environment> "
+            "(or use --all)"
+        )
+        raise typer.Exit(code=1)
+    env_keys_path = request.folder / ".env.keys"
+    if not env_keys_path.exists():
+        print_error(f"File not found: {env_keys_path}")
+        raise typer.Exit(code=1)
+    key_name = f"DOTENV_PRIVATE_KEY_{request.environment.upper()}"
+    try:
+        key_value = EnvKeysFile(env_keys_path).read_key(key_name)
+    except (OSError, ValueError) as e:
+        print_error(f"Cannot read {env_keys_path}: {e}")
+        raise typer.Exit(code=1) from None
+    if not key_value:
+        print_error(f"Key '{key_name}' not found in {env_keys_path}")
+        raise typer.Exit(code=1)
+    return request.secret_name, f"{key_name}={key_value}"
+
+
+def _push_single_secret(request: VaultPushRequest) -> None:
+    """Push one direct value or one key read from a service folder."""
+    from envdrift.vault import VaultError
+
+    settings = resolve_vault_settings(
+        request.config,
+        request.provider,
+        request.vault_url,
+        request.region,
+        request.project_id,
+    )
+    secret_name, value = _single_push_value(request)
+    client = build_authenticated_client(settings)
+    try:
+        result = client.set_secret(secret_name, value)
+    except VaultError as e:
+        print_error(f"Failed to push secret: {e}")
+        raise typer.Exit(code=1) from None
+    print_success(f"Pushed secret '{secret_name}' to {settings.provider} vault")
+    if result.version:
+        console.print(f"  Version: {result.version}")
+
+
+def _validate_pull_folder(folder: Path) -> None:
+    """Reject missing or non-directory targets before the vault round trip."""
+    if not folder.exists():
+        print_error(f"Folder not found: {folder}")
+        raise typer.Exit(code=1)
+    if not folder.is_dir():
+        print_error(f"Not a directory: {folder}")
+        raise typer.Exit(code=1)
+
+
+def _missing_secret_region_note(settings: VaultSettings, client: VaultClient) -> str:
+    """Describe the effective AWS region for a not-found error."""
+    if settings.provider != "aws":
+        return ""
+    client_region = getattr(client, "region", None)
+    return f" (region {client_region})" if client_region else ""
+
+
+def _fetch_pull_secret(
+    request: VaultPullRequest,
+    settings: VaultSettings,
+    client: VaultClient,
+) -> SecretValue:
+    """Fetch one vault secret with provider-specific failure context."""
+    from envdrift.vault import VaultError
+    from envdrift.vault.base import SecretNotFoundError
+
+    try:
+        return client.get_secret(request.secret_name)
+    except SecretNotFoundError:
+        region_note = _missing_secret_region_note(settings, client)
+        print_error(
+            f"Secret '{request.secret_name}' not found in {settings.provider} vault{region_note}"
+        )
+        raise typer.Exit(code=1) from None
+    except VaultError as e:
+        print_error(f"Failed to fetch secret: {e}")
+        raise typer.Exit(code=1) from None
+
+
+def _extract_pull_key(request: VaultPullRequest, secret: SecretValue) -> tuple[str, str]:
+    """Normalize vault key material and reject environment-prefix mismatches."""
+    from envdrift.vault.keymaterial import KeyMaterialError, extract_key_material
+
+    key_name = f"DOTENV_PRIVATE_KEY_{request.environment.upper()}"
+    try:
+        key_value, stored_suffix = extract_key_material(secret, request.environment)
+    except KeyMaterialError as e:
+        print_error(f"Cannot install secret as a dotenvx key: {e}")
+        raise typer.Exit(code=1) from None
+    if stored_suffix is not None and stored_suffix.upper() != request.environment.upper():
+        print_error(
+            f"Secret holds 'DOTENV_PRIVATE_KEY_{stored_suffix.upper()}' but "
+            f"--env {request.environment} expects '{key_name}'. "
+            "Re-run with --env matching the environment the secret was pushed for "
+            "(or push the secret under the correct environment)."
+        )
+        raise typer.Exit(code=1)
+    return key_name, key_value
+
+
+def _write_pull_key(request: VaultPullRequest, key_name: str, key_value: str) -> Path:
+    """Write fetched key material while preserving clean filesystem errors."""
+    from envdrift.sync.operations import EnvKeysFile
+
+    env_keys_path = request.folder / ".env.keys"
+    try:
+        EnvKeysFile(env_keys_path).write_key(
+            key_name,
+            key_value,
+            environment=request.environment,
+        )
+    except (OSError, ValueError) as e:
+        print_error(f"Cannot write {env_keys_path}: {e}")
+        raise typer.Exit(code=1) from None
+    return env_keys_path
+
+
+def _resolve_pull_target(request: VaultPullRequest) -> Path:
+    """Resolve an optional custom env filename under the service folder."""
+    try:
+        if request.env_file is not None:
+            return resolve_custom_env_file(request.folder, request.env_file)
+        return request.folder / f".env.{request.environment}"
+    except ValueError as e:
+        print_error(f"Invalid --env-file: {e}")
+        raise typer.Exit(code=1) from None
+
+
+def _resolve_pull_backend(config: Path | None) -> tuple[EncryptionBackend, EncryptionProvider]:
+    """Resolve and validate the encryption backend used after a key pull."""
+    from envdrift.cli_commands.encryption_helpers import resolve_encryption_backend
+    from envdrift.config import ConfigLoadError, ConfigNotFoundError
+
+    if config is not None and config.suffix.lower() != ".toml":
+        print_warning(
+            f"--config {config} has no .toml suffix; it is used for vault settings "
+            "but ignored when selecting the encryption backend (auto-detected instead)."
+        )
+    try:
+        backend, provider, _ = resolve_encryption_backend(config)
+    except (ConfigNotFoundError, ConfigLoadError) as e:
+        print_error(str(e))
+        raise typer.Exit(code=1) from None
+    except ValueError as e:
+        print_error(f"Unsupported encryption backend: {e}")
+        raise typer.Exit(code=1) from None
+    if not backend.is_installed():
+        print_error(f"{backend.name} is not installed")
+        console.print(backend.install_instructions())
+        raise typer.Exit(code=1)
+    return backend, provider
+
+
+def _decrypt_pull_target(
+    request: VaultPullRequest,
+    target: Path,
+    env_keys_path: Path,
+) -> None:
+    """Normalize custom dotenvx metadata and decrypt the target file."""
+    from envdrift.encryption import (
+        EncryptionBackendError,
+        EncryptionNotFoundError,
+        EncryptionProvider,
+    )
+
+    backend, provider = _resolve_pull_backend(request.config)
+    if provider == EncryptionProvider.DOTENVX and request.env_file is not None:
+        from envdrift.integrations.dotenvx import normalize_dotenvx_metadata
+
+        normalize_dotenvx_metadata(target, env_keys_path, request.environment)
+    try:
+        result = backend.decrypt(target.resolve(), keys_file=env_keys_path.resolve())
+    except (EncryptionNotFoundError, EncryptionBackendError) as e:
+        print_error(f"Failed to decrypt {target}: {e}")
+        raise typer.Exit(code=1) from None
+    if not result.success:
+        print_error(f"Failed to decrypt {target}: {result.message}")
+        raise typer.Exit(code=1)
+    print_success(f"Decrypted {target}")
+
+
+def execute_vault_pull(request: VaultPullRequest) -> None:
+    """Fetch, install, and optionally use one vault-backed encryption key."""
+    _validate_pull_folder(request.folder)
+    settings = resolve_vault_settings(
+        request.config,
+        request.provider,
+        request.vault_url,
+        request.region,
+        request.project_id,
+    )
+    client = build_authenticated_client(settings)
+    secret = _fetch_pull_secret(request, settings, client)
+    key_name, key_value = _extract_pull_key(request, secret)
+    env_keys_path = _write_pull_key(request, key_name, key_value)
+    print_success(f"Pulled '{request.secret_name}' -> {key_name} written to {env_keys_path}")
+    if request.no_decrypt:
+        return
+    target = _resolve_pull_target(request)
+    if not target.exists():
+        console.print(f"[dim]Key written; no {target} found to decrypt.[/dim]")
+        return
+    _decrypt_pull_target(request, target, env_keys_path)

--- a/src/envdrift/cli_commands/vault_helpers.py
+++ b/src/envdrift/cli_commands/vault_helpers.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Never
 
 import typer
 
@@ -29,6 +29,17 @@ class VaultSettings:
 
 
 @dataclass(frozen=True)
+class VaultConnectionOptions:
+    """CLI inputs used to resolve and construct a vault client."""
+
+    config: Path | None
+    provider: str | None
+    vault_url: str | None
+    region: str | None
+    project_id: str | None
+
+
+@dataclass(frozen=True)
 class VaultPushRequest:
     """Parsed inputs for a vault-push invocation."""
 
@@ -39,11 +50,7 @@ class VaultPushRequest:
     all_services: bool
     force: bool
     skip_encrypt: bool
-    config: Path | None
-    provider: str | None
-    vault_url: str | None
-    region: str | None
-    project_id: str | None
+    connection: VaultConnectionOptions
 
 
 @dataclass(frozen=True)
@@ -53,11 +60,7 @@ class VaultPullRequest:
     folder: Path
     secret_name: str
     environment: str
-    config: Path | None
-    provider: str | None
-    vault_url: str | None
-    region: str | None
-    project_id: str | None
+    connection: VaultConnectionOptions
     no_decrypt: bool
     env_file: Path | None
 
@@ -112,11 +115,8 @@ def _provider_vault_url(
     """Resolve provider-specific URL, preserving explicit CLI precedence."""
     if explicit_url is not None or vault_config is None:
         return explicit_url
-    if provider == "azure":
-        return getattr(vault_config, "azure_vault_url", None)
-    if provider == "hashicorp":
-        return getattr(vault_config, "hashicorp_url", None)
-    return None
+    attribute = {"azure": "azure_vault_url", "hashicorp": "hashicorp_url"}.get(provider)
+    return getattr(vault_config, attribute, None) if attribute is not None else None
 
 
 def _validate_vault_settings(settings: VaultSettings) -> None:
@@ -129,26 +129,20 @@ def _validate_vault_settings(settings: VaultSettings) -> None:
         raise typer.Exit(code=1)
 
 
-def resolve_vault_settings(
-    config: Path | None,
-    provider: str | None,
-    vault_url: str | None,
-    region: str | None,
-    project_id: str | None,
-) -> VaultSettings:
+def resolve_vault_settings(options: VaultConnectionOptions) -> VaultSettings:
     """Merge CLI flags with the config's vault settings and validate them."""
-    envdrift_config = _load_vault_config(config)
+    envdrift_config = _load_vault_config(options.config)
     vault_config = getattr(envdrift_config, "vault", None)
-    effective_provider = provider or getattr(vault_config, "provider", None)
+    effective_provider = options.provider or getattr(vault_config, "provider", None)
     if not effective_provider:
         print_error("Vault provider required. Use --provider or configure in envdrift.toml")
         raise typer.Exit(code=1)
 
     settings = VaultSettings(
         provider=effective_provider,
-        vault_url=_provider_vault_url(effective_provider, vault_url, vault_config),
-        region=region or getattr(vault_config, "aws_region", None),
-        project_id=project_id or getattr(vault_config, "gcp_project_id", None),
+        vault_url=_provider_vault_url(effective_provider, options.vault_url, vault_config),
+        region=options.region or getattr(vault_config, "aws_region", None),
+        project_id=options.project_id or getattr(vault_config, "gcp_project_id", None),
     )
     _validate_vault_settings(settings)
     return settings
@@ -156,15 +150,13 @@ def resolve_vault_settings(
 
 def _vault_client_kwargs(settings: VaultSettings) -> dict[str, str | None]:
     """Build provider-specific client keyword arguments."""
-    if settings.provider == "azure":
-        return {"vault_url": settings.vault_url}
-    if settings.provider == "aws":
-        return {"region": settings.region or "us-east-1"}
-    if settings.provider == "hashicorp":
-        return {"url": settings.vault_url}
-    if settings.provider == "gcp":
-        return {"project_id": settings.project_id}
-    return {}
+    kwargs_by_provider: dict[str, dict[str, str | None]] = {
+        "azure": {"vault_url": settings.vault_url},
+        "aws": {"region": settings.region or "us-east-1"},
+        "hashicorp": {"url": settings.vault_url},
+        "gcp": {"project_id": settings.project_id},
+    }
+    return kwargs_by_provider.get(settings.provider, {})
 
 
 def build_authenticated_client(settings: VaultSettings) -> VaultClient:
@@ -198,32 +190,37 @@ def execute_vault_push(request: VaultPushRequest) -> None:
     _push_single_secret(request)
 
 
-def _load_bulk_push_context(request: VaultPushRequest) -> _BulkPushContext:
-    """Load sync, vault, and encryption dependencies for bulk push."""
-    from envdrift.cli_commands.encryption_helpers import (
-        build_sops_encrypt_kwargs,
-        resolve_encryption_backend,
-    )
+def _load_bulk_vault(
+    options: VaultConnectionOptions,
+) -> tuple[SyncConfig, VaultClient, str]:
+    """Load bulk mappings and authenticate their vault client."""
     from envdrift.cli_commands.sync import load_sync_config_and_client
-    from envdrift.config import ConfigLoadError, ConfigNotFoundError
-    from envdrift.encryption import EncryptionProvider
     from envdrift.vault import VaultError
 
     sync_config, client, vault_provider, _, _, _ = load_sync_config_and_client(
-        config_file=request.config,
-        provider=request.provider,
-        vault_url=request.vault_url,
-        region=request.region,
-        project_id=request.project_id,
+        config_file=options.config,
+        provider=options.provider,
+        vault_url=options.vault_url,
+        region=options.region,
+        project_id=options.project_id,
     )
     try:
         client.authenticate()
     except VaultError as e:
         print_error(str(e))
         raise typer.Exit(code=1) from None
+    return sync_config, client, vault_provider
+
+
+def _load_encryption_backend(
+    config: Path | None,
+) -> tuple[EncryptionBackend, EncryptionProvider, Any]:
+    """Resolve an encryption backend with clean config-facing failures."""
+    from envdrift.cli_commands.encryption_helpers import resolve_encryption_backend
+    from envdrift.config import ConfigLoadError, ConfigNotFoundError
 
     try:
-        backend, backend_provider, encryption_config = resolve_encryption_backend(request.config)
+        return resolve_encryption_backend(config)
     except (ConfigNotFoundError, ConfigLoadError) as e:
         print_error(str(e))
         raise typer.Exit(code=1) from None
@@ -231,22 +228,42 @@ def _load_bulk_push_context(request: VaultPushRequest) -> _BulkPushContext:
         print_error(f"Unsupported encryption backend: {e}")
         raise typer.Exit(code=1) from None
 
+
+def _require_installed_backend(backend: EncryptionBackend) -> None:
+    """Fail with install guidance when an encryption backend is unavailable."""
     if not backend.is_installed():
         print_error(f"{backend.name} is not installed")
         console.print(backend.install_instructions())
         raise typer.Exit(code=1)
-    sops_kwargs = (
-        build_sops_encrypt_kwargs(encryption_config)
-        if backend_provider == EncryptionProvider.SOPS
-        else {}
+
+
+def _bulk_sops_kwargs(
+    provider: EncryptionProvider,
+    encryption_config: Any,
+) -> dict[str, Any]:
+    """Build SOPS-only encryption options for bulk push."""
+    from envdrift.cli_commands.encryption_helpers import build_sops_encrypt_kwargs
+    from envdrift.encryption import EncryptionProvider
+
+    if provider != EncryptionProvider.SOPS:
+        return {}
+    return build_sops_encrypt_kwargs(encryption_config)
+
+
+def _load_bulk_push_context(request: VaultPushRequest) -> _BulkPushContext:
+    """Load sync, vault, and encryption dependencies for bulk push."""
+    sync_config, client, vault_provider = _load_bulk_vault(request.connection)
+    backend, backend_provider, encryption_config = _load_encryption_backend(
+        request.connection.config
     )
+    _require_installed_backend(backend)
     return _BulkPushContext(
         sync_config=sync_config,
         client=client,
         vault_provider=vault_provider,
         backend=backend,
         backend_provider=backend_provider,
-        sops_kwargs=sops_kwargs,
+        sops_kwargs=_bulk_sops_kwargs(backend_provider, encryption_config),
         force=request.force,
         skip_encrypt=request.skip_encrypt,
     )
@@ -498,19 +515,39 @@ def _single_push_value(request: VaultPushRequest) -> tuple[str, str]:
 
 def _file_push_value(request: VaultPushRequest) -> tuple[str, str]:
     """Read one private key from a service's .env.keys file."""
+    folder, secret_name, environment = _require_file_push_inputs(request)
+    env_keys_path = folder / ".env.keys"
+    key_name = f"DOTENV_PRIVATE_KEY_{environment.upper()}"
+    key_value = _read_file_push_key(env_keys_path, key_name)
+    return secret_name, f"{key_name}={key_value}"
+
+
+def _missing_file_push_inputs() -> Never:
+    """Exit with the shared single-service usage error."""
+    print_error(
+        "Required: envdrift vault-push <folder> <secret-name> --env <environment> (or use --all)"
+    )
+    raise typer.Exit(code=1)
+
+
+def _require_file_push_inputs(request: VaultPushRequest) -> tuple[Path, str, str]:
+    """Narrow required single-service inputs without a compound conditional."""
+    if not request.folder:
+        _missing_file_push_inputs()
+    if not request.secret_name:
+        _missing_file_push_inputs()
+    if not request.environment:
+        _missing_file_push_inputs()
+    return request.folder, request.secret_name, request.environment
+
+
+def _read_file_push_key(env_keys_path: Path, key_name: str) -> str:
+    """Read one required key with clean filesystem and missing-key errors."""
     from envdrift.sync.operations import EnvKeysFile
 
-    if not request.folder or not request.secret_name or not request.environment:
-        print_error(
-            "Required: envdrift vault-push <folder> <secret-name> --env <environment> "
-            "(or use --all)"
-        )
-        raise typer.Exit(code=1)
-    env_keys_path = request.folder / ".env.keys"
     if not env_keys_path.exists():
         print_error(f"File not found: {env_keys_path}")
         raise typer.Exit(code=1)
-    key_name = f"DOTENV_PRIVATE_KEY_{request.environment.upper()}"
     try:
         key_value = EnvKeysFile(env_keys_path).read_key(key_name)
     except (OSError, ValueError) as e:
@@ -519,20 +556,14 @@ def _file_push_value(request: VaultPushRequest) -> tuple[str, str]:
     if not key_value:
         print_error(f"Key '{key_name}' not found in {env_keys_path}")
         raise typer.Exit(code=1)
-    return request.secret_name, f"{key_name}={key_value}"
+    return key_value
 
 
 def _push_single_secret(request: VaultPushRequest) -> None:
     """Push one direct value or one key read from a service folder."""
     from envdrift.vault import VaultError
 
-    settings = resolve_vault_settings(
-        request.config,
-        request.provider,
-        request.vault_url,
-        request.region,
-        request.project_id,
-    )
+    settings = resolve_vault_settings(request.connection)
     secret_name, value = _single_push_value(request)
     client = build_authenticated_client(settings)
     try:
@@ -634,28 +665,20 @@ def _resolve_pull_target(request: VaultPullRequest) -> Path:
         raise typer.Exit(code=1) from None
 
 
-def _resolve_pull_backend(config: Path | None) -> tuple[EncryptionBackend, EncryptionProvider]:
-    """Resolve and validate the encryption backend used after a key pull."""
-    from envdrift.cli_commands.encryption_helpers import resolve_encryption_backend
-    from envdrift.config import ConfigLoadError, ConfigNotFoundError
-
+def _warn_non_toml_encryption_config(config: Path | None) -> None:
+    """Explain why a non-TOML config cannot select the encryption backend."""
     if config is not None and config.suffix.lower() != ".toml":
         print_warning(
             f"--config {config} has no .toml suffix; it is used for vault settings "
             "but ignored when selecting the encryption backend (auto-detected instead)."
         )
-    try:
-        backend, provider, _ = resolve_encryption_backend(config)
-    except (ConfigNotFoundError, ConfigLoadError) as e:
-        print_error(str(e))
-        raise typer.Exit(code=1) from None
-    except ValueError as e:
-        print_error(f"Unsupported encryption backend: {e}")
-        raise typer.Exit(code=1) from None
-    if not backend.is_installed():
-        print_error(f"{backend.name} is not installed")
-        console.print(backend.install_instructions())
-        raise typer.Exit(code=1)
+
+
+def _resolve_pull_backend(config: Path | None) -> tuple[EncryptionBackend, EncryptionProvider]:
+    """Resolve and validate the encryption backend used after a key pull."""
+    _warn_non_toml_encryption_config(config)
+    backend, provider, _ = _load_encryption_backend(config)
+    _require_installed_backend(backend)
     return backend, provider
 
 
@@ -671,7 +694,7 @@ def _decrypt_pull_target(
         EncryptionProvider,
     )
 
-    backend, provider = _resolve_pull_backend(request.config)
+    backend, provider = _resolve_pull_backend(request.connection.config)
     if provider == EncryptionProvider.DOTENVX and request.env_file is not None:
         from envdrift.integrations.dotenvx import normalize_dotenvx_metadata
 
@@ -690,13 +713,7 @@ def _decrypt_pull_target(
 def execute_vault_pull(request: VaultPullRequest) -> None:
     """Fetch, install, and optionally use one vault-backed encryption key."""
     _validate_pull_folder(request.folder)
-    settings = resolve_vault_settings(
-        request.config,
-        request.provider,
-        request.vault_url,
-        request.region,
-        request.project_id,
-    )
+    settings = resolve_vault_settings(request.connection)
     client = build_authenticated_client(settings)
     secret = _fetch_pull_secret(request, settings, client)
     key_name, key_value = _extract_pull_key(request, secret)


### PR DESCRIPTION
## Summary

- keep the Typer-facing `vault-push` and `vault-pull` callbacks as CC 1 request adapters
- extract provider resolution, authentication, bulk mapping processing, key installation, and decryption into focused helpers
- preserve both commands' rendered `--help` output byte-for-byte and retain all existing failure boundaries

This is the vault half of #577. The issue stays open for the separate `sync.py` `lock`/`pull` refactor.

## Code health

- `vault_push`: 390 lines / CC 52 -> 31 lines / CC 1
- `vault_pull`: 246 lines / CC 24 -> 27 lines / CC 1
- largest extracted helper: 52 lines
- highest extracted helper complexity: CC 8

## Validation

- `uv run ruff check src tests`
- `uv run ruff format --check .`
- `uv run pyrefly check`
- `uv run bandit -r src -c pyproject.toml`
- `uv run pytest -m "not integration"` (3,359 passed, 6 skipped, 1 existing xpass)
- `uv run pytest -m integration` with pinned dotenvx 2.4.1 (505 passed, 37 conditional skips)
- focused vault suite (74 passed; helper module 94% coverage)
- byte-for-byte `vault-push --help` and `vault-pull --help` comparison against main

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jainal09/envdrift/pull/628?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added descriptive help text for the `vault-push` and `vault-pull` commands.
  * Improved vault push and pull workflows across supported providers.
  * Added provider-specific validation and clearer errors for missing configuration or secrets.
  * Enhanced bulk secret synchronization, encryption handling, and dotenvx key management.
  * Added optional decryption when pulling secrets, with support for custom environment files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR decomposes the vault CLI commands into smaller command helpers.

- Thin `vault-push` and `vault-pull` Typer adapters.
- Shared vault provider resolution and authenticated client setup.
- Extracted bulk push, single push, key install, and decrypt helpers.
- Explicit help text passed during command registration.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/envdrift/cli.py | Registers the vault commands with imported help constants. |
| src/envdrift/cli_commands/vault.py | Keeps the public vault command callbacks as request adapters. |
| src/envdrift/cli_commands/vault_helpers.py | Moves vault command execution into focused helper functions. |

<sub>Reviews (3): Last reviewed commit: ["refactor(cli): isolate vault push flag w..."](https://github.com/jainal09/envdrift/commit/46e7ee2643113e51b19d70ee40bec687c0eeb5d0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43551123)</sub>

<!-- /greptile_comment -->