### PR TITLE
refactor(cli): lower sync phase complexity

### DIFF
--- a/src/envdrift/cli_commands/sync_helpers.py
+++ b/src/envdrift/cli_commands/sync_helpers.py
@@ -187,29 +187,32 @@ def _print_pull_header(request: PullRequest, context: SyncCommandContext) -> Non
 
 
 def _ephemeral_keys_from_sync_result(sync_result: Any, mappings: list[ServiceMapping]):
-    from envdrift.sync.result import SyncAction
-
     mappings_by_folder: dict[Path, ServiceMapping] = {}
     for mapping in mappings:
         mappings_by_folder.setdefault(mapping.folder_path.resolve(), mapping)
 
     ephemeral_keys: dict[Path, tuple[str, str]] = {}
     for service_result in sync_result.services:
-        action = getattr(service_result, "action", None)
-        key_value = getattr(service_result, "vault_key_value", None)
-        if action != SyncAction.EPHEMERAL or not key_value:
-            continue
-        matched = mappings_by_folder.get(service_result.folder_path.resolve())
-        environment = (
-            matched.effective_environment
-            if matched is not None
-            else service_result.folder_path.name
-        )
-        ephemeral_keys[service_result.folder_path.resolve()] = (
-            f"DOTENV_PRIVATE_KEY_{environment.upper()}",
-            key_value,
-        )
+        ephemeral_key = _ephemeral_key_from_service_result(service_result, mappings_by_folder)
+        if ephemeral_key is not None:
+            folder, key = ephemeral_key
+            ephemeral_keys[folder] = key
     return ephemeral_keys
