### PR TITLE
fix(scanner): scan untracked non-env files

### DIFF
--- a/src/envdrift/scanner/_native_io.py
+++ b/src/envdrift/scanner/_native_io.py
@@ -1,0 +1,38 @@
+"""Bounded file reads for the built-in scanner."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Protect default scans from large untracked logs/datasets that Git correctly
+# reports as commit candidates. Dedicated scanners can handle larger artifacts.
+NATIVE_MAX_SCAN_BYTES = 10 * 1024 * 1024
+
+
+def read_raw_scannable_bytes(file_path: Path) -> bytes | None:
+    """Return bounded file bytes, or ``None`` when unreadable/oversized."""
+    try:
+        size = file_path.stat().st_size
+        if size > NATIVE_MAX_SCAN_BYTES:
+            logger.debug(
+                "Skipping native scan of oversized file %s (%d bytes; limit %d)",
+                file_path,
+                size,
+                NATIVE_MAX_SCAN_BYTES,
+            )
+            return None
+        with file_path.open("rb") as stream:
+            raw = stream.read(NATIVE_MAX_SCAN_BYTES + 1)
+    except OSError:
+        return None
+    if len(raw) <= NATIVE_MAX_SCAN_BYTES:
+        return raw
+    logger.debug(
+        "Skipping native scan of file that grew beyond %d bytes: %s",
+        NATIVE_MAX_SCAN_BYTES,
+        file_path,
+    )
+    return None

--- a/src/envdrift/scanner/native.py
+++ b/src/envdrift/scanner/native.py
@@ -73,9 +73,8 @@ DEFAULT_IGNORE_PATTERNS = (
     ".env.example",
     ".env.sample",
     ".env.template",
-    # Documentation and text files
+    # Documentation markup (plain .txt files can be real config/secret stores)
     "*.md",
-    "*.txt",
     "*.rst",
     "*.adoc",
     # Minified files (high entropy but not secrets)
@@ -230,12 +229,13 @@ DEFAULT_IGNORE_PATTERNS = (
 # gitignored; it must not be treated as an "unencrypted env file" to encrypt.
 DOTENVX_KEYS_FILENAME = ".env.keys"
 
-# git pathspecs that match env-file naming shapes at any depth: the leading-dot
+# Git pathspecs that match env-file naming shapes at any depth: the leading-dot
 # convention (.env, .env.*) and the trailing-suffix convention (<name>.env,
-# #477). Passed to `git ls-files` so git itself filters to env files instead of
-# enumerating every untracked or ignored path (e.g. a large node_modules) and
-# letting Python discard them. A superset of _is_env_file (it also matches e.g.
-# ".envrc"), which still does the precise filtering, so correctness is unchanged.
+# #477). These are only for the deliberately exceptional ignored-file pass:
+# ordinary untracked files must be scanned regardless of name, while ignored
+# files stay excluded unless they are env stores that may be plaintext locally.
+# A superset of _is_env_file (it also matches e.g. ".envrc"), which still does
+# the precise filtering.
 _ENV_FILE_PATHSPECS = (":(glob)**/.env*", ":(glob)**/*.env")
 
 
@@ -477,11 +477,12 @@ class NativeScanner(ScannerBackend):
         )
 
     def _collect_files(self, directory: Path) -> list[Path]:
-        """Collect files using hybrid approach: git ls-files + untracked .env files.
+        """Collect tracked and untracked files using Git, plus ignored env stores.
 
         This is much faster than rglob because:
         1. git ls-files reads from git's index (no filesystem traversal)
-        2. Untracked .env files are found via git, respecting .gitignore
+        2. Untracked files are found via git, respecting .gitignore
+        3. Ignored env stores get a narrow safety pass for partial encryption
 
         Args:
             directory: Directory to scan.
@@ -522,8 +523,11 @@ class NativeScanner(ScannerBackend):
             # git not available - fall back to os.walk
             return self._collect_files_fallback(directory)
 
-        # Method 2: Get untracked .env* files (respects .gitignore)
-        # These are files developers might forget to encrypt before committing
+        # Method 2: Get every ordinary untracked file (respects .gitignore).
+        # Restricting this pass to .env-shaped names let secrets in config.txt,
+        # secrets.yaml, and other would-be commit inputs bypass the native scanner
+        # with exit 0. Git already applies the repository's ignore policy, and the
+        # normal _should_ignore/_looks_binary filters still apply before scanning.
         try:
             result = subprocess.run(  # nosec B603, B607
                 [
@@ -532,8 +536,6 @@ class NativeScanner(ScannerBackend):
                     "--others",
                     "--exclude-standard",
                     "-z",
-                    "--",
-                    *_ENV_FILE_PATHSPECS,
                 ],
                 capture_output=True,
                 text=True,
@@ -544,7 +546,7 @@ class NativeScanner(ScannerBackend):
             )
             if result.returncode == 0:
                 for rel_path in result.stdout.split("\0"):
-                    if rel_path and _is_env_file(rel_path):
+                    if rel_path:
                         files.add(directory / rel_path)
         except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
             pass

--- a/src/envdrift/scanner/native.py
+++ b/src/envdrift/scanner/native.py
@@ -30,6 +30,7 @@ from envdrift.scanner._native_filters import (
     _is_encrypted_value_line,
     _looks_like_code_member_access,
 )
+from envdrift.scanner._native_io import read_raw_scannable_bytes
 from envdrift.scanner.base import (
     FindingSeverity,
     ScanFinding,
@@ -718,15 +719,14 @@ class NativeScanner(ScannerBackend):
     def _read_scannable_content(file_path: Path) -> str | None:
         """Read ``file_path`` and return its text content, or ``None`` to skip it.
 
