### PR TITLE
refactor(cli): decompose sync loader and command

### DIFF
--- a/src/envdrift/cli_commands/sync.py
+++ b/src/envdrift/cli_commands/sync.py
@@ -10,10 +10,9 @@ from typing import TYPE_CHECKING, Annotated, Any
 
 import typer
 
-from envdrift.output.rich import console, print_error, print_warning
+from envdrift.output.rich import console, print_warning
 from envdrift.sync.operations import atomic_write
 from envdrift.utils import normalize_max_workers
-from envdrift.vault.base import SecretNotFoundError, VaultError
 
 if TYPE_CHECKING:
     from envdrift.encryption import EncryptionProvider
@@ -61,206 +60,21 @@ def load_sync_config_and_client(
     region: str | None,
     project_id: str | None,
 ) -> tuple[SyncConfig, Any, str, str | None, str | None, str | None]:
-    """
-    Load sync configuration and instantiate a vault client using CLI arguments, discovered project config, or an explicit config file.
+    """Load sync mappings and construct their provider-specific vault client."""
 
-    This resolves effective provider, vault URL, and region by preferring CLI arguments over project defaults (from a provided TOML file, discovered envdrift.toml/pyproject.toml, or an explicit legacy config), constructs a SyncConfig (from a TOML, legacy pair file, or project sync mappings), validates required provider-specific options, and returns the SyncConfig along with a ready-to-use vault client and the resolved provider/URL/region.
+    from envdrift.cli_commands.sync_config_helpers import (
+        SyncLoadRequest,
+        load_sync_connection,
+    )
 
-    Parameters:
-        config_file (Path | None): Path provided via --config. If a TOML file is given, it is used for defaults and/or as the sync config source; other extensions may be treated as legacy pair files.
-        provider (str | None): CLI provider override (e.g., "azure", "aws", "hashicorp", "gcp"). If omitted, the provider from project config is used when available.
-        vault_url (str | None): CLI vault URL override for providers that require it (Azure, HashiCorp). If omitted, the value from project config is used when present.
-        region (str | None): CLI region override for AWS. If omitted, the value from project config is used when present.
-        project_id (str | None): CLI project ID override for GCP Secret Manager. If omitted, the value from project config is used when present.
-
-    Returns:
-        tuple[SyncConfig, Any, str, str | None, str | None]: A tuple containing:
-            - SyncConfig: the resolved synchronization configuration with mappings.
-            - vault_client: an instantiated vault client for the resolved provider.
-            - effective_provider: the resolved provider string.
-            - effective_vault_url: the resolved vault URL when applicable, otherwise None.
-            - effective_region: the resolved region when applicable, otherwise None.
-            - effective_project_id: the resolved GCP project ID when applicable, otherwise None.
-
-    Raises:
-        typer.Exit: Exits with a non-zero code if no valid sync configuration can be found, required provider options are missing, the config file is invalid or unreadable, or the vault client cannot be created.
-    """
-    from envdrift.config import ConfigLoadError, ConfigNotFoundError, find_config, load_config
-    from envdrift.sync.config import ServiceMapping, SyncConfig, SyncConfigError
-    from envdrift.vault import get_vault_client
-
-    # Determine config source for defaults:
-    # 1. If --config points to a TOML file, use it for defaults
-    # 2. Otherwise, use auto-discovery (find_config)
-    # Note: discovery only runs when --config is not provided. If --config points
-    # to a non-TOML file (e.g., pair.txt), we skip discovery to avoid pulling
-    # defaults from unrelated projects.
-    envdrift_config = None
-    config_path = None
-
-    if config_file is not None and config_file.suffix.lower() == ".toml":
-        # Use the explicitly provided TOML file for defaults
-        config_path = config_file
-        try:
-            envdrift_config = load_config(config_path)
-        except ConfigLoadError as e:
-            # The loader's message is already the clean one-liner (TOML syntax
-            # error / unreadable file / invalid section) (#443 #32, #491).
-            print_error(str(e))
-            raise typer.Exit(code=1) from None
-        except ConfigNotFoundError:
-            pass
-    elif config_file is None:
-        # Auto-discover config from envdrift.toml or pyproject.toml
-        config_path = find_config()
-        if config_path:
-            try:
-                envdrift_config = load_config(config_path)
-            except ConfigNotFoundError:
-                pass
-            except ConfigLoadError as e:
-                # A discovered-but-broken config used to be a mere warning and
-                # the command continued with defaults, silently changing
-                # behavior; fail loudly instead (#491). The config WAS found,
-                # so falling through to "No sync configuration found" would
-                # hide the real problem (#488). load_config already folds TOML
-                # syntax errors, unreadable files, and malformed sections into
-                # one clean ConfigLoadError message.
-                print_error(str(e))
-                raise typer.Exit(code=1) from None
-
-    vault_config = getattr(envdrift_config, "vault", None)
-
-    # Determine effective provider (CLI overrides config)
-    effective_provider = provider or getattr(vault_config, "provider", None)
-
-    # Determine effective vault URL (CLI overrides config)
-    effective_vault_url = vault_url
-    if effective_vault_url is None and vault_config:
-        if effective_provider == "azure":
-            effective_vault_url = getattr(vault_config, "azure_vault_url", None)
-        elif effective_provider == "hashicorp":
-            effective_vault_url = getattr(vault_config, "hashicorp_url", None)
-
-    # Determine effective region (CLI overrides config)
-    effective_region = region
-    if effective_region is None and vault_config:
-        effective_region = getattr(vault_config, "aws_region", None)
-
-    effective_project_id = project_id
-    if effective_project_id is None and vault_config:
-        effective_project_id = getattr(vault_config, "gcp_project_id", None)
-
-    vault_sync = getattr(vault_config, "sync", None)
-
-    # Load sync config from file or project config
-    sync_config: SyncConfig | None = None
-
-    if config_file is not None:
-        # Explicit config file provided
-        if not config_file.exists():
-            print_error(f"Config file not found: {config_file}")
-            raise typer.Exit(code=1)
-
-        try:
-            # Detect format by extension
-            if config_file.suffix.lower() == ".toml":
-                sync_config = SyncConfig.from_toml_file(config_file)
-            else:
-                # Legacy pair.txt format
-                sync_config = SyncConfig.from_file(config_file)
-        except SyncConfigError as e:
-            print_error(f"Invalid config file: {e}")
-            raise typer.Exit(code=1) from None
-    elif vault_sync and vault_sync.mappings:
-        # Use mappings from project config
-        sync_config = SyncConfig(
-            mappings=[
-                ServiceMapping(
-                    secret_name=m.secret_name,
-                    folder_path=Path(m.folder_path),
-                    vault_name=m.vault_name,
-                    environment=m.environment,
-                    env_file=Path(m.env_file) if m.env_file else None,
-                    profile=m.profile,
-                    activate_to=Path(m.activate_to) if m.activate_to else None,
-                    ephemeral_keys=m.ephemeral_keys,
-                )
-                for m in vault_sync.mappings
-            ],
-            default_vault_name=vault_sync.default_vault_name,
-            env_keys_filename=vault_sync.env_keys_filename,
-            max_workers=vault_sync.max_workers,
-            ephemeral_keys=vault_sync.ephemeral_keys,
+    return load_sync_connection(
+        SyncLoadRequest(
+            config_file=config_file,
+            provider=provider,
+            vault_url=vault_url,
+            region=region,
+            project_id=project_id,
         )
-    elif config_path and config_path.suffix.lower() == ".toml":
-        # Try to load sync config from discovered TOML
-        try:
-            sync_config = SyncConfig.from_toml_file(config_path)
-        except SyncConfigError as e:
-            print_warning(f"Could not load sync config from {config_path}: {e}")
-
-    if sync_config is None or not sync_config.mappings:
-        # envdrift.toml is the PRIMARY documented config mechanism (README /
-        # quickstart lead with it) — omitting it here steered users debugging a
-        # missing config away from the recommended setup (#488).
-        print_error(
-            "No sync configuration found. Provide one of:\n"
-            "  [vault.sync] section in envdrift.toml (auto-discovered)\n"
-            "  [tool.envdrift.vault.sync] section in pyproject.toml\n"
-            "  --config <file.toml>  TOML config with [vault.sync] section\n"
-            "  --config <pair.txt>   Legacy format: secret=folder"
-        )
-        raise typer.Exit(code=1)
-
-    # Validate provider is set
-    if effective_provider is None:
-        print_error(
-            "--provider is required (or set [vault] provider in config). "
-            "Options: azure, aws, hashicorp, gcp"
-        )
-        raise typer.Exit(code=1)
-
-    # Validate provider-specific options
-    if effective_provider == "azure" and not effective_vault_url:
-        print_error("Azure provider requires --vault-url (or [vault.azure] vault_url in config)")
-        raise typer.Exit(code=1)
-
-    if effective_provider == "hashicorp" and not effective_vault_url:
-        print_error("HashiCorp provider requires --vault-url (or [vault.hashicorp] url in config)")
-        raise typer.Exit(code=1)
-
-    if effective_provider == "gcp" and not effective_project_id:
-        print_error("GCP provider requires --project-id (or [vault.gcp] project_id in config)")
-        raise typer.Exit(code=1)
-
-    # Create vault client
-    try:
-        vault_kwargs: dict = {}
-        if effective_provider == "azure":
-            vault_kwargs["vault_url"] = effective_vault_url
-        elif effective_provider == "aws":
-            vault_kwargs["region"] = effective_region or "us-east-1"
-        elif effective_provider == "hashicorp":
-            vault_kwargs["url"] = effective_vault_url
-        elif effective_provider == "gcp":
-            vault_kwargs["project_id"] = effective_project_id
-
-        vault_client = get_vault_client(effective_provider, **vault_kwargs)
-    except ImportError as e:
-        print_error(str(e))
-        raise typer.Exit(code=1) from None
-    except ValueError as e:
-        print_error(str(e))
-        raise typer.Exit(code=1) from None
-
-    return (
-        sync_config,
-        vault_client,
-        effective_provider,
-        effective_vault_url,
-        effective_region,
-        effective_project_id,
     )
 
 
@@ -459,95 +273,29 @@ def sync(
     errors occurred, whenever a --check-decryption test fails (even without --ci), and when
     --check-decryption is requested but dotenvx is not installed (nothing can be verified).
     """
-    from envdrift.output.rich import print_service_sync_status, print_sync_result
-    from envdrift.sync.config import SyncConfigError
 
-    # An explicitly requested decryption check must be able to actually run.
-    # Without dotenvx the engine degrades every per-service test to SKIPPED,
-    # so the run would exit 0 having verified nothing — the same
-    # cannot-verify-downgraded-to-success class as #473. Mirror
-    # `decrypt --verify-vault`, which fails loudly for the identical state.
-    if check_decryption and shutil.which("dotenvx") is None:
-        print_error("dotenvx is not installed - cannot verify decryption")
-        raise typer.Exit(code=1)
+    from envdrift.cli_commands.sync_run_helpers import SyncRequest, SyncRuntime, execute_sync
 
-    sync_config, vault_client, effective_provider, _, _, _ = load_sync_config_and_client(
-        config_file=config_file,
-        provider=provider,
-        vault_url=vault_url,
-        region=region,
-        project_id=project_id,
+    execute_sync(
+        SyncRequest(
+            config_file=config_file,
+            provider=provider,
+            vault_url=vault_url,
+            region=region,
+            project_id=project_id,
+            verify=verify,
+            force=force,
+            check_decryption=check_decryption,
+            validate_schema=validate_schema,
+            schema=schema,
+            service_dir=service_dir,
+            ci=ci,
+        ),
+        SyncRuntime(
+            load_sync=load_sync_config_and_client,
+            find_binary=shutil.which,
+        ),
     )
-    from envdrift.integrations.hook_check import ensure_git_hook_setup
-
-    hook_errors = ensure_git_hook_setup(config_file=config_file)
-    if hook_errors:
-        for error in hook_errors:
-            print_error(error)
-        raise typer.Exit(code=1)
-
-    # Create sync engine
-    from envdrift.sync.engine import SyncEngine, SyncMode
-
-    mode = SyncMode(
-        verify_only=verify,
-        force_update=force,
-        check_decryption=check_decryption,
-        validate_schema=validate_schema,
-        schema_path=schema,
-        service_dir=service_dir,
-    )
-
-    # Progress callback for non-CI mode
-    def progress_callback(msg: str) -> None:
-        if not ci:
-            console.print(f"[dim]{msg}[/dim]")
-
-    # Prompt callback (disabled in force/verify/ci modes)
-    def prompt_callback(msg: str) -> bool:
-        if force or verify or ci:
-            return force
-        response = console.input(f"{msg} (y/N): ").strip().lower()
-        return response in ("y", "yes")
-
-    engine = SyncEngine(
-        config=sync_config,
-        vault_client=vault_client,
-        mode=mode,
-        prompt_callback=prompt_callback,
-        progress_callback=progress_callback,
-    )
-
-    # Print header
-    console.print()
-    mode_str = "VERIFY" if verify else ("FORCE" if force else "Interactive")
-    console.print(f"[bold]Vault Sync[/bold] - Mode: {mode_str}")
-    console.print(
-        f"[dim]Provider: {effective_provider} | Services: {len(sync_config.mappings)}[/dim]"
-    )
-    console.print()
-
-    # Run sync
-    try:
-        result = engine.sync_all()
-    except (VaultError, SyncConfigError, SecretNotFoundError, OSError, UnicodeDecodeError) as e:
-        print_error(f"Sync failed: {e}")
-        raise typer.Exit(code=1) from None
-
-    # Print results
-    for service_result in result.services:
-        print_service_sync_status(service_result)
-
-    print_sync_result(result)
-
-    # Exit with appropriate code
-    if ci and result.has_errors:
-        raise typer.Exit(code=1)
-    # An explicitly requested decryption check that failed must fail the run
-    # even without --ci: printing "Decryption: FAILED" and exiting 0 is an
-    # untruthful verdict that scripts and pre-commit hooks silently miss (#473).
-    if check_decryption and result.decryption_failed > 0:
-        raise typer.Exit(code=1)
 
 
 PULL_HELP = """Pull keys from vault and decrypt all env files (one-command developer setup).

--- a/src/envdrift/cli_commands/sync.py
+++ b/src/envdrift/cli_commands/sync.py
@@ -210,59 +210,118 @@ def _write_merged_combined_file(clear_file: Path, secret_file: Path, combined_fi
     atomic_write(combined_file, "\n".join(combined_lines) + "\n", max_permissions=0o600)
 
 
+_SyncConfigOption = Annotated[
+    Path | None,
+    typer.Option(
+        "--config",
+        "-c",
+        help="Path to sync config file (TOML or legacy pair.txt format)",
+    ),
+]
+_ProviderOption = Annotated[
+    str | None,
+    typer.Option("--provider", "-p", help="Vault provider: azure, aws, hashicorp, gcp"),
+]
+_VaultUrlOption = Annotated[
+    str | None,
+    typer.Option("--vault-url", help="Vault URL (Azure Key Vault or HashiCorp Vault)"),
+]
+_RegionOption = Annotated[
+    str | None,
+    typer.Option("--region", help="AWS region (default: us-east-1)"),
+]
+_ProjectIdOption = Annotated[
+    str | None,
+    typer.Option("--project-id", help="GCP project ID (Secret Manager)"),
+]
+_PullForceOption = Annotated[
+    bool,
+    typer.Option("--force", "-f", help="Update all mismatches without prompting"),
+]
+_ProfileOption = Annotated[
+    str | None,
+    typer.Option("--profile", help="Only process mappings for this profile"),
+]
+_SkipSyncOption = Annotated[
+    bool,
+    typer.Option("--skip-sync", help="Skip syncing keys from vault, only decrypt files"),
+]
+_MergeOption = Annotated[
+    bool,
+    typer.Option(
+        "--merge",
+        "-m",
+        help="For partial encryption: create combined decrypted .env file from .clear + .secret",
+    ),
+]
+_LockForceOption = Annotated[
+    bool,
+    typer.Option("--force", "-f", help="Force encryption without prompting"),
+]
+_VerifyVaultOption = Annotated[
+    bool,
+    typer.Option("--verify-vault", help="Verify local keys match vault before encrypting"),
+]
+_SyncKeysOption = Annotated[
+    bool,
+    typer.Option(
+        "--sync-keys", help="Sync keys from vault before encrypting (implies --verify-vault)"
+    ),
+]
+_CheckOnlyOption = Annotated[
+    bool,
+    typer.Option("--check", help="Only check encryption status, don't encrypt"),
+]
+_AllFilesOption = Annotated[
+    bool,
+    typer.Option(
+        "--all",
+        help="Include partial encryption files: encrypt .secret files and delete combined files",
+    ),
+]
+_SyncVerifyOption = Annotated[
+    bool,
+    typer.Option("--verify", help="Check only, don't modify files"),
+]
+_SyncForceOption = Annotated[
+    bool,
+    typer.Option("--force", "-f", help="Update all mismatches without prompting"),
+]
+_CheckDecryptionOption = Annotated[
+    bool,
+    typer.Option("--check-decryption", help="Verify keys can decrypt .env files"),
+]
+_ValidateSchemaOption = Annotated[
+    bool,
+    typer.Option("--validate-schema", help="Run schema validation after sync"),
+]
+_SchemaOption = Annotated[
+    str | None,
+    typer.Option("--schema", "-s", help="Schema path for validation"),
+]
+_ServiceDirOption = Annotated[
+    Path | None,
+    typer.Option("--service-dir", "-d", help="Service directory for schema imports"),
+]
+_CiOption = Annotated[
+    bool,
+    typer.Option("--ci", help="CI mode: exit with code 1 on errors"),
+]
+
+
 def sync(
-    config_file: Annotated[
-        Path | None,
-        typer.Option(
-            "--config",
-            "-c",
-            help="Path to sync config file (TOML or legacy pair.txt format)",
-        ),
-    ] = None,
-    provider: Annotated[
-        str | None,
-        typer.Option("--provider", "-p", help="Vault provider: azure, aws, hashicorp, gcp"),
-    ] = None,
-    vault_url: Annotated[
-        str | None,
-        typer.Option("--vault-url", help="Vault URL (Azure Key Vault or HashiCorp Vault)"),
-    ] = None,
-    region: Annotated[
-        str | None,
-        typer.Option("--region", help="AWS region (default: us-east-1)"),
-    ] = None,
-    project_id: Annotated[
-        str | None,
-        typer.Option("--project-id", help="GCP project ID (Secret Manager)"),
-    ] = None,
-    verify: Annotated[
-        bool,
-        typer.Option("--verify", help="Check only, don't modify files"),
-    ] = False,
-    force: Annotated[
-        bool,
-        typer.Option("--force", "-f", help="Update all mismatches without prompting"),
-    ] = False,
-    check_decryption: Annotated[
-        bool,
-        typer.Option("--check-decryption", help="Verify keys can decrypt .env files"),
-    ] = False,
-    validate_schema: Annotated[
-        bool,
-        typer.Option("--validate-schema", help="Run schema validation after sync"),
-    ] = False,
-    schema: Annotated[
-        str | None,
-        typer.Option("--schema", "-s", help="Schema path for validation"),
-    ] = None,
-    service_dir: Annotated[
-        Path | None,
-        typer.Option("--service-dir", "-d", help="Service directory for schema imports"),
-    ] = None,
-    ci: Annotated[
-        bool,
-        typer.Option("--ci", help="CI mode: exit with code 1 on errors"),
-    ] = False,
+    config_file: _SyncConfigOption = None,
+    provider: _ProviderOption = None,
+    vault_url: _VaultUrlOption = None,
+    region: _RegionOption = None,
+    project_id: _ProjectIdOption = None,
+    verify: _SyncVerifyOption = False,
+    force: _SyncForceOption = False,
+    check_decryption: _CheckDecryptionOption = False,
+    validate_schema: _ValidateSchemaOption = False,
+    schema: _SchemaOption = None,
+    service_dir: _ServiceDirOption = None,
+    ci: _CiOption = False,
 ) -> None:
     """
     Sync encryption keys from a configured vault to local .env.keys files for each service.
@@ -389,76 +448,6 @@ Examples:
     # Include partial encryption files (encrypt .secret, delete combined)
     envdrift lock --all
 """
-
-_SyncConfigOption = Annotated[
-    Path | None,
-    typer.Option(
-        "--config",
-        "-c",
-        help="Path to sync config file (TOML or legacy pair.txt format)",
-    ),
-]
-_ProviderOption = Annotated[
-    str | None,
-    typer.Option("--provider", "-p", help="Vault provider: azure, aws, hashicorp, gcp"),
-]
-_VaultUrlOption = Annotated[
-    str | None,
-    typer.Option("--vault-url", help="Vault URL (Azure Key Vault or HashiCorp Vault)"),
-]
-_RegionOption = Annotated[
-    str | None,
-    typer.Option("--region", help="AWS region (default: us-east-1)"),
-]
-_ProjectIdOption = Annotated[
-    str | None,
-    typer.Option("--project-id", help="GCP project ID (Secret Manager)"),
-]
-_PullForceOption = Annotated[
-    bool,
-    typer.Option("--force", "-f", help="Update all mismatches without prompting"),
-]
-_ProfileOption = Annotated[
-    str | None,
-    typer.Option("--profile", help="Only process mappings for this profile"),
-]
-_SkipSyncOption = Annotated[
-    bool,
-    typer.Option("--skip-sync", help="Skip syncing keys from vault, only decrypt files"),
-]
-_MergeOption = Annotated[
-    bool,
-    typer.Option(
-        "--merge",
-        "-m",
-        help="For partial encryption: create combined decrypted .env file from .clear + .secret",
-    ),
-]
-_LockForceOption = Annotated[
-    bool,
-    typer.Option("--force", "-f", help="Force encryption without prompting"),
-]
-_VerifyVaultOption = Annotated[
-    bool,
-    typer.Option("--verify-vault", help="Verify local keys match vault before encrypting"),
-]
-_SyncKeysOption = Annotated[
-    bool,
-    typer.Option(
-        "--sync-keys", help="Sync keys from vault before encrypting (implies --verify-vault)"
-    ),
-]
-_CheckOnlyOption = Annotated[
-    bool,
-    typer.Option("--check", help="Only check encryption status, don't encrypt"),
-]
-_AllFilesOption = Annotated[
-    bool,
-    typer.Option(
-        "--all",
-        help="Include partial encryption files: encrypt .secret files and delete combined files",
-    ),
-]
 
 
 def pull(

--- a/src/envdrift/cli_commands/sync_config_helpers.py
+++ b/src/envdrift/cli_commands/sync_config_helpers.py
@@ -170,23 +170,42 @@ def _require_sync_config(sync_config: SyncConfig | None) -> SyncConfig:
     raise typer.Exit(code=1)
 
 
-def _validate_vault_settings(settings: _VaultSettings) -> str:
+def _require_provider(settings: _VaultSettings) -> str:
     if settings.provider is None:
         print_error(
             "--provider is required (or set [vault] provider in config). "
             "Options: azure, aws, hashicorp, gcp"
         )
         raise typer.Exit(code=1)
-    if settings.provider == "azure" and not settings.vault_url:
-        print_error("Azure provider requires --vault-url (or [vault.azure] vault_url in config)")
-        raise typer.Exit(code=1)
-    if settings.provider == "hashicorp" and not settings.vault_url:
-        print_error("HashiCorp provider requires --vault-url (or [vault.hashicorp] url in config)")
-        raise typer.Exit(code=1)
-    if settings.provider == "gcp" and not settings.project_id:
-        print_error("GCP provider requires --project-id (or [vault.gcp] project_id in config)")
-        raise typer.Exit(code=1)
     return settings.provider
+
+
+def _validate_provider_options(provider: str, settings: _VaultSettings) -> None:
+    requirements = {
+        "azure": (
+            settings.vault_url,
+            "Azure provider requires --vault-url (or [vault.azure] vault_url in config)",
+        ),
+        "hashicorp": (
+            settings.vault_url,
+            "HashiCorp provider requires --vault-url (or [vault.hashicorp] url in config)",
+        ),
+        "gcp": (
+            settings.project_id,
+            "GCP provider requires --project-id (or [vault.gcp] project_id in config)",
+        ),
+    }
+    requirement = requirements.get(provider)
+    if requirement is None or requirement[0]:
+        return
+    print_error(requirement[1])
+    raise typer.Exit(code=1)
+
+
+def _validate_vault_settings(settings: _VaultSettings) -> str:
+    provider = _require_provider(settings)
+    _validate_provider_options(provider, settings)
+    return provider
 
 
 def _vault_client_kwargs(settings: _VaultSettings) -> dict[str, str | None]:

--- a/src/envdrift/cli_commands/sync_config_helpers.py
+++ b/src/envdrift/cli_commands/sync_config_helpers.py
@@ -1,0 +1,229 @@
+"""Configuration and vault-client loading for sync-family commands."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import typer
+
+from envdrift.output.rich import print_error, print_warning
+
+if TYPE_CHECKING:
+    from envdrift.sync.config import SyncConfig
+
+
+@dataclass(frozen=True)
+class SyncLoadRequest:
+    """CLI inputs used to load sync mappings and their vault client."""
+
+    config_file: Path | None
+    provider: str | None
+    vault_url: str | None
+    region: str | None
+    project_id: str | None
+
+
+@dataclass(frozen=True)
+class _ConfigDefaults:
+    path: Path | None
+    config: Any | None
+
+
+@dataclass(frozen=True)
+class _VaultSettings:
+    provider: str | None
+    vault_url: str | None
+    region: str | None
+    project_id: str | None
+
+
+def _defaults_path(request: SyncLoadRequest) -> Path | None:
+    from envdrift.config import find_config
+
+    if request.config_file is not None and request.config_file.suffix.lower() == ".toml":
+        return request.config_file
+    if request.config_file is None:
+        return find_config()
+    return None
+
+
+def _load_envdrift_config(path: Path | None) -> Any | None:
+    from envdrift.config import ConfigLoadError, ConfigNotFoundError, load_config
+
+    if path is None:
+        return None
+    try:
+        return load_config(path)
+    except ConfigNotFoundError:
+        return None
+    except ConfigLoadError as exc:
+        print_error(str(exc))
+        raise typer.Exit(code=1) from None
+
+
+def _load_defaults(request: SyncLoadRequest) -> _ConfigDefaults:
+    path = _defaults_path(request)
+    return _ConfigDefaults(path=path, config=_load_envdrift_config(path))
+
+
+def _provider_vault_url(
+    provider: str | None, explicit_url: str | None, vault_config: Any | None
+) -> str | None:
+    if explicit_url is not None or vault_config is None:
+        return explicit_url
+    attribute = {"azure": "azure_vault_url", "hashicorp": "hashicorp_url"}.get(provider or "")
+    return getattr(vault_config, attribute, None) if attribute else None
+
+
+def _config_default(explicit: str | None, vault_config: Any | None, attribute: str) -> str | None:
+    if explicit is not None or vault_config is None:
+        return explicit
+    return getattr(vault_config, attribute, None)
+
+
+def _resolve_vault_settings(request: SyncLoadRequest, defaults: _ConfigDefaults) -> _VaultSettings:
+    vault_config = getattr(defaults.config, "vault", None)
+    provider = request.provider or getattr(vault_config, "provider", None)
+    return _VaultSettings(
+        provider=provider,
+        vault_url=_provider_vault_url(provider, request.vault_url, vault_config),
+        region=_config_default(request.region, vault_config, "aws_region"),
+        project_id=_config_default(request.project_id, vault_config, "gcp_project_id"),
+    )
+
+
+def _load_explicit_sync_config(config_file: Path) -> SyncConfig:
+    from envdrift.sync.config import SyncConfig, SyncConfigError
+
+    if not config_file.exists():
+        print_error(f"Config file not found: {config_file}")
+        raise typer.Exit(code=1)
+    try:
+        if config_file.suffix.lower() == ".toml":
+            return SyncConfig.from_toml_file(config_file)
+        return SyncConfig.from_file(config_file)
+    except SyncConfigError as exc:
+        print_error(f"Invalid config file: {exc}")
+        raise typer.Exit(code=1) from None
+
+
+def _mapping_from_project(mapping: Any):
+    from envdrift.sync.config import ServiceMapping
+
+    return ServiceMapping(
+        secret_name=mapping.secret_name,
+        folder_path=Path(mapping.folder_path),
+        vault_name=mapping.vault_name,
+        environment=mapping.environment,
+        env_file=Path(mapping.env_file) if mapping.env_file else None,
+        profile=mapping.profile,
+        activate_to=Path(mapping.activate_to) if mapping.activate_to else None,
+        ephemeral_keys=mapping.ephemeral_keys,
+    )
+
+
+def _sync_config_from_project(vault_sync: Any) -> SyncConfig:
+    from envdrift.sync.config import SyncConfig
+
+    return SyncConfig(
+        mappings=[_mapping_from_project(mapping) for mapping in vault_sync.mappings],
+        default_vault_name=vault_sync.default_vault_name,
+        env_keys_filename=vault_sync.env_keys_filename,
+        max_workers=vault_sync.max_workers,
+        ephemeral_keys=vault_sync.ephemeral_keys,
+    )
+
+
+def _load_discovered_sync_config(config_path: Path) -> SyncConfig | None:
+    from envdrift.sync.config import SyncConfig, SyncConfigError
+
+    try:
+        return SyncConfig.from_toml_file(config_path)
+    except SyncConfigError as exc:
+        print_warning(f"Could not load sync config from {config_path}: {exc}")
+        return None
+
+
+def _load_sync_config(request: SyncLoadRequest, defaults: _ConfigDefaults) -> SyncConfig | None:
+    if request.config_file is not None:
+        return _load_explicit_sync_config(request.config_file)
+    vault_sync = getattr(getattr(defaults.config, "vault", None), "sync", None)
+    if vault_sync and vault_sync.mappings:
+        return _sync_config_from_project(vault_sync)
+    if defaults.path and defaults.path.suffix.lower() == ".toml":
+        return _load_discovered_sync_config(defaults.path)
+    return None
+
+
+def _require_sync_config(sync_config: SyncConfig | None) -> SyncConfig:
+    if sync_config is not None and sync_config.mappings:
+        return sync_config
+    print_error(
+        "No sync configuration found. Provide one of:\n"
+        "  [vault.sync] section in envdrift.toml (auto-discovered)\n"
+        "  [tool.envdrift.vault.sync] section in pyproject.toml\n"
+        "  --config <file.toml>  TOML config with [vault.sync] section\n"
+        "  --config <pair.txt>   Legacy format: secret=folder"
+    )
+    raise typer.Exit(code=1)
+
+
+def _validate_vault_settings(settings: _VaultSettings) -> str:
+    if settings.provider is None:
+        print_error(
+            "--provider is required (or set [vault] provider in config). "
+            "Options: azure, aws, hashicorp, gcp"
+        )
+        raise typer.Exit(code=1)
+    if settings.provider == "azure" and not settings.vault_url:
+        print_error("Azure provider requires --vault-url (or [vault.azure] vault_url in config)")
+        raise typer.Exit(code=1)
+    if settings.provider == "hashicorp" and not settings.vault_url:
+        print_error("HashiCorp provider requires --vault-url (or [vault.hashicorp] url in config)")
+        raise typer.Exit(code=1)
+    if settings.provider == "gcp" and not settings.project_id:
+        print_error("GCP provider requires --project-id (or [vault.gcp] project_id in config)")
+        raise typer.Exit(code=1)
+    return settings.provider
+
+
+def _vault_client_kwargs(settings: _VaultSettings) -> dict[str, str | None]:
+    kwargs_by_provider: dict[str, dict[str, str | None]] = {
+        "azure": {"vault_url": settings.vault_url},
+        "aws": {"region": settings.region or "us-east-1"},
+        "hashicorp": {"url": settings.vault_url},
+        "gcp": {"project_id": settings.project_id},
+    }
+    return kwargs_by_provider.get(settings.provider or "", {})
+
+
+def _create_vault_client(provider: str, settings: _VaultSettings) -> Any:
+    from envdrift.vault import get_vault_client
+
+    try:
+        return get_vault_client(provider, **_vault_client_kwargs(settings))
+    except (ImportError, ValueError) as exc:
+        print_error(str(exc))
+        raise typer.Exit(code=1) from None
+
+
+def load_sync_connection(
+    request: SyncLoadRequest,
+) -> tuple[SyncConfig, Any, str, str | None, str | None, str | None]:
+    """Load sync mappings, resolve provider settings, and build their client."""
+
+    defaults = _load_defaults(request)
+    settings = _resolve_vault_settings(request, defaults)
+    sync_config = _require_sync_config(_load_sync_config(request, defaults))
+    provider = _validate_vault_settings(settings)
+    client = _create_vault_client(provider, settings)
+    return (
+        sync_config,
+        client,
+        provider,
+        settings.vault_url,
+        settings.region,
+        settings.project_id,
+    )

--- a/src/envdrift/cli_commands/sync_run_helpers.py
+++ b/src/envdrift/cli_commands/sync_run_helpers.py
@@ -94,7 +94,7 @@ def _new_sync_engine(request: SyncRequest, context: _SyncContext):
             console.print(f"[dim]{message}[/dim]")
 
     def prompt_callback(message: str) -> bool:
-        if request.force or request.verify or request.ci:
+        if _prompting_disabled(request):
             return request.force
         response = console.input(f"{message} (y/N): ").strip().lower()
         return response in ("y", "yes")
@@ -106,6 +106,10 @@ def _new_sync_engine(request: SyncRequest, context: _SyncContext):
         prompt_callback=prompt_callback,
         progress_callback=progress_callback,
     )
+
+
+def _prompting_disabled(request: SyncRequest) -> bool:
+    return request.force or request.verify or request.ci
 
 
 def _print_sync_header(request: SyncRequest, context: _SyncContext) -> None:

--- a/src/envdrift/cli_commands/sync_run_helpers.py
+++ b/src/envdrift/cli_commands/sync_run_helpers.py
@@ -1,0 +1,155 @@
+"""Execution workflow for the high-level sync command."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import typer
+
+from envdrift.output.rich import console, print_error
+from envdrift.vault.base import SecretNotFoundError, VaultError
+
+if TYPE_CHECKING:
+    from envdrift.sync.config import SyncConfig
+
+
+@dataclass(frozen=True)
+class SyncRequest:
+    """User-selected options for one ``envdrift sync`` invocation."""
+
+    config_file: Path | None
+    provider: str | None
+    vault_url: str | None
+    region: str | None
+    project_id: str | None
+    verify: bool
+    force: bool
+    check_decryption: bool
+    validate_schema: bool
+    schema: str | None
+    service_dir: Path | None
+    ci: bool
+
+
+@dataclass(frozen=True)
+class SyncRuntime:
+    """Patchable seams used by the sync command workflow."""
+
+    load_sync: Callable[..., tuple[SyncConfig, Any, str, str | None, str | None, str | None]]
+    find_binary: Callable[[str], str | None]
+
+
+@dataclass(frozen=True)
+class _SyncContext:
+    config: SyncConfig
+    vault_client: Any
+    provider: str
+
+
+def _require_decryption_tool(request: SyncRequest, runtime: SyncRuntime) -> None:
+    if request.check_decryption and runtime.find_binary("dotenvx") is None:
+        print_error("dotenvx is not installed - cannot verify decryption")
+        raise typer.Exit(code=1)
+
+
+def _raise_hook_errors(config_file: Path | None) -> None:
+    from envdrift.integrations.hook_check import ensure_git_hook_setup
+
+    errors = ensure_git_hook_setup(config_file=config_file)
+    for error in errors:
+        print_error(error)
+    if errors:
+        raise typer.Exit(code=1)
+
+
+def _load_sync_context(request: SyncRequest, runtime: SyncRuntime) -> _SyncContext:
+    sync_config, vault_client, provider, _, _, _ = runtime.load_sync(
+        config_file=request.config_file,
+        provider=request.provider,
+        vault_url=request.vault_url,
+        region=request.region,
+        project_id=request.project_id,
+    )
+    _raise_hook_errors(request.config_file)
+    return _SyncContext(config=sync_config, vault_client=vault_client, provider=provider)
+
+
+def _new_sync_engine(request: SyncRequest, context: _SyncContext):
+    from envdrift.sync.engine import SyncEngine, SyncMode
+
+    mode = SyncMode(
+        verify_only=request.verify,
+        force_update=request.force,
+        check_decryption=request.check_decryption,
+        validate_schema=request.validate_schema,
+        schema_path=request.schema,
+        service_dir=request.service_dir,
+    )
+
+    def progress_callback(message: str) -> None:
+        if not request.ci:
+            console.print(f"[dim]{message}[/dim]")
+
+    def prompt_callback(message: str) -> bool:
+        if request.force or request.verify or request.ci:
+            return request.force
+        response = console.input(f"{message} (y/N): ").strip().lower()
+        return response in ("y", "yes")
+
+    return SyncEngine(
+        config=context.config,
+        vault_client=context.vault_client,
+        mode=mode,
+        prompt_callback=prompt_callback,
+        progress_callback=progress_callback,
+    )
+
+
+def _print_sync_header(request: SyncRequest, context: _SyncContext) -> None:
+    console.print()
+    mode = "VERIFY" if request.verify else ("FORCE" if request.force else "Interactive")
+    console.print(f"[bold]Vault Sync[/bold] - Mode: {mode}")
+    console.print(
+        f"[dim]Provider: {context.provider} | Services: {len(context.config.mappings)}[/dim]"
+    )
+    console.print()
+
+
+def _run_sync_engine(engine: Any):
+    from envdrift.sync.config import SyncConfigError
+
+    try:
+        return engine.sync_all()
+    except (VaultError, SyncConfigError, SecretNotFoundError, OSError, UnicodeDecodeError) as exc:
+        print_error(f"Sync failed: {exc}")
+        raise typer.Exit(code=1) from None
+
+
+def _print_sync_result(result: Any) -> None:
+    from envdrift.output.rich import print_service_sync_status, print_sync_result
+
+    for service_result in result.services:
+        print_service_sync_status(service_result)
+    print_sync_result(result)
+
+
+def _raise_sync_result_errors(request: SyncRequest, result: Any) -> None:
+    if request.ci and result.has_errors:
+        raise typer.Exit(code=1)
+    if request.check_decryption and result.decryption_failed > 0:
+        raise typer.Exit(code=1)
+
+
+def execute_sync(request: SyncRequest, runtime: SyncRuntime) -> None:
+    """Run the sync workflow while keeping the Typer command as an adapter."""
+
+    _require_decryption_tool(request, runtime)
+    context = _load_sync_context(request, runtime)
+    engine = _new_sync_engine(request, context)
+    _print_sync_header(request, context)
+    result = _run_sync_engine(engine)
+    _print_sync_result(result)
+    _raise_sync_result_errors(request, result)


### PR DESCRIPTION
## Summary

- split sync config discovery, provider resolution, mapping construction, validation, and client creation into typed helper phases
- route the sync Typer callback through a SyncRequest workflow with explicit patchable runtime seams
- reduce load_sync_config_and_client from CC 46 to CC 1 and sync from CC 13 to CC 1
- keep every new helper at CC 8 or lower with no suppressions

## Behavior contract

- sync --help is byte-identical to main
- fresh-directory missing-config output is byte-identical to main with the same exit code
- public loader tuple shape and CLI patch seams remain compatible
- no user-facing behavior or release-triggering functionality changes

## Validation

- Ruff check and format check
- Pyrefly: 0 errors
- Bandit: 0 issues
- focused loader and CLI suites: 336 passed, 1 existing xpass
- non-integration suite: 3,359 passed, 6 skipped, 1 existing xpass
- full real-backend integration suite: 505 passed, 37 skipped against LocalStack, Vault, and Lowkey

Closes #631

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jainal09/envdrift/pull/637?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors the sync command into smaller helper phases. The main changes are:

- Moves sync config discovery and vault-client creation into `sync_config_helpers.py`.
- Moves sync command execution into `sync_run_helpers.py`.
- Keeps the public loader and Typer command adapters in `sync.py`.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/envdrift/cli_commands/sync.py | Keeps the public sync command and loader adapters while routing the implementation through helper modules. |
| src/envdrift/cli_commands/sync_config_helpers.py | Adds typed helpers for config discovery, provider resolution, sync mapping loading, validation, and vault-client construction. |
| src/envdrift/cli_commands/sync_run_helpers.py | Adds a typed sync execution workflow for decryption-tool checks, hook validation, engine setup, result printing, and exit handling. |

<sub>Reviews (2): Last reviewed commit: ["refactor(cli): satisfy sync health gates"](https://github.com/jainal09/envdrift/commit/8cf54638b77ae98e769b4bf0c801adfd98a74688) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43582407)</sub>

<!-- /greptile_comment -->