+
+
+def _ephemeral_key_from_service_result(
+    service_result: Any, mappings_by_folder: dict[Path, ServiceMapping]
+) -> tuple[Path, tuple[str, str]] | None:
+    from envdrift.sync.result import SyncAction
+
+    action = getattr(service_result, "action", None)
+    key_value = getattr(service_result, "vault_key_value", None)
+    if action != SyncAction.EPHEMERAL or not key_value:
+        return None
+    folder = service_result.folder_path.resolve()
+    matched = mappings_by_folder.get(folder)
+    environment = matched.effective_environment if matched else service_result.folder_path.name
+    return folder, (f"DOTENV_PRIVATE_KEY_{environment.upper()}", key_value)
 
 
 def _sync_pull_keys(
@@ -331,17 +334,9 @@ def _should_queue_decryption(
     context: _PullDecryptContext,
 ) -> bool:
     from envdrift.cli_commands import encryption_helpers
-    from envdrift.encryption import EncryptionProvider, detect_encryption_provider
 
-    keys_file = mapping.folder_path / (context.command.sync_config.env_keys_filename or ".env.keys")
-    try:
-        context.runtime.normalize_metadata(
-            env_file, keys_file, environment, context.encryption.provider
-        )
-        content = env_file.read_text(encoding="utf-8")
-    except (OSError, ValueError) as exc:
-        console.print(f"  [red]![/red] {env_file} [red]- error reading file: {exc}[/red]")
-        context.state.errors += 1
+    content = _read_pull_encrypted_file(mapping, env_file, environment, context)
+    if content is None:
         return False
 
     if encryption_helpers.should_attempt_decryption(
@@ -349,29 +344,55 @@ def _should_queue_decryption(
     ):
         return True
 
-    detected = detect_encryption_provider(env_file)
-    if detected and detected != context.encryption.provider:
-        if (
-            detected == EncryptionProvider.DOTENVX
-            and context.encryption.provider != EncryptionProvider.DOTENVX
-        ):
-            console.print(
-                f"  [red]![/red] {env_file} [red]- encrypted with dotenvx, but config uses "
-                f"{context.encryption.provider.value}[/red]"
-            )
-            context.state.errors += 1
-            return False
-        console.print(
-            f"  [dim]=[/dim] {env_file} [dim]- skipped (encrypted with {detected.value}, "
-            f"config uses {context.encryption.provider.value})[/dim]"
-        )
-        context.state.skipped += 1
+    if _record_pull_provider_mismatch(env_file, context):
         return False
 
     console.print(f"  [dim]=[/dim] {env_file} [dim]- skipped (not encrypted)[/dim]")
     context.state.skipped += 1
     _record_activation(mapping, env_file, context)
     return False
+
+
+def _read_pull_encrypted_file(
+    mapping: ServiceMapping,
+    env_file: Path,
+    environment: str,
+    context: _PullDecryptContext,
+) -> str | None:
+    keys_file = mapping.folder_path / (context.command.sync_config.env_keys_filename or ".env.keys")
+    try:
+        context.runtime.normalize_metadata(
+            env_file, keys_file, environment, context.encryption.provider
+        )
+        return env_file.read_text(encoding="utf-8")
+    except (OSError, ValueError) as exc:
+        console.print(f"  [red]![/red] {env_file} [red]- error reading file: {exc}[/red]")
+        context.state.errors += 1
+        return None
+
+
+def _record_pull_provider_mismatch(env_file: Path, context: _PullDecryptContext) -> bool:
+    from envdrift.encryption import EncryptionProvider, detect_encryption_provider
+
+    detected = detect_encryption_provider(env_file)
+    if not detected or detected == context.encryption.provider:
+        return False
+    if (
+        detected == EncryptionProvider.DOTENVX
+        and context.encryption.provider != EncryptionProvider.DOTENVX
+    ):
+        console.print(
+            f"  [red]![/red] {env_file} [red]- encrypted with dotenvx, but config uses "
+            f"{context.encryption.provider.value}[/red]"
+        )
+        context.state.errors += 1
+        return True
+    console.print(
+        f"  [dim]=[/dim] {env_file} [dim]- skipped (encrypted with {detected.value}, "
+        f"config uses {context.encryption.provider.value})[/dim]"
+    )
+    context.state.skipped += 1
+    return True
 
 
 def _queue_pull_mapping(mapping: ServiceMapping, context: _PullDecryptContext) -> None:
@@ -436,6 +457,13 @@ def _record_pull_decrypt_result(
 
 
 def _print_pull_decrypt_summary(state: _PullDecryptState) -> None:
+    lines = _pull_decrypt_summary_lines(state)
+    console.print()
+    console.print(Panel("\n".join(lines), title="Decrypt Summary", expand=False))
+    _raise_pull_decrypt_errors(state)
+
+
+def _pull_decrypt_summary_lines(state: _PullDecryptState) -> list[str]:
     lines = [
         f"Decrypted: {state.decrypted}",
         f"Skipped: {state.skipped}",
@@ -445,8 +473,10 @@ def _print_pull_decrypt_summary(state: _PullDecryptState) -> None:
         lines.append(f"Activated: {state.activated}")
     if state.activation_errors > 0:
         lines.append(f"Activation errors: {state.activation_errors}")
-    console.print()
-    console.print(Panel("\n".join(lines), title="Decrypt Summary", expand=False))
+    return lines
+
+
+def _raise_pull_decrypt_errors(state: _PullDecryptState) -> None:
     if state.errors > 0:
         print_warning("Some files could not be decrypted")
     if state.activation_errors > 0:
@@ -588,17 +618,28 @@ def _process_pull_partial_encryption(request: PullRequest, runtime: PullRuntime)
     console.print()
     console.print("[bold cyan]Step 3:[/bold cyan] Processing partial encryption files...")
     console.print()
-    if request.merge:
-        from envdrift.cli_commands.partial import _ensure_combined_gitignore
-
-        _ensure_combined_gitignore(partial_config.partial_encryption.environments)
+    _prepare_pull_partial_merge(partial_config, request.merge)
     state = _PullPartialState()
     for env_config in partial_config.partial_encryption.environments:
-        if env_config.secrets_only:
-            _pull_secrets_only_environment(env_config, state)
-        else:
-            _pull_combined_environment(env_config, request.merge, state, runtime)
+        _pull_partial_environment(env_config, request.merge, state, runtime)
     _print_partial_pull_summary(state, request.merge)
+
+
+def _prepare_pull_partial_merge(partial_config: Any, merge: bool) -> None:
+    if not merge:
+        return
+    from envdrift.cli_commands.partial import _ensure_combined_gitignore
+
+    _ensure_combined_gitignore(partial_config.partial_encryption.environments)
+
+
+def _pull_partial_environment(
+    env_config: Any, merge: bool, state: _PullPartialState, runtime: PullRuntime
+) -> None:
+    if env_config.secrets_only:
+        _pull_secrets_only_environment(env_config, state)
+        return
+    _pull_combined_environment(env_config, merge, state, runtime)
 
 
 def execute_pull(request: PullRequest, runtime: PullRuntime) -> None:

--- a/src/envdrift/cli_commands/sync_lock_keys.py
+++ b/src/envdrift/cli_commands/sync_lock_keys.py
@@ -92,17 +92,7 @@ def _compare_lock_vault_key(
         context.vault_client.ensure_authenticated()
         secret = context.vault_client.get_secret(local.mapping.secret_name)
         if not _vault_secret_has_value(secret):
-            console.print(
-                f"  [red]✗[/red] {local.mapping.folder_path} "
-                f"[red]- cannot verify: vault secret "
-                f"'{local.mapping.secret_name}' is empty[/red]"
-            )
-            state.errors.append(
-                f"{local.mapping.folder_path}: cannot verify - vault secret "
-                f"'{local.mapping.secret_name}' is empty "
-                f"(push the key with 'envdrift vault-push')"
-            )
-            state.verification_issues += 1
+            _record_unavailable_vault_secret(local, "is empty", state)
             return
         vault_key, vault_suffix = extract_key_material(secret, local.environment)
         if _vault_key_matches(local.value, vault_key, vault_suffix, local.environment):
@@ -110,41 +100,53 @@ def _compare_lock_vault_key(
                 f"  [green]✓[/green] {local.mapping.folder_path} [dim]- keys match vault[/dim]"
             )
             return
-        console.print(
-            f"  [red]✗[/red] {local.mapping.folder_path} "
-            f"[red]- KEY MISMATCH: local key differs from vault![/red]"
-        )
-        state.errors.append(
-            f"{local.mapping.folder_path}: local key does not match vault "
-            f"(run 'envdrift lock --sync-keys' to fix)"
-        )
-        state.verification_issues += 1
+        _record_lock_key_mismatch(local, state)
     except SecretNotFoundError:
-        console.print(
-            f"  [red]✗[/red] {local.mapping.folder_path} "
-            f"[red]- cannot verify: vault secret "
-            f"'{local.mapping.secret_name}' not found[/red]"
-        )
-        state.errors.append(
-            f"{local.mapping.folder_path}: cannot verify - vault secret "
-            f"'{local.mapping.secret_name}' "
-            f"not found (push the key with 'envdrift vault-push')"
-        )
-        state.verification_issues += 1
+        _record_unavailable_vault_secret(local, "not found", state)
     except KeyMaterialError as exc:
-        console.print(
-            f"  [red]✗[/red] {local.mapping.folder_path} [red]- KEY UNUSABLE: {exc}[/red]"
-        )
-        state.errors.append(f"{local.mapping.folder_path}: vault key material unusable - {exc}")
-        state.verification_issues += 1
-        state.unusable_keys += 1
+        _record_unusable_vault_key(local, exc, state)
     except VaultError as exc:
-        console.print(
-            f"  [red]![/red] {local.mapping.folder_path} "
-            f"[red]- error: vault access failed: {exc}[/red]"
-        )
-        state.errors.append(f"{local.mapping.folder_path}: vault error - {exc}")
-        state.verification_issues += 1
+        _record_vault_access_error(local, exc, state)
+
+
+def _record_unavailable_vault_secret(local: _LocalLockKey, reason: str, state: _LockState) -> None:
+    console.print(
+        f"  [red]✗[/red] {local.mapping.folder_path} "
+        f"[red]- cannot verify: vault secret '{local.mapping.secret_name}' {reason}[/red]"
+    )
+    state.errors.append(
+        f"{local.mapping.folder_path}: cannot verify - vault secret "
+        f"'{local.mapping.secret_name}' {reason} (push the key with 'envdrift vault-push')"
+    )
+    state.verification_issues += 1
+
+
+def _record_lock_key_mismatch(local: _LocalLockKey, state: _LockState) -> None:
+    console.print(
+        f"  [red]✗[/red] {local.mapping.folder_path} "
+        f"[red]- KEY MISMATCH: local key differs from vault![/red]"
+    )
+    state.errors.append(
+        f"{local.mapping.folder_path}: local key does not match vault "
+        f"(run 'envdrift lock --sync-keys' to fix)"
+    )
+    state.verification_issues += 1
+
+
+def _record_unusable_vault_key(local: _LocalLockKey, error: Exception, state: _LockState) -> None:
+    console.print(f"  [red]✗[/red] {local.mapping.folder_path} [red]- KEY UNUSABLE: {error}[/red]")
+    state.errors.append(f"{local.mapping.folder_path}: vault key material unusable - {error}")
+    state.verification_issues += 1
+    state.unusable_keys += 1
+
+
+def _record_vault_access_error(local: _LocalLockKey, error: Exception, state: _LockState) -> None:
+    console.print(
+        f"  [red]![/red] {local.mapping.folder_path} "
+        f"[red]- error: vault access failed: {error}[/red]"
+    )
+    state.errors.append(f"{local.mapping.folder_path}: vault error - {error}")
+    state.verification_issues += 1
 
 
 def _vault_secret_has_value(secret: Any) -> bool:


### PR DESCRIPTION
## Summary

- extract pull decision and reporting blocks into named phase helpers
- isolate vault-key verification failure reporting
- clear the two mean-complexity findings that remained when #630 was merged

## Context

This is the review-fix commit that raced the merge of #630. The merged PR ended at 1e6507d; this follow-up carries only the already-validated complexity cleanup on top of the resulting main commit.

No command behavior or output changes.

## Validation

- Ruff check and format check
- Pyrefly: 0 errors
- Bandit: 0 issues
- focused sync suite: 249 passed, 5 skipped
- non-integration suite: 3,359 passed, 6 skipped, 1 existing xpass
- pull and lock help hashes remain byte-identical to #630/main
- local function-complexity means: sync_helpers 3.30; sync_lock_keys 2.58
- no function has more than four arguments

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jainal09/envdrift/pull/634?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR lowers sync command complexity by moving repeated logic into focused helpers. The main changes are:

- Extracted ephemeral key derivation into a service-result helper.
- Split pull decryption file reading and provider-mismatch reporting.
- Moved pull decrypt summary construction and error raising into helpers.
- Extracted partial-encryption pull preparation and environment dispatch.
- Moved lock-key verification reporting into dedicated helper functions.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- The decryption read path still treats empty file content as a successful read.
- The extracted reporting helpers keep the same state updates and control flow.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/envdrift/cli_commands/sync_helpers.py | Refactors pull sync helpers while preserving the existing decryption, activation, partial-encryption, and ephemeral-key flows. |
| src/envdrift/cli_commands/sync_lock_keys.py | Refactors lock-key verification reporting while preserving the existing counters and error messages. |

<sub>Reviews (4): Last reviewed commit: ["Merge branch &#39;main&#39; into refactor/sync-c..."](https://github.com/jainal09/envdrift/commit/5b54cddaed6129649dcb4d682d9f6825c046b67e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43579542)</sub>

<!-- /greptile_comment -->