-        Reads raw bytes (so the binary check sees the true content: ``read_text``
-        with ``errors="ignore"`` would silently drop the very non-text bytes that
-        identify a binary file), decodes demonstrably-Unicode text first, and
-        neutralizes stray NULs. Returns ``None`` for an unreadable file, a genuine
-        binary blob, or an empty/whitespace-only file.
+        Rejects oversized files before opening them, then performs a bounded read
+        so a concurrently growing file cannot bypass the cap. Raw bytes let the
+        binary check see the true content (``read_text(errors="ignore")`` would
+        silently drop the bytes that identify a binary file). Returns ``None``
+        for an unreadable/oversized file, a genuine binary blob, or empty content.
         """
-        try:
-            raw = file_path.read_bytes()
-        except OSError:
+        raw = read_raw_scannable_bytes(file_path)
+        if raw is None:
             return None
 
         # Decode demonstrably-Unicode text before the binary heuristic can see it

--- a/tests/integration/test_guard_cli_e2e.py
+++ b/tests/integration/test_guard_cli_e2e.py
@@ -10,6 +10,7 @@ Coverage (highest value first):
 - BP-16  test_critical_finding_exit_code_one_non_ci (P0)
 - BP-16  test_committed_private_key_exit_code_one (P0)
 - BP-17  test_high_unencrypted_env_file_exit_code_two_non_ci (P0)
+- #441   test_untracked_non_env_secret_is_discovered (P0)
 - BUG    test_staged_secret_dropped_when_run_from_subdirectory (P0)
 - HP-17  test_allowed_clear_file_exempt_from_unencrypted_but_secrets_still_scanned (P0)
 - HP-10  test_entropy_flag_enables_high_entropy_detection (P1)
@@ -220,6 +221,28 @@ def test_critical_finding_exit_code_one_non_ci(git_repo: Path) -> None:
     assert "aws-secret-access-key" in _rule_ids(payload)
     assert payload["summary"]["by_severity"]["critical"] >= 1
     assert payload["exit_code"] == 1
+
+
+def test_untracked_non_env_secret_is_discovered(git_repo: Path) -> None:
+    """An untracked non-.env file is part of a normal repository scan (#441).
+
+    Before this regression fix, native discovery asked Git only for untracked
+    .env-shaped names. A config.txt containing a high-confidence credential was
+    therefore absent from the scan, and guard returned a false-success exit 0.
+    """
+    work_dir = git_repo
+    target = work_dir / "config.txt"
+    target.write_text(f'aws_secret_access_key = "{_AWS_SECRET}"\n')
+
+    result = _run_envdrift(
+        ["guard", "--native-only", "--no-auto-install", "--json", "."], cwd=work_dir
+    )
+    payload = _guard_json(result)
+
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert payload["exit_code"] == 1
+    assert "aws-secret-access-key" in _rule_ids(payload)
+    assert any(Path(finding["file_path"]).name == "config.txt" for finding in payload["findings"])
 
 
 # --- BP-16 (P0, second vector): tracked .env.keys -> committed-private-key ------

--- a/tests/integration/test_scanner_external_binaries.py
+++ b/tests/integration/test_scanner_external_binaries.py
@@ -448,11 +448,16 @@ def test_trivy_distinct_secrets_survive_skip_duplicate_cli(tmp_path):
         pytest.fail(
             f"guard --json stdout is not clean JSON: {exc}\nstdout:\n{out}\nstderr:\n{proc.stderr}"
         )
-    trivy_files = {
-        Path(f["file_path"]).name for f in payload["findings"] if f["scanner"] == "trivy"
-    }
-    assert trivy_files == {"a.txt", "b.txt"}, (
-        f"--skip-duplicate must keep both distinct secrets, got {sorted(trivy_files)}\n"
+    # Native now scans untracked .txt files (#441), so cross-scanner duplicate
+    # collapse may correctly retain the native-owned copy of each secret. The
+    # companion direct-Trivy test below proves both raw hashes originate from
+    # Trivy; this CLI assertion owns the aggregate contract that both distinct
+    # values survive --skip-duplicate regardless of scanner attribution.
+    reported_files = {Path(f["file_path"]).name for f in payload["findings"]}
+    scanner_results = {result["name"]: result for result in payload["scanner_results"]}
+    assert scanner_results["trivy"]["files_scanned"] == 2, scanner_results
+    assert reported_files == {"a.txt", "b.txt"}, (
+        f"--skip-duplicate must keep both distinct secrets, got {sorted(reported_files)}\n"
         f"stdout:\n{out}\nstderr:\n{proc.stderr}"
     )
     # Critical findings present -> guard exits 1.

--- a/tests/scanner/test_native.py
+++ b/tests/scanner/test_native.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 import errno
 import os
 from pathlib import Path, PureWindowsPath
+from types import SimpleNamespace
 
 import pytest
 
+from envdrift.scanner._native_io import NATIVE_MAX_SCAN_BYTES
 from envdrift.scanner.base import FindingSeverity
 from envdrift.scanner.engine import GuardConfig, ScanEngine
 from envdrift.scanner.native import _ENV_FILE_PATHSPECS, NativeScanner
@@ -85,13 +87,11 @@ class TestNativeScannerInternals:
         (tmp_path / ".env.z").touch()
         calls: list[list[str]] = []
 
+        outputs = iter(("b.txt\0a.txt\0", ".env.z\0.env.a\0", ".env.z\0.env.a\0"))
+
         def mock_run(cmd, **kwargs):
             calls.append(cmd)
-            if cmd[:2] == ["git", "ls-files"] and "--others" not in cmd:
-                return subprocess.CompletedProcess(cmd, 0, stdout="b.txt\0a.txt\0", stderr="")
-            if cmd[:2] == ["git", "ls-files"] and "--others" in cmd:
-                return subprocess.CompletedProcess(cmd, 0, stdout=".env.z\0.env.a\0", stderr="")
-            return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="")
+            return subprocess.CompletedProcess(cmd, 0, stdout=next(outputs), stderr="")
 
         monkeypatch.setattr(subprocess, "run", mock_run)
 
@@ -102,11 +102,9 @@ class TestNativeScannerInternals:
         )
 
         assert files == expected
+        assert len(calls) == 3
         assert all("-z" in cmd for cmd in calls)
-        ordinary_untracked = next(
-            cmd for cmd in calls if "--others" in cmd and "--ignored" not in cmd
-        )
-        ignored_env = next(cmd for cmd in calls if "--ignored" in cmd)
+        _, ordinary_untracked, ignored_env = calls
         assert "--" not in ordinary_untracked
         assert ignored_env[-3:] == ["--", *_ENV_FILE_PATHSPECS]
 
@@ -196,17 +194,27 @@ class TestNativeScannerInternals:
         git("add", ".gitignore")
 
         untracked = tmp_path / "config.txt"
+        oversized = tmp_path / "big-output.txt"
         ignored_non_env = tmp_path / "ignored.txt"
         ignored_env = tmp_path / ".env.production.secret"
         untracked.write_text("GITHUB_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\n")
+        oversized.write_text("GITHUB_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\n")
+        with oversized.open("ab") as stream:
+            stream.truncate(NATIVE_MAX_SCAN_BYTES + 1)
         ignored_non_env.write_text("GITHUB_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\n")
         ignored_env.write_text("API_KEY=plaintext-leak\n")
 
         collected = {path.resolve() for path in NativeScanner()._collect_files(tmp_path)}
 
         assert untracked.resolve() in collected
+        assert oversized.resolve() in collected
         assert ignored_non_env.resolve() not in collected
         assert ignored_env.resolve() in collected
+
+        result = NativeScanner().scan([tmp_path])
+        finding_paths = {finding.file_path.resolve() for finding in result.findings}
+        assert untracked.resolve() in finding_paths
+        assert oversized.resolve() not in finding_paths
 
     def test_collect_files_includes_gitignored_mapped_env_file(self, tmp_path: Path):
         """A gitignored custom env filename from vault.sync must still be collected."""
@@ -378,15 +386,33 @@ class TestNativeScannerInternals:
         scanner = NativeScanner()
         file_path = tmp_path / "config.py"
         file_path.write_text("SECRET=VALUE")
-        original_read_text = Path.read_text
+        original_open = Path.open
 
         def raise_error(self, *args, **kwargs):
             if self == file_path:
                 raise OSError("boom")
-            return original_read_text(self, *args, **kwargs)
+            return original_open(self, *args, **kwargs)
 
-        monkeypatch.setattr(Path, "read_text", raise_error)
+        monkeypatch.setattr(Path, "open", raise_error)
         assert scanner._scan_file(file_path) == []
+
+    def test_read_scannable_content_bounds_a_file_that_grows_after_stat(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """The read cap still holds if a file grows between stat and open."""
+        file_path = tmp_path / "growing.txt"
+        file_path.write_text("GITHUB_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\n")
+        with file_path.open("ab") as stream:
+            stream.truncate(NATIVE_MAX_SCAN_BYTES + 1)
+        original_stat = Path.stat
+
+        def report_small_size(self, *args, **kwargs):
+            if self == file_path:
+                return SimpleNamespace(st_size=1)
+            return original_stat(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "stat", report_small_size)
+        assert NativeScanner._read_scannable_content(file_path) is None
 
     def test_scan_file_skips_empty_content(self, tmp_path: Path):
         """Empty files return no findings."""

--- a/tests/scanner/test_native.py
+++ b/tests/scanner/test_native.py
@@ -10,7 +10,7 @@ import pytest
 
 from envdrift.scanner.base import FindingSeverity
 from envdrift.scanner.engine import GuardConfig, ScanEngine
-from envdrift.scanner.native import NativeScanner
+from envdrift.scanner.native import _ENV_FILE_PATHSPECS, NativeScanner
 
 
 class TestNativeScanner:
@@ -103,6 +103,12 @@ class TestNativeScannerInternals:
 
         assert files == expected
         assert all("-z" in cmd for cmd in calls)
+        ordinary_untracked = next(
+            cmd for cmd in calls if "--others" in cmd and "--ignored" not in cmd
+        )
+        ignored_env = next(cmd for cmd in calls if "--ignored" in cmd)
+        assert "--" not in ordinary_untracked
+        assert ignored_env[-3:] == ["--", *_ENV_FILE_PATHSPECS]
 
     @pytest.mark.skipif(os.name == "nt", reason="Windows filenames cannot contain arbitrary bytes")
     def test_collect_files_round_trips_non_utf8_git_paths(self, tmp_path: Path):
@@ -165,6 +171,42 @@ class TestNativeScannerInternals:
         collected = scanner._collect_files(tmp_path)
 
         assert (tmp_path / ".env.production.secret").resolve() in {p.resolve() for p in collected}
+
+    def test_collect_files_includes_untracked_non_env_files_but_respects_gitignore(
+        self, tmp_path: Path
+    ):
+        """Untracked commit candidates are scanned regardless of filename.
+
+        The native scanner used to ask Git only for untracked .env-shaped paths,
+        so a secret in config.txt or settings.yaml produced a clean exit. Gitignored
+        non-env files remain an explicit repository opt-out, while the existing
+        ignored-env safety pass still includes plaintext secret stores.
+        """
+        import shutil
+        import subprocess
+
+        if shutil.which("git") is None:
+            pytest.skip("git not available")
+
+        def git(*args: str) -> None:
+            subprocess.run(["git", *args], cwd=tmp_path, check=True, capture_output=True)
+
+        git("init")
+        (tmp_path / ".gitignore").write_text("ignored.txt\n.env.production.secret\n")
+        git("add", ".gitignore")
+
+        untracked = tmp_path / "config.txt"
+        ignored_non_env = tmp_path / "ignored.txt"
+        ignored_env = tmp_path / ".env.production.secret"
+        untracked.write_text("GITHUB_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\n")
+        ignored_non_env.write_text("GITHUB_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\n")
+        ignored_env.write_text("API_KEY=plaintext-leak\n")
+
+        collected = {path.resolve() for path in NativeScanner()._collect_files(tmp_path)}
+
+        assert untracked.resolve() in collected
+        assert ignored_non_env.resolve() not in collected
+        assert ignored_env.resolve() in collected
 
     def test_collect_files_includes_gitignored_mapped_env_file(self, tmp_path: Path):
         """A gitignored custom env filename from vault.sync must still be collected."""


### PR DESCRIPTION
## Summary

- enumerate every ordinary untracked file reported by Git instead of restricting discovery to .env-shaped names
- allow plain .txt commit candidates through native scanning so config.txt cannot bypass content detection
- keep repository ignore rules authoritative for non-env files and preserve the narrow ignored-env safety pass used by partial encryption
- add real-Git unit coverage and a real-process CLI regression that proves an untracked config.txt secret exits 1

## Why

Current main returns exit 0 with zero findings when an untracked non-.env file contains a high-confidence credential. The file is dropped twice: the Git query only requests env-shaped untracked paths, and the native default ignore list discards all .txt files. This PR closes both gates without crawling ignored dependency trees.

## Related issue

Partial #441. This is intentionally standalone because broadening untracked discovery is the high-severity item with repository-size and ignore-boundary implications.

## Testing

- [x] uv run pytest -q --no-cov tests/scanner — 747 passed, 4 skipped (binary availability gates)
- [x] uv run pytest -q --no-cov tests/integration/test_guard_cli_e2e.py — 24 passed
- [x] uv run pytest -m "not integration" -q — 3360 passed, 6 skipped, 543 deselected, 1 existing xpass
- [x] uv run ruff check src tests
- [x] uv run ruff format --check .
- [x] uv run pyrefly check — 0 errors
- [x] uv run bandit -r src -c pyproject.toml — no issues

## Checklist

- [x] Real Git and real CLI regression coverage
- [x] No test disabled, skipped, or xfailed by this change
- [x] Gitignored non-env files remain excluded
- [x] Gitignored partial-encryption env stores remain included
- [x] Existing binary/content filters remain active

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jainal09/envdrift/pull/639?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The native scanner now considers additional untracked secret-containing files (including `.txt` and `.yaml`), rather than only `.env`-style names.
  * Scanning is more robust against unusually large or rapidly-changing files by enforcing bounded, size-limited reads.
* **Tests**
  * Added an end-to-end regression test ensuring untracked, non-`.env` files are discovered via the guard CLI.
  * Expanded native scanner test coverage for file selection and strict scan-size behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates native scanning so untracked non-env files can be checked for secrets. The main changes are:

- Git discovery now includes ordinary untracked files.
- Plain `.txt` files are no longer skipped by the native defaults.
- Native file reads now have a fixed size cap.
- Tests cover untracked config files, ignored files, and oversized files.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/envdrift/scanner/_native_io.py | Adds the bounded native file read helper used before content scanning. |
| src/envdrift/scanner/native.py | Broadens untracked file discovery and routes native content reads through the new size-limited helper. |
| tests/scanner/test_native.py | Adds tests for untracked non-env discovery, gitignore behavior, oversized file skipping, and file growth during reads. |
| tests/integration/test_guard_cli_e2e.py | Adds a CLI test showing an untracked `config.txt` secret is reported. |
| tests/integration/test_scanner_external_binaries.py | Updates duplicate handling expectations after native scanning can report untracked text-file secrets. |

<sub>Reviews (3): Last reviewed commit: ["test(scanner): preserve trivy aggregate ..."](https://github.com/jainal09/envdrift/commit/08b97059e541ad858cc101a7522026aa509a23bd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43583829)</sub>

<!-- /greptile_comment -->