### PR TITLE
fix(scanner): report incomplete scans truthfully

### DIFF
--- a/docs/cli/guard.md
+++ b/docs/cli/guard.md
@@ -264,6 +264,16 @@ Control auto-installation of external scanners.
 envdrift guard --no-auto-install
 ```
 
+With `--no-auto-install`, a missing scanner binary is handled by how the
+scanner was selected. A scanner you selected **explicitly** — its CLI flag
+(e.g. `--gitleaks`) or a `[guard] scanners` list written in your config —
+fails closed: the failure is recorded and the run exits `5` (scan
+incomplete). A scanner active only via the built-in **default** set is
+skipped instead, with a visible warning (Scanners Skipped panel, stderr
+warning) and a truthful `skipped`/`skip_reason` record in `--json`; the
+exit code is unaffected, so `guard --no-auto-install` stays green on a
+machine that simply doesn't have the optional binary.
+
 Auto-installed scanner binaries are verified against the upstream-published
 SHA256 checksums before they are installed or executed; the install fails
 closed when the checksum is missing, unreachable, or mismatched. Set
@@ -462,6 +472,13 @@ Blocking findings take precedence — a critical finding plus a scanner error
 still exits 1. The scanner errors are listed in the human output (Scanner
 Errors panel), in `--json` under `scanner_results[].error`, and in `--sarif`
 as invocation `toolExecutionNotifications`.
+
+Exit 5 applies to scanners you **selected** — a CLI flag or a `[guard]
+scanners` list written in your config. A scanner active only via the built-in
+default set whose binary is missing under `--no-auto-install` never ran and
+never failed: it is skipped with a visible warning and a
+`scanner_results[].skipped`/`skip_reason` record, and does not change the
+exit code (see `--auto-install` above).
 
 The machine-readable verdict fields always match the process exit code: the
 `--json` document's `exit_code`/`has_blocking_findings` and the `--sarif`

--- a/docs/specs/guard-command-spec.md
+++ b/docs/specs/guard-command-spec.md
@@ -1455,6 +1455,7 @@ class TrufflehogScanner(ScannerBackend):
 
 from __future__ import annotations
 
+import logging
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -1469,6 +1470,8 @@ from .base import (
 from .native import NativeScanner
 from .gitleaks import GitleaksScanner
 from .trufflehog import TrufflehogScanner
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -1518,6 +1521,7 @@ class ScanEngine:
         # Skip records for default-set scanners whose binary is unavailable
         # with auto-install disabled; included in every aggregated result.
         self.skipped_results: list[ScanResult] = []
+        self._explicit_scanner_names = frozenset(self.config.explicit_scanners)
 
         # Initialize scanners based on config
         if config.use_native:
@@ -1536,24 +1540,28 @@ class ScanEngine:
     def _retain_scanner(self, scanner: ScannerBackend) -> None:
         """Retain an external scanner, or record a skip when it cannot run.
 
-        EXPLICITLY-selected scanners (CLI flag, or a `scanners` list written
-        in the config) are always retained: with the binary unavailable and
-        auto-install disabled the scan records their failure and the run
-        exits 5 (scan incomplete). A scanner active only via the DEFAULT set
-        is skipped instead — with a warning and a truthful skip record
-        (`ScanResult.skip_reason`) carried in the aggregated results — so a
-        missing optional binary cannot fail a run nobody asked it to gate.
+        Explicitly-requested scanners (``config.explicit_scanners``) are always
+        retained: with the binary unavailable and auto-install disabled the
+        scan records their failure and the run exits 5 (scan incomplete), never
+        the all-clear 0. A scanner active only via the DEFAULT set is skipped
+        instead — with a warning and a truthful skip record — so a missing
+        optional binary cannot fail a run the user never asked it to gate
+        (#641).
         """
         if (
             self.config.auto_install
-            or scanner.name in set(self.config.explicit_scanners)
+            or scanner.name in self._explicit_scanner_names
             or scanner.is_installed()
         ):
             self.scanners.append(scanner)
             return
-        self.skipped_results.append(
-            ScanResult(scanner_name=scanner.name, skip_reason="not installed; skipped")
+        reason = (
+            f"{scanner.name} is not installed and auto-install is disabled; "
+            "skipping this default-selection scanner. Install it or select it "
+            "explicitly to make the missing binary a blocking scan error."
         )
+        logger.warning(reason)
+        self.skipped_results.append(ScanResult(scanner_name=scanner.name, skip_reason=reason))
 
     def scan(self, paths: list[Path]) -> AggregatedScanResult:
         """Run all scanners and aggregate results."""

--- a/docs/specs/guard-command-spec.md
+++ b/docs/specs/guard-command-spec.md
@@ -912,7 +912,8 @@ def format_json(result: AggregatedScanResult) -> str:
     return json.dumps({
         "findings": [f.to_dict() for f in result.unique_findings],
         "summary": {
-            "total": result.total_findings,
+            "total": len(result.unique_findings),
+            "total_raw": result.total_findings,
             "unique": len(result.unique_findings),
             "by_severity": {
                 s.value: sum(1 for f in result.unique_findings if f.severity == s)

--- a/docs/specs/guard-command-spec.md
+++ b/docs/specs/guard-command-spec.md
@@ -1483,6 +1483,9 @@ class GuardConfig:
     entropy_threshold: float = 4.5
     ignore_paths: list[str] = field(default_factory=list)
     fail_on_severity: FindingSeverity = FindingSeverity.HIGH
+    # Scanners the caller EXPLICITLY requested (CLI flag or a `scanners`
+    # list written in the config), as opposed to the built-in default set.
+    explicit_scanners: list[str] = field(default_factory=list)
 
     @classmethod
     def from_toml(cls, config: dict) -> GuardConfig:
@@ -1512,6 +1515,9 @@ class ScanEngine:
     def __init__(self, config: GuardConfig):
         self.config = config
         self.scanners: list[ScannerBackend] = []
+        # Skip records for default-set scanners whose binary is unavailable
+        # with auto-install disabled; included in every aggregated result.
+        self.skipped_results: list[ScanResult] = []
 
         # Initialize scanners based on config
         if config.use_native:
@@ -1522,19 +1528,39 @@ class ScanEngine:
             ))
 
         if config.use_gitleaks:
-            scanner = GitleaksScanner(auto_install=config.auto_install)
-            if scanner.is_installed() or config.auto_install:
-                self.scanners.append(scanner)
+            self._retain_scanner(GitleaksScanner(auto_install=config.auto_install))
 
         if config.use_trufflehog:
-            scanner = TrufflehogScanner(auto_install=config.auto_install)
-            if scanner.is_installed() or config.auto_install:
-                self.scanners.append(scanner)
+            self._retain_scanner(TrufflehogScanner(auto_install=config.auto_install))
+
+    def _retain_scanner(self, scanner: ScannerBackend) -> None:
+        """Retain an external scanner, or record a skip when it cannot run.
+
+        EXPLICITLY-selected scanners (CLI flag, or a `scanners` list written
+        in the config) are always retained: with the binary unavailable and
+        auto-install disabled the scan records their failure and the run
+        exits 5 (scan incomplete). A scanner active only via the DEFAULT set
+        is skipped instead — with a warning and a truthful skip record
+        (`ScanResult.skip_reason`) carried in the aggregated results — so a
+        missing optional binary cannot fail a run nobody asked it to gate.
+        """
+        if (
+            self.config.auto_install
+            or scanner.name in set(self.config.explicit_scanners)
+            or scanner.is_installed()
+        ):
+            self.scanners.append(scanner)
+            return
+        self.skipped_results.append(
+            ScanResult(scanner_name=scanner.name, skip_reason="not installed; skipped")
+        )
 
     def scan(self, paths: list[Path]) -> AggregatedScanResult:
         """Run all scanners and aggregate results."""
         start_time = time.time()
-        results: list[ScanResult] = []
+        # Skip records ride along in `results` so every output mode sees a
+        # default-set scanner that was skipped for a missing binary.
+        results: list[ScanResult] = list(self.skipped_results)
 
         for scanner in self.scanners:
             result = scanner.scan(
@@ -1780,6 +1806,26 @@ envdrift guard [OPTIONS] [PATHS]...
 | `--fail-on` | | `high` | Minimum severity to fail |
 | `--verbose` | `-v` | `false` | Show detailed output including scanner info |
 | `--config` | `-c` | | Path to `envdrift.toml` config file (auto-detected if not specified) |
+
+### Explicit vs default scanner selection
+
+A scanner is **explicitly selected** when its CLI flag is passed (e.g.
+`--gitleaks`) or when the config file itself writes a `[guard] scanners`
+list that includes it. A scanner active only via the built-in default set
+(`["native", "gitleaks"]` with no `scanners` key and no flag) is a
+**default-set** scanner.
+
+The distinction matters only when the scanner's binary is unavailable and
+auto-install is disabled (`--no-auto-install` / `auto_install = false`):
+
+- **Explicit + unavailable**: the scanner is retained fail-closed. Its
+  failure is recorded (`scanner_results[].error`), the scan is incomplete,
+  and the run exits `5` unless a blocking finding produces a severity code.
+- **Default-set + unavailable**: the scanner is skipped. The skip is visible
+  as a warning in human output (Scanners Skipped panel + stderr warning) and
+  recorded truthfully in `--json` (`scanner_results[].skipped: true` with a
+  `skip_reason`, `error` stays `null`), and the exit code is unaffected — a
+  missing optional binary cannot fail a run nobody asked it to gate.
 
 ### Exit Codes
 

--- a/src/envdrift/__init__.py
+++ b/src/envdrift/__init__.py
@@ -7,6 +7,8 @@ envdrift helps you:
 - Support dotenvx encryption for secure .env files
 """
 
+import logging
+
 try:
     from envdrift._version import __version__
 except ImportError:
@@ -26,5 +28,13 @@ __author__ = "Jainal Gosaliya"
 __email__ = "gosaliya.jainal@gmail.com"
 
 from envdrift.api import diff, init, validate
+
+# Standard library-package practice (Logging HOWTO): a NullHandler on the
+# package logger so library log records (e.g. the scan engine's skip warnings)
+# never leak to stderr through logging's lastResort handler when the
+# application configures no handlers — the CLI prints its own "Warning:" line,
+# so the leak duplicated it (#641). SDK users who configure logging still
+# receive every record.
+logging.getLogger("envdrift").addHandler(logging.NullHandler())
 
 __all__ = ["__version__", "diff", "init", "validate"]

--- a/src/envdrift/cli_commands/guard.py
+++ b/src/envdrift/cli_commands/guard.py
@@ -749,6 +749,28 @@ def guard(
     use_trivy_final = trivy if trivy is not None else "trivy" in guard_cfg.scanners
     use_infisical_final = infisical if infisical is not None else "infisical" in guard_cfg.scanners
 
+    # A scanner is EXPLICITLY selected when its CLI flag was passed or the
+    # config file itself lists it under [guard] scanners — not when it is
+    # active only via the built-in default set. Explicit scanners are retained
+    # fail-closed by the engine (missing binary + no auto-install => recorded
+    # error, exit 5); default-set ones are skipped with a visible warning so a
+    # missing optional binary cannot fail a run nobody asked it to gate (#641).
+    explicit_scanners = [
+        name
+        for flag, name in (
+            (gitleaks, "gitleaks"),
+            (trufflehog, "trufflehog"),
+            (detect_secrets, "detect-secrets"),
+            (kingfisher, "kingfisher"),
+            (git_secrets, "git-secrets"),
+            (talisman, "talisman"),
+            (trivy, "trivy"),
+            (infisical, "infisical"),
+        )
+        if flag is True
+        or (flag is None and guard_cfg.scanners_explicit and name in guard_cfg.scanners)
+    ]
+
     if native_only:
         use_gitleaks_final = False
         use_trufflehog_final = False
@@ -846,6 +868,7 @@ def guard(
         allowed_clear_files=allowed_clear_files,
         combined_files=combined_files,
         mapped_env_files=mapped_env_files,
+        explicit_scanners=explicit_scanners,
     )
 
     # Create output console (suppress colors in CI mode or JSON/SARIF output)
@@ -984,6 +1007,12 @@ def guard(
     finally:
         if staged_tmpdir is not None:
             staged_tmpdir.cleanup()
+
+    # A default-set scanner skipped for a missing binary (no auto-install) must
+    # be visible in every output mode; stderr keeps --json/--sarif stdout
+    # parseable (#641). Human mode additionally gets the Scanners Skipped panel.
+    for skip_record in (r for r in result.results if r.skipped):
+        _warn_stderr(skip_record.skip_reason or f"{skip_record.scanner_name} scanner was skipped")
 
     # One source of truth for the verdict (#478): compute the effective exit
     # code BEFORE rendering, so the machine-readable documents carry the exact

--- a/src/envdrift/config.py
+++ b/src/envdrift/config.py
@@ -156,6 +156,11 @@ class GuardConfig:
     """
 
     scanners: list[str] = field(default_factory=lambda: ["native", "gitleaks"])
+    # Whether the ``scanners`` list was written in the config file (as opposed
+    # to the built-in default set). Explicitly-listed scanners fail closed when
+    # their binary is unavailable; default-set ones are skipped with a visible
+    # warning instead (#641).
+    scanners_explicit: bool = False
     auto_install: bool = True
     include_history: bool = False
     check_entropy: bool | None = None  # None = entropy on env files only (default)
@@ -498,6 +503,7 @@ def _build_guard_config(guard_section: dict[str, Any]) -> GuardConfig:
         )
     return GuardConfig(
         scanners=scanners,
+        scanners_explicit="scanners" in guard_section,
         auto_install=guard_section.get("auto_install", True),
         include_history=guard_section.get("include_history", False),
         # Wrong-typed guard knobs are rejected here, at config-load time, with

--- a/src/envdrift/scanner/base.py
+++ b/src/envdrift/scanner/base.py
@@ -165,6 +165,10 @@ class ScanResult:
         files_scanned: Number of files that were scanned.
         duration_ms: Time taken to complete the scan in milliseconds.
         error: Error message if the scan failed, None otherwise.
+        skip_reason: Why the scanner was skipped without running, None when it
+            ran. A skipped scanner is distinct from both "ran clean" and
+            "failed": it carries no error (the run stays complete for exit-code
+            purposes) but must remain visible in every output mode (#641).
     """
 
     scanner_name: str
@@ -172,11 +176,17 @@ class ScanResult:
     files_scanned: int = 0
     duration_ms: int = 0
     error: str | None = None
+    skip_reason: str | None = None
 
     @property
     def success(self) -> bool:
         """Check if the scan completed without errors."""
         return self.error is None
+
+    @property
+    def skipped(self) -> bool:
+        """Whether this scanner was skipped without running (#641)."""
+        return self.skip_reason is not None
 
 
 @dataclass

--- a/src/envdrift/scanner/engine.py
+++ b/src/envdrift/scanner/engine.py
@@ -78,6 +78,13 @@ class GuardConfig:
         allowed_clear_files: Files that are intentionally unencrypted (from partial_encryption config).
         combined_files: Combined files from partial_encryption config (secret + clear merged).
         mapped_env_files: Custom env files from vault.sync mappings.
+        explicit_scanners: Names of scanners the caller EXPLICITLY requested
+            (CLI flag or a ``scanners`` list written in the config), as opposed
+            to scanners active only via the built-in default set. An explicit
+            scanner whose binary is unavailable with auto-install disabled is
+            retained fail-closed (recorded error, scan incomplete, exit 5); a
+            default-set one is skipped with a visible warning and a truthful
+            skip record instead of failing the run (#641).
     """
 
     use_native: bool = True
@@ -105,6 +112,7 @@ class GuardConfig:
         default_factory=list
     )  # Combined files from partial_encryption
     mapped_env_files: list[str] = field(default_factory=list)
+    explicit_scanners: list[str] = field(default_factory=list)
 
     @classmethod
     def from_dict(cls, config: dict) -> GuardConfig:
@@ -127,7 +135,10 @@ class GuardConfig:
         """
         guard_config = config.get("guard", {})
 
-        # Parse scanners list
+        # Parse scanners list. A ``scanners`` key written by the caller is an
+        # explicit selection (those scanners fail closed when unavailable);
+        # the fallback default set is not (#641).
+        scanners_configured = "scanners" in guard_config
         scanners = guard_config.get("scanners", ["native", "gitleaks"])
         if isinstance(scanners, str):
             scanners = [scanners]
@@ -172,6 +183,7 @@ class GuardConfig:
             allowed_clear_files=allowed_clear_files,
             combined_files=combined_files,
             mapped_env_files=mapped_env_files,
+            explicit_scanners=list(scanners) if scanners_configured else [],
         )
 
     @staticmethod
@@ -269,6 +281,12 @@ class ScanEngine:
         """
         self.config = config or GuardConfig()
         self.scanners: list[ScannerBackend] = []
+        # Skip records for default-set scanners whose binary is unavailable
+        # with auto-install disabled: they must stay visible in every output
+        # mode without failing the run the way an explicit selection does
+        # (#641). Included in every AggregatedScanResult this engine produces.
+        self.skipped_results: list[ScanResult] = []
+        self._explicit_scanner_names = frozenset(self.config.explicit_scanners)
 
         # Initialize centralized ignore filter for post-scan filtering.
         # User-configured ignore_paths suppress everything (explicit opt-out);
@@ -312,6 +330,32 @@ class ScanEngine:
                 error=str(e),
             )
 
+    def _retain_scanner(self, scanner: ScannerBackend) -> None:
+        """Retain an external scanner, or record a skip when it cannot run.
+
+        Explicitly-requested scanners (``config.explicit_scanners``) are always
+        retained: with the binary unavailable and auto-install disabled the
+        scan records their failure and the run exits 5 (scan incomplete), never
+        the all-clear 0. A scanner active only via the DEFAULT set is skipped
+        instead — with a warning and a truthful skip record — so a missing
+        optional binary cannot fail a run the user never asked it to gate
+        (#641).
+        """
+        if (
+            self.config.auto_install
+            or scanner.name in self._explicit_scanner_names
+            or scanner.is_installed()
+        ):
+            self.scanners.append(scanner)
+            return
+        reason = (
+            f"{scanner.name} is not installed and auto-install is disabled; "
+            "skipping this default-selection scanner. Install it or select it "
+            "explicitly to make the missing binary a blocking scan error."
+        )
+        logger.warning(reason)
+        self.skipped_results.append(ScanResult(scanner_name=scanner.name, skip_reason=reason))
+
     def _initialize_scanners(self) -> None:
         """Initialize scanner instances based on configuration."""
         # Native scanner (always available)
@@ -333,7 +377,7 @@ class ScanEngine:
                 from envdrift.scanner.gitleaks import GitleaksScanner
 
                 scanner = GitleaksScanner(auto_install=self.config.auto_install)
-                self.scanners.append(scanner)
+                self._retain_scanner(scanner)
             except ImportError:
                 pass  # Gitleaks not yet implemented
 
@@ -343,7 +387,7 @@ class ScanEngine:
                 from envdrift.scanner.trufflehog import TrufflehogScanner
 
                 scanner = TrufflehogScanner(auto_install=self.config.auto_install)
-                self.scanners.append(scanner)
+                self._retain_scanner(scanner)
             except ImportError:
                 pass  # Trufflehog not yet implemented
 
@@ -353,7 +397,7 @@ class ScanEngine:
                 from envdrift.scanner.detect_secrets import DetectSecretsScanner
 
                 scanner = DetectSecretsScanner(auto_install=self.config.auto_install)
-                self.scanners.append(scanner)
+                self._retain_scanner(scanner)
             except ImportError:
                 pass  # detect-secrets not yet implemented
 
@@ -370,7 +414,7 @@ class ScanEngine:
                     extract_archives=True,
                     jobs=1,  # deterministic results over speed
                 )
-                self.scanners.append(scanner)
+                self._retain_scanner(scanner)
             except ImportError:
                 logger.debug("Kingfisher scanner not available - module not found")
 
@@ -383,7 +427,7 @@ class ScanEngine:
                     auto_install=self.config.auto_install,
                     register_aws=True,  # Register AWS patterns by default
                 )
-                self.scanners.append(scanner)
+                self._retain_scanner(scanner)
             except ImportError:
                 logger.debug("git-secrets scanner not available - module not found")
 
@@ -393,7 +437,7 @@ class ScanEngine:
                 from envdrift.scanner.talisman import TalismanScanner
 
                 scanner = TalismanScanner(auto_install=self.config.auto_install)
-                self.scanners.append(scanner)
+                self._retain_scanner(scanner)
             except ImportError:
                 logger.debug("Talisman scanner not available - module not found")
 
@@ -403,7 +447,7 @@ class ScanEngine:
                 from envdrift.scanner.trivy import TrivyScanner
 
                 scanner = TrivyScanner(auto_install=self.config.auto_install)
-                self.scanners.append(scanner)
+                self._retain_scanner(scanner)
             except ImportError:
                 logger.debug("Trivy scanner not available - module not found")
 
@@ -413,7 +457,7 @@ class ScanEngine:
                 from envdrift.scanner.infisical import InfisicalScanner
 
                 scanner = InfisicalScanner(auto_install=self.config.auto_install)
-                self.scanners.append(scanner)
+                self._retain_scanner(scanner)
             except ImportError:
                 logger.debug("Infisical scanner not available - module not found")
 
@@ -454,12 +498,14 @@ class ScanEngine:
                 - total_duration_ms: total scan duration in milliseconds.
         """
         start_time = time.time()
-        results: list[ScanResult] = []
+        # Skip records ride along in ``results`` so every output mode sees a
+        # default-set scanner that was skipped for a missing binary (#641).
+        results: list[ScanResult] = list(self.skipped_results)
 
         # Early return if no scanners configured
         if not self.scanners:
             return AggregatedScanResult(
-                results=[],
+                results=results,
                 total_findings=0,
                 unique_findings=[],
                 scanners_used=[],

--- a/src/envdrift/scanner/engine.py
+++ b/src/envdrift/scanner/engine.py
@@ -333,8 +333,7 @@ class ScanEngine:
                 from envdrift.scanner.gitleaks import GitleaksScanner
 
                 scanner = GitleaksScanner(auto_install=self.config.auto_install)
-                if scanner.is_installed() or self.config.auto_install:
-                    self.scanners.append(scanner)
+                self.scanners.append(scanner)
             except ImportError:
                 pass  # Gitleaks not yet implemented
 
@@ -344,8 +343,7 @@ class ScanEngine:
                 from envdrift.scanner.trufflehog import TrufflehogScanner
 
                 scanner = TrufflehogScanner(auto_install=self.config.auto_install)
-                if scanner.is_installed() or self.config.auto_install:
-                    self.scanners.append(scanner)
+                self.scanners.append(scanner)
             except ImportError:
                 pass  # Trufflehog not yet implemented
 
@@ -355,8 +353,7 @@ class ScanEngine:
                 from envdrift.scanner.detect_secrets import DetectSecretsScanner
 
                 scanner = DetectSecretsScanner(auto_install=self.config.auto_install)
-                if scanner.is_installed() or self.config.auto_install:
-                    self.scanners.append(scanner)
+                self.scanners.append(scanner)
             except ImportError:
                 pass  # detect-secrets not yet implemented
 
@@ -373,8 +370,7 @@ class ScanEngine:
                     extract_archives=True,
                     jobs=1,  # deterministic results over speed
                 )
-                if scanner.is_installed() or self.config.auto_install:
-                    self.scanners.append(scanner)
+                self.scanners.append(scanner)
             except ImportError:
                 logger.debug("Kingfisher scanner not available - module not found")
 
@@ -387,8 +383,7 @@ class ScanEngine:
                     auto_install=self.config.auto_install,
                     register_aws=True,  # Register AWS patterns by default
                 )
-                if scanner.is_installed() or self.config.auto_install:
-                    self.scanners.append(scanner)
+                self.scanners.append(scanner)
             except ImportError:
                 logger.debug("git-secrets scanner not available - module not found")
 
@@ -398,8 +393,7 @@ class ScanEngine:
                 from envdrift.scanner.talisman import TalismanScanner
 
                 scanner = TalismanScanner(auto_install=self.config.auto_install)
-                if scanner.is_installed() or self.config.auto_install:
-                    self.scanners.append(scanner)
+                self.scanners.append(scanner)
             except ImportError:
                 logger.debug("Talisman scanner not available - module not found")
 
@@ -409,8 +403,7 @@ class ScanEngine:
                 from envdrift.scanner.trivy import TrivyScanner
 
                 scanner = TrivyScanner(auto_install=self.config.auto_install)
-                if scanner.is_installed() or self.config.auto_install:
-                    self.scanners.append(scanner)
+                self.scanners.append(scanner)
             except ImportError:
                 logger.debug("Trivy scanner not available - module not found")
 
@@ -420,8 +413,7 @@ class ScanEngine:
                 from envdrift.scanner.infisical import InfisicalScanner
 
                 scanner = InfisicalScanner(auto_install=self.config.auto_install)
-                if scanner.is_installed() or self.config.auto_install:
-                    self.scanners.append(scanner)
+                self.scanners.append(scanner)
             except ImportError:
                 logger.debug("Infisical scanner not available - module not found")
 

--- a/src/envdrift/scanner/gitleaks.py
+++ b/src/envdrift/scanner/gitleaks.py
@@ -35,6 +35,7 @@ from envdrift.scanner.base import (
     ScanResult,
 )
 from envdrift.scanner.patterns import hash_secret, redact_secret
+from envdrift.utils.git import get_git_root, has_git_head
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -77,6 +78,40 @@ class GitleaksNotFoundError(Exception):
     """Gitleaks binary not found."""
 
     pass
+
+
+def _git_history_target(path: Path) -> tuple[Path | None, str | None]:
+    """Resolve and validate the repository Gitleaks must scan for ``path``."""
+    git_root = get_git_root(path)
+    if git_root is None:
+        return None, f"Cannot scan Git history for {path}: not inside a Git repository"
+    if not has_git_head(git_root):
+        return None, f"Cannot scan Git history for {path}: the Git repository has no commits"
+    return git_root, None
+
+
+def _prepare_scan_targets(
+    paths: list[Path], *, include_git_history: bool
+) -> tuple[list[tuple[Path, Path]], str | None]:
+    """Build unique command targets and finding bases for one Gitleaks run."""
+    targets: list[tuple[Path, Path]] = []
+    seen_history_roots: set[Path] = set()
+    for path in paths:
+        if not path.exists():
+            continue
+        if not include_git_history:
+            targets.append((path, path))
+            continue
+
+        history_target, error = _git_history_target(path)
+        if error is not None or history_target is None:
+            return [], error or f"Cannot scan Git history for {path}"
+        resolved_target = history_target.resolve()
+        if resolved_target in seen_history_roots:
+            continue
+        seen_history_roots.add(resolved_target)
+        targets.append((history_target, history_target))
+    return targets, None
 
 
 class GitleaksInstallError(Exception):
@@ -496,6 +531,18 @@ class GitleaksScanner(ScannerBackend):
             ScanResult containing all findings.
         """
         start_time = time.time()
+        all_findings: list[ScanFinding] = []
+        total_files = 0
+
+        scan_targets, target_error = _prepare_scan_targets(
+            paths, include_git_history=include_git_history
+        )
+        if target_error is not None:
+            return ScanResult(
+                scanner_name=self.name,
+                error=target_error,
+                duration_ms=int((time.time() - start_time) * 1000),
+            )
 
         try:
             binary = self._find_binary()
@@ -506,35 +553,25 @@ class GitleaksScanner(ScannerBackend):
                 duration_ms=int((time.time() - start_time) * 1000),
             )
 
-        all_findings: list[ScanFinding] = []
-        total_files = 0
-
-        for path in paths:
-            if not path.exists():
-                continue
-
+        for scan_target, finding_base in scan_targets:
             # Create temp file for JSON output (gitleaks requires --report-path for JSON)
             with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as report_file:
                 report_path = Path(report_file.name)
 
             try:
                 # Build command
+                command = "git" if include_git_history else "dir"
                 args = [
                     str(binary),
-                    "detect",
-                    "--source",
-                    str(path),
+                    command,
                     "--report-format",
                     "json",
                     "--report-path",
                     str(report_path),
                     "--exit-code",
                     "0",  # Don't fail on findings, we handle that
+                    str(scan_target),
                 ]
-
-                # If not scanning git history, use --no-git
-                if not include_git_history:
-                    args.append("--no-git")
 
                 result = subprocess.run(  # nosec B603
                     args,
@@ -543,14 +580,14 @@ class GitleaksScanner(ScannerBackend):
                     encoding="utf-8",
                     errors="replace",
                     timeout=300,  # 5 minute timeout
-                    cwd=str(path) if path.is_dir() else str(path.parent),
+                    cwd=str(scan_target) if scan_target.is_dir() else str(scan_target.parent),
                 )
 
                 if result.returncode != 0:
                     error_msg = (
                         result.stderr.strip()
                         or result.stdout.strip()
-                        or f"gitleaks scan failed for {path} (exit code {result.returncode})"
+                        or f"gitleaks scan failed for {scan_target} (exit code {result.returncode})"
                     )
                     return ScanResult(
                         scanner_name=self.name,
@@ -570,7 +607,7 @@ class GitleaksScanner(ScannerBackend):
                             }
                             total_files += len(files_with_findings)
                             for item in findings_data:
-                                finding = self._parse_finding(item, path)
+                                finding = self._parse_finding(item, finding_base)
                                 if finding:
                                     all_findings.append(finding)
                     except json.JSONDecodeError:
@@ -581,7 +618,7 @@ class GitleaksScanner(ScannerBackend):
                 return ScanResult(
                     scanner_name=self.name,
                     findings=all_findings,
-                    error=f"Scan timed out for {path}",
+                    error=f"Scan timed out for {scan_target}",
                     duration_ms=int((time.time() - start_time) * 1000),
                 )
             except Exception as e:

--- a/src/envdrift/scanner/gitleaks.py
+++ b/src/envdrift/scanner/gitleaks.py
@@ -92,9 +92,17 @@ def _git_history_target(path: Path) -> tuple[Path | None, str | None]:
 
 def _prepare_scan_targets(
     paths: list[Path], *, include_git_history: bool
-) -> tuple[list[tuple[Path, Path]], str | None]:
-    """Build unique command targets and finding bases for one Gitleaks run."""
+) -> tuple[list[tuple[Path, Path]], list[str]]:
+    """Build unique command targets and finding bases for one Gitleaks run.
+
+    Preflight failures are collected PER TARGET: a path that cannot be
+    history-scanned (outside a git repository, or a repository with no
+    commits) yields a diagnostic without discarding the other, valid targets.
+    One bad argument used to abort the whole run — regardless of argument
+    order — and suppress the valid repository's history findings (#641).
+    """
     targets: list[tuple[Path, Path]] = []
+    errors: list[str] = []
     seen_history_roots: set[Path] = set()
     for path in paths:
         if not path.exists():
@@ -105,13 +113,20 @@ def _prepare_scan_targets(
 
         history_target, error = _git_history_target(path)
         if error is not None or history_target is None:
-            return [], error or f"Cannot scan Git history for {path}"
+            errors.append(error or f"Cannot scan Git history for {path}")
+            continue
         resolved_target = history_target.resolve()
         if resolved_target in seen_history_roots:
             continue
         seen_history_roots.add(resolved_target)
         targets.append((history_target, history_target))
-    return targets, None
+    return targets, errors
+
+
+def _combined_error(run_error: str | None, target_errors: list[str]) -> str | None:
+    """Join a run failure with the per-target preflight diagnostics (#641)."""
+    parts = ([run_error] if run_error else []) + target_errors
+    return "; ".join(parts) if parts else None
 
 
 class GitleaksInstallError(Exception):
@@ -534,13 +549,17 @@ class GitleaksScanner(ScannerBackend):
         all_findings: list[ScanFinding] = []
         total_files = 0
 
-        scan_targets, target_error = _prepare_scan_targets(
+        # Per-target preflight: invalid history targets become diagnostics,
+        # the valid ones still get scanned. Every returned ScanResult carries
+        # the diagnostics in its error so an invalid argument keeps the run
+        # truthfully incomplete without suppressing real findings (#641).
+        scan_targets, target_errors = _prepare_scan_targets(
             paths, include_git_history=include_git_history
         )
-        if target_error is not None:
+        if target_errors and not scan_targets:
             return ScanResult(
                 scanner_name=self.name,
-                error=target_error,
+                error=_combined_error(None, target_errors),
                 duration_ms=int((time.time() - start_time) * 1000),
             )
 
@@ -549,7 +568,7 @@ class GitleaksScanner(ScannerBackend):
         except GitleaksNotFoundError as e:
             return ScanResult(
                 scanner_name=self.name,
-                error=str(e),
+                error=_combined_error(str(e), target_errors),
                 duration_ms=int((time.time() - start_time) * 1000),
             )
 
@@ -592,7 +611,7 @@ class GitleaksScanner(ScannerBackend):
                     return ScanResult(
                         scanner_name=self.name,
                         findings=all_findings,
-                        error=error_msg,
+                        error=_combined_error(error_msg, target_errors),
                         duration_ms=int((time.time() - start_time) * 1000),
                     )
 
@@ -618,14 +637,14 @@ class GitleaksScanner(ScannerBackend):
                 return ScanResult(
                     scanner_name=self.name,
                     findings=all_findings,
-                    error=f"Scan timed out for {scan_target}",
+                    error=_combined_error(f"Scan timed out for {scan_target}", target_errors),
                     duration_ms=int((time.time() - start_time) * 1000),
                 )
             except Exception as e:
                 return ScanResult(
                     scanner_name=self.name,
                     findings=all_findings,
-                    error=str(e),
+                    error=_combined_error(str(e), target_errors),
                     duration_ms=int((time.time() - start_time) * 1000),
                 )
             finally:
@@ -637,6 +656,7 @@ class GitleaksScanner(ScannerBackend):
             scanner_name=self.name,
             findings=all_findings,
             files_scanned=total_files,
+            error=_combined_error(None, target_errors),
             duration_ms=int((time.time() - start_time) * 1000),
         )
 

--- a/src/envdrift/scanner/output.py
+++ b/src/envdrift/scanner/output.py
@@ -178,6 +178,20 @@ def format_rich(result: AggregatedScanResult, console: Console | None = None) ->
     if console is None:
         console = Console()
 
+    # Surface default-set scanners skipped for a missing binary: the skip must
+    # be visible in human output even though it does not fail the run (#641).
+    skipped = [r for r in result.results if r.skipped]
+    if skipped:
+        skip_lines = [f"[yellow]{r.scanner_name}[/yellow]: {r.skip_reason}" for r in skipped]
+        console.print(
+            Panel(
+                "\n".join(skip_lines),
+                title="Scanners Skipped",
+                border_style="yellow",
+            )
+        )
+        console.print()
+
     # Surface scanner errors prominently. Filter on the ScanResult.success
     # contract (error is not None), not truthiness, so an empty-string failure
     # still lands in the panel and matches the Scan Incomplete verdict (#478).
@@ -314,6 +328,11 @@ def format_json(result: AggregatedScanResult, exit_code: int | None = None) -> s
                 "files_scanned": r.files_scanned,
                 "duration_ms": r.duration_ms,
                 "error": r.error,
+                # A skipped scanner (default-set, binary unavailable, no
+                # auto-install) is distinguishable from both "ran clean"
+                # (skipped false, error null) and "failed" (error set) (#641).
+                "skipped": r.skipped,
+                "skip_reason": r.skip_reason,
             }
             for r in result.results
         ],

--- a/src/envdrift/scanner/output.py
+++ b/src/envdrift/scanner/output.py
@@ -80,6 +80,13 @@ def _severity_cell(finding: ScanFinding) -> Text:
     return cell
 
 
+def _display_location(finding: ScanFinding) -> str:
+    """Include short commit context when a finding came from Git history."""
+    if finding.commit_sha:
+        return f"{finding.commit_sha[:8]} @ {finding.location}"
+    return finding.location
+
+
 def _build_full_findings_table(findings: list[ScanFinding]) -> Table:
     """Findings table for non-interactive output (``guard --ci``, piped, hooks).
 
@@ -97,8 +104,30 @@ def _build_full_findings_table(findings: list[ScanFinding]) -> Table:
     table.add_column("Preview", style="dim", max_width=20)
     for f in findings:
         table.add_row(
-            _severity_cell(f), f.location, f.rule_id, f.description, f.secret_preview or "-"
+            _severity_cell(f),
+            _display_location(f),
+            f.rule_id,
+            f.description,
+            f.secret_preview or "-",
         )
+    return table
+
+
+def _build_log_findings_table(findings: list[ScanFinding]) -> Table:
+    """Stack complete finding records for narrow CI, pipes, and redirected logs."""
+    table = Table.grid(expand=True, padding=(0, 0))
+    table.add_column(overflow="fold")
+    for finding in findings:
+        record = Text()
+        record.append_text(_severity_cell(finding))
+        record.append(f"  {_display_location(finding)}", style="cyan")
+        record.append("\nRule: ", style="bold")
+        record.append(finding.rule_id, style="magenta")
+        record.append("\nDescription: ", style="bold")
+        record.append(finding.description)
+        record.append("\nPreview: ", style="bold")
+        record.append(finding.secret_preview or "-", style="dim")
+        table.add_row(record)
     return table
 
 
@@ -119,7 +148,7 @@ def _build_compact_findings_table(findings: list[ScanFinding], *, wide: bool) ->
     if wide:
         table.add_column("Preview", style="dim", no_wrap=True, max_width=14, overflow="ellipsis")
     for f in findings:
-        row: list[str | Text] = [_severity_cell(f), f.location]
+        row: list[str | Text] = [_severity_cell(f), _display_location(f)]
         if wide:
             row.append(f.rule_id)
         row.append(f.description)
@@ -130,10 +159,12 @@ def _build_compact_findings_table(findings: list[ScanFinding], *, wide: bool) ->
 
 
 def _build_findings_table(result: AggregatedScanResult, *, interactive: bool, wide: bool) -> Table:
-    """Dispatch to the full (non-interactive) or compact (interactive) table."""
+    """Dispatch to a layout that stays readable at the available width."""
     findings = sorted(result.unique_findings, key=lambda f: f.severity, reverse=True)
-    if not interactive:
+    if not interactive and wide:
         return _build_full_findings_table(findings)
+    if not interactive:
+        return _build_log_findings_table(findings)
     return _build_compact_findings_table(findings, wide=wide)
 
 
@@ -214,10 +245,9 @@ def format_rich(result: AggregatedScanResult, console: Console | None = None) ->
         )
     )
 
-    # Findings table. A non-interactive console (`guard --ci`, piped, redirected)
-    # keeps all columns (so CI logs retain the rule id + preview); an interactive
-    # terminal gets the compact, width-aware one (dropping the secondary columns
-    # only when genuinely narrow).
+    # Findings table. Narrow non-interactive output stacks complete records so
+    # no field is dropped or squeezed into an unreadable vertical stripe. Wide
+    # logs keep the full table; interactive terminals use the compact layout.
     console.print(
         _build_findings_table(
             result,
@@ -269,7 +299,8 @@ def format_json(result: AggregatedScanResult, exit_code: int | None = None) -> s
     data = {
         "findings": [f.to_dict() for f in result.unique_findings],
         "summary": {
-            "total": result.total_findings,
+            "total": len(result.unique_findings),
+            "total_raw": result.total_findings,
             "unique": len(result.unique_findings),
             "by_severity": {
                 severity.value: sum(1 for f in result.unique_findings if f.severity == severity)

--- a/src/envdrift/scanner/talisman.py
+++ b/src/envdrift/scanner/talisman.py
@@ -92,14 +92,20 @@ _NO_COMMIT_ERROR_MARKERS = (
 )
 
 
-def _friendly_execution_error(error: str, path: Path) -> str:
-    """Translate Talisman's opaque empty-repository failure when provable."""
+def _friendly_execution_error(error: str, display_path: Path, check_path: Path) -> str:
+    """Translate Talisman's opaque empty-repository failure when provable.
+
+    ``check_path`` locates the Git repository (the directory the scan ran
+    from); ``display_path`` is what the user asked to scan and is what the
+    message names — for a file target the two differ, and naming the parent
+    directory instead of the file misdirects the user (#641).
+    """
     normalized = error.lower()
     if any(marker in normalized for marker in _NO_COMMIT_ERROR_MARKERS):
-        git_root = get_git_root(path)
+        git_root = get_git_root(check_path)
         if git_root is not None and not has_git_head(git_root):
             return (
-                f"Talisman cannot scan {path}: the Git repository has no commits. "
+                f"Talisman cannot scan {display_path}: the Git repository has no commits. "
                 "Create an initial commit, then run the scan again."
             )
     return error
@@ -108,7 +114,7 @@ def _friendly_execution_error(error: str, path: Path) -> str:
 def _execution_error(result: subprocess.CompletedProcess[str], path: Path, work_dir: Path) -> str:
     """Build a useful error from a failed Talisman subprocess."""
     raw_error = result.stderr.strip() or result.stdout.strip() or f"talisman scan failed for {path}"
-    return _friendly_execution_error(raw_error, work_dir)
+    return _friendly_execution_error(raw_error, path, work_dir)
 
 
 def _extract_secret_from_message(message: str) -> str:

--- a/src/envdrift/scanner/talisman.py
+++ b/src/envdrift/scanner/talisman.py
@@ -35,6 +35,7 @@ from envdrift.scanner.base import (
 )
 from envdrift.scanner.patterns import hash_secret, redact_secret
 from envdrift.scanner.platform_utils import get_platform_info, get_venv_bin_dir
+from envdrift.utils.git import get_git_root, has_git_head
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -81,6 +82,27 @@ _TALISMAN_SECRET_MARKERS = (
     "secret pattern :",
     "secret pattern:",
 )
+
+_NO_COMMIT_ERROR_MARKERS = (
+    "exit status 128",
+    "bad revision",
+    "unknown revision",
+    "ambiguous argument 'head'",
+    "does not have any commits",
+)
+
+
+def _friendly_execution_error(error: str, path: Path) -> str:
+    """Translate Talisman's opaque empty-repository failure when provable."""
+    normalized = error.lower()
+    if any(marker in normalized for marker in _NO_COMMIT_ERROR_MARKERS):
+        git_root = get_git_root(path)
+        if git_root is not None and not has_git_head(git_root):
+            return (
+                f"Talisman cannot scan {path}: the Git repository has no commits. "
+                "Create an initial commit, then run the scan again."
+            )
+    return error
 
 
 def _extract_secret_from_message(message: str) -> str:
@@ -526,6 +548,7 @@ class TalismanScanner(ScannerBackend):
                         stderr_msg = result.stderr.strip()
                         stdout_msg = result.stdout.strip()
                         error_msg = stderr_msg or stdout_msg or f"talisman scan failed for {path}"
+                        error_msg = _friendly_execution_error(error_msg, work_dir)
                         return ScanResult(
                             scanner_name=self.name,
                             findings=all_findings,

--- a/src/envdrift/scanner/talisman.py
+++ b/src/envdrift/scanner/talisman.py
@@ -105,6 +105,12 @@ def _friendly_execution_error(error: str, path: Path) -> str:
     return error
 
 
+def _execution_error(result: subprocess.CompletedProcess[str], path: Path, work_dir: Path) -> str:
+    """Build a useful error from a failed Talisman subprocess."""
+    raw_error = result.stderr.strip() or result.stdout.strip() or f"talisman scan failed for {path}"
+    return _friendly_execution_error(raw_error, work_dir)
+
+
 def _extract_secret_from_message(message: str) -> str:
     """Recover the offending secret/content from a talisman failure message.
 
@@ -544,15 +550,10 @@ class TalismanScanner(ScannerBackend):
 
                     # Check for execution errors: non-zero exit code without valid report
                     if result.returncode != 0 and not report_found:
-                        # Prefer stderr over stdout for error messages
-                        stderr_msg = result.stderr.strip()
-                        stdout_msg = result.stdout.strip()
-                        error_msg = stderr_msg or stdout_msg or f"talisman scan failed for {path}"
-                        error_msg = _friendly_execution_error(error_msg, work_dir)
                         return ScanResult(
                             scanner_name=self.name,
                             findings=all_findings,
-                            error=error_msg,
+                            error=_execution_error(result, path, work_dir),
                             duration_ms=int((time.time() - start_time) * 1000),
                         )
 

--- a/src/envdrift/utils/git.py
+++ b/src/envdrift/utils/git.py
@@ -79,6 +79,32 @@ def get_git_root(path: Path) -> Path | None:
         return None
 
 
+def has_git_head(path: Path) -> bool:
+    """Return whether the repository containing ``path`` has a commit at HEAD.
+
+    An initialized repository with no commits is a valid work tree, but history
+    scanners cannot produce a trustworthy verdict for it. Keep that state
+    distinct from a repository with an empty *working tree*.
+    """
+    git_root = get_git_root(path)
+    if git_root is None:
+        return False
+
+    try:
+        result = subprocess.run(  # nosec B603, B607
+            ["git", "rev-parse", "--verify", "HEAD^{commit}"],
+            cwd=str(git_root),
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="surrogateescape",
+            timeout=10,
+        )
+        return result.returncode == 0
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return False
+
+
 def get_file_from_git(file_path: Path, ref: str = "HEAD") -> str | None:
     """
     Get the content of a file from a git ref (default: HEAD).

--- a/tests/scanner/test_engine.py
+++ b/tests/scanner/test_engine.py
@@ -448,8 +448,10 @@ class TestScanEngine:
 
         assert names == ["gitleaks"]
 
-    def test_engine_keeps_uninstalled_when_auto_install_disabled(self, monkeypatch, tmp_path):
-        """A requested unavailable scanner must run and report its failure."""
+    def test_engine_keeps_explicit_uninstalled_when_auto_install_disabled(
+        self, monkeypatch, tmp_path
+    ):
+        """An EXPLICITLY requested unavailable scanner must run and report its failure."""
 
         def make_scanner(class_name: str, scanner_name: str):
             def __init__(self, auto_install: bool = True):
@@ -494,6 +496,7 @@ class TestScanEngine:
             use_trufflehog=False,
             use_detect_secrets=False,
             auto_install=False,
+            explicit_scanners=["gitleaks"],
         )
         engine = ScanEngine(config)
         assert [scanner.name for scanner in engine.scanners] == ["gitleaks"]
@@ -504,6 +507,82 @@ class TestScanEngine:
         assert result.has_errors is True
         assert result.results[0].error == "gitleaks not found"
         assert result.exit_code == 5
+
+    def test_engine_skips_default_uninstalled_when_auto_install_disabled(
+        self, monkeypatch, tmp_path
+    ):
+        """A DEFAULT-set unavailable scanner is skipped with a truthful record (#641).
+
+        Same setup as the explicit test above, but without ``explicit_scanners``:
+        the run must stay green (exit 0) and the skip must be visible in the
+        aggregated results, distinguishable from both "ran clean" and "failed".
+        """
+
+        def make_scanner(class_name: str, scanner_name: str):
+            def __init__(self, auto_install: bool = True):
+                self._installed = False
+
+            def name(self) -> str:
+                return scanner_name
+
+            def description(self) -> str:
+                return f"{scanner_name} scanner"
+
+            def is_installed(self) -> bool:
+                return self._installed
+
+            def scan(
+                self,
+                paths: list[Path],
+                include_git_history: bool = False,
+            ) -> ScanResult:  # pragma: no cover - a skipped scanner must not run
+                raise AssertionError("a skipped scanner must never be scanned")
+
+            return type(
+                class_name,
+                (ScannerBackend,),
+                {
+                    "__init__": __init__,
+                    "name": property(name),
+                    "description": property(description),
+                    "is_installed": is_installed,
+                    "scan": scan,
+                },
+            )
+
+        gitleaks_mod = SimpleNamespace(
+            GitleaksScanner=make_scanner("GitleaksScanner", "gitleaks"),
+        )
+        monkeypatch.setitem(sys.modules, "envdrift.scanner.gitleaks", gitleaks_mod)
+
+        config = GuardConfig(
+            use_native=False,
+            use_gitleaks=True,
+            use_trufflehog=False,
+            use_detect_secrets=False,
+            auto_install=False,
+        )
+        engine = ScanEngine(config)
+        assert engine.scanners == []
+
+        result = engine.scan([tmp_path])
+
+        assert result.scanners_used == []
+        assert result.has_errors is False
+        assert result.exit_code == 0
+        skipped = [r for r in result.results if r.skipped]
+        assert [r.scanner_name for r in skipped] == ["gitleaks"]
+        assert skipped[0].error is None
+        assert skipped[0].skip_reason is not None
+        assert "not installed" in skipped[0].skip_reason
+
+    def test_from_dict_marks_configured_scanners_explicit(self):
+        """A ``scanners`` list written by the caller is an explicit selection (#641)."""
+        config = GuardConfig.from_dict({"guard": {"scanners": ["native", "gitleaks"]}})
+        assert config.explicit_scanners == ["native", "gitleaks"]
+
+        default_config = GuardConfig.from_dict({})
+        assert default_config.explicit_scanners == []
 
     def test_scan_empty_directory(self, tmp_path: Path):
         """Test scanning an empty directory."""

--- a/tests/scanner/test_engine.py
+++ b/tests/scanner/test_engine.py
@@ -448,8 +448,8 @@ class TestScanEngine:
 
         assert names == ["gitleaks"]
 
-    def test_engine_skips_uninstalled_when_auto_install_disabled(self, monkeypatch):
-        """Disabled auto-install skips unavailable scanners."""
+    def test_engine_keeps_uninstalled_when_auto_install_disabled(self, monkeypatch, tmp_path):
+        """A requested unavailable scanner must run and report its failure."""
 
         def make_scanner(class_name: str, scanner_name: str):
             def __init__(self, auto_install: bool = True):
@@ -469,7 +469,7 @@ class TestScanEngine:
                 paths: list[Path],
                 include_git_history: bool = False,
             ) -> ScanResult:
-                return ScanResult(scanner_name=self.name)
+                return ScanResult(scanner_name=self.name, error="gitleaks not found")
 
             return type(
                 class_name,
@@ -496,7 +496,14 @@ class TestScanEngine:
             auto_install=False,
         )
         engine = ScanEngine(config)
-        assert engine.scanners == []
+        assert [scanner.name for scanner in engine.scanners] == ["gitleaks"]
+
+        result = engine.scan([tmp_path])
+
+        assert result.scanners_used == ["gitleaks"]
+        assert result.has_errors is True
+        assert result.results[0].error == "gitleaks not found"
+        assert result.exit_code == 5
 
     def test_scan_empty_directory(self, tmp_path: Path):
         """Test scanning an empty directory."""

--- a/tests/scanner/test_gitleaks.py
+++ b/tests/scanner/test_gitleaks.py
@@ -24,6 +24,7 @@ from envdrift.scanner.gitleaks import (
     GitleaksScanner,
     _get_gitleaks_download_urls,
     _get_gitleaks_version,
+    _git_history_target,
     get_gitleaks_path,
     get_platform_info,
     get_venv_bin_dir,
@@ -499,6 +500,50 @@ class TestFindingParsing:
         assert finding.rule_id == "gitleaks-unknown"
 
 
+class TestGitHistoryTarget:
+    """Tests for the preflight that prevents false-clean history scans."""
+
+    def test_rejects_non_git_directory(self, tmp_path: Path):
+        target, error = _git_history_target(tmp_path)
+
+        assert target is None
+        assert error is not None
+        assert "not inside a Git repository" in error
+
+    def test_rejects_repository_without_commits(self, tmp_path: Path):
+        subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True, check=True)
+
+        target, error = _git_history_target(tmp_path)
+
+        assert target is None
+        assert error is not None
+        assert "has no commits" in error
+
+    def test_returns_repository_root(self, tmp_path: Path):
+        subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True, check=True)
+        subprocess.run(
+            [
+                "git",
+                "-c",
+                "user.name=Test",
+                "-c",
+                "user.email=test@example.com",
+                "commit",
+                "--allow-empty",
+                "-m",
+                "initial",
+            ],
+            cwd=tmp_path,
+            capture_output=True,
+            check=True,
+        )
+
+        target, error = _git_history_target(tmp_path)
+
+        assert target == tmp_path.resolve()
+        assert error is None
+
+
 class TestGitleaksScanExecution:
     """Tests for gitleaks scan execution with mocked subprocess."""
 
@@ -587,26 +632,69 @@ class TestGitleaksScanExecution:
         assert "timed out" in result.error.lower()
 
     def test_scan_with_git_history_flag(self, mock_scanner: GitleaksScanner, tmp_path: Path):
-        """Test that scan passes correct args for git history scan."""
+        """Git history uses the modern positional ``gitleaks git`` command."""
         with patch.object(mock_scanner, "_find_binary", return_value=mock_scanner._binary_path):
-            with patch("subprocess.run") as mock_run:
-                mock_run.return_value = MagicMock(stdout="[]", stderr="", returncode=0)
-                mock_scanner.scan([tmp_path], include_git_history=True)
+            with patch(
+                "envdrift.scanner.gitleaks._git_history_target",
+                return_value=(tmp_path, None),
+            ):
+                with patch("subprocess.run") as mock_run:
+                    mock_run.return_value = MagicMock(stdout="[]", stderr="", returncode=0)
+                    mock_scanner.scan([tmp_path], include_git_history=True)
 
-        # Check that --no-git was NOT passed
         call_args = mock_run.call_args[0][0]
-        assert "--no-git" not in call_args
+        assert call_args[1] == "git"
+        assert "detect" not in call_args
+        assert "--source" not in call_args
+        assert call_args[-1] == str(tmp_path)
 
     def test_scan_without_git_history_flag(self, mock_scanner: GitleaksScanner, tmp_path: Path):
-        """Test that scan passes --no-git when not scanning history."""
+        """Working-tree scans use the modern positional ``gitleaks dir`` command."""
         with patch.object(mock_scanner, "_find_binary", return_value=mock_scanner._binary_path):
             with patch("subprocess.run") as mock_run:
                 mock_run.return_value = MagicMock(stdout="[]", stderr="", returncode=0)
                 mock_scanner.scan([tmp_path], include_git_history=False)
 
-        # Check that --no-git WAS passed
         call_args = mock_run.call_args[0][0]
-        assert "--no-git" in call_args
+        assert call_args[1] == "dir"
+        assert "detect" not in call_args
+        assert "--no-git" not in call_args
+        assert call_args[-1] == str(tmp_path)
+
+    def test_history_outside_git_is_an_error(self, mock_scanner: GitleaksScanner, tmp_path: Path):
+        """A zero-commit Gitleaks false pass must not become a clean result."""
+        with patch.object(mock_scanner, "_find_binary", return_value=mock_scanner._binary_path):
+            with patch(
+                "envdrift.scanner.gitleaks._git_history_target",
+                return_value=(None, "not inside a Git repository"),
+            ):
+                with patch("subprocess.run") as mock_run:
+                    result = mock_scanner.scan([tmp_path], include_git_history=True)
+
+        assert result.success is False
+        assert result.error is not None
+        assert "not inside a Git repository" in result.error
+        mock_run.assert_not_called()
+
+    def test_history_scans_each_repository_once(
+        self, mock_scanner: GitleaksScanner, tmp_path: Path
+    ):
+        """Multiple requested paths in one repository do not duplicate the scan."""
+        first = tmp_path / "first"
+        second = tmp_path / "second"
+        first.mkdir()
+        second.mkdir()
+        with patch.object(mock_scanner, "_find_binary", return_value=mock_scanner._binary_path):
+            with patch(
+                "envdrift.scanner.gitleaks._git_history_target",
+                return_value=(tmp_path, None),
+            ):
+                with patch("subprocess.run") as mock_run:
+                    mock_run.return_value = MagicMock(stdout="[]", stderr="", returncode=0)
+                    result = mock_scanner.scan([first, second], include_git_history=True)
+
+        assert result.success is True
+        mock_run.assert_called_once()
 
     def test_scan_multiple_paths(self, mock_scanner: GitleaksScanner, tmp_path: Path):
         """Test scanning multiple paths."""
@@ -749,3 +837,31 @@ class TestGitleaksIntegration:
         assert result.success is True
         # gitleaks should detect this pattern
         # Note: may or may not trigger depending on gitleaks config
+
+    def test_scan_git_history_uses_modern_command_and_reports_commit(self, tmp_path: Path):
+        """The real Gitleaks 8.x history path returns commit-attributed findings."""
+        token = "ghp_" + "016C7eX9bQ2vYwN3kLmZpRtUaScDfGhJkL01"
+        subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True, check=True)
+        (tmp_path / "secret.txt").write_text(f"TOKEN={token}\n", encoding="utf-8")
+        subprocess.run(["git", "add", "secret.txt"], cwd=tmp_path, capture_output=True, check=True)
+        subprocess.run(
+            [
+                "git",
+                "-c",
+                "user.name=Test",
+                "-c",
+                "user.email=test@example.com",
+                "commit",
+                "-m",
+                "add secret",
+            ],
+            cwd=tmp_path,
+            capture_output=True,
+            check=True,
+        )
+
+        result = GitleaksScanner(auto_install=False).scan([tmp_path], include_git_history=True)
+
+        assert result.success is True, result.error
+        assert result.findings
+        assert all(finding.commit_sha for finding in result.findings)

--- a/tests/scanner/test_gitleaks.py
+++ b/tests/scanner/test_gitleaks.py
@@ -24,7 +24,6 @@ from envdrift.scanner.gitleaks import (
     GitleaksScanner,
     _get_gitleaks_download_urls,
     _get_gitleaks_version,
-    _git_history_target,
     get_gitleaks_path,
     get_platform_info,
     get_venv_bin_dir,
@@ -500,50 +499,6 @@ class TestFindingParsing:
         assert finding.rule_id == "gitleaks-unknown"
 
 
-class TestGitHistoryTarget:
-    """Tests for the preflight that prevents false-clean history scans."""
-
-    def test_rejects_non_git_directory(self, tmp_path: Path):
-        target, error = _git_history_target(tmp_path)
-
-        assert target is None
-        assert error is not None
-        assert "not inside a Git repository" in error
-
-    def test_rejects_repository_without_commits(self, tmp_path: Path):
-        subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True, check=True)
-
-        target, error = _git_history_target(tmp_path)
-
-        assert target is None
-        assert error is not None
-        assert "has no commits" in error
-
-    def test_returns_repository_root(self, tmp_path: Path):
-        subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True, check=True)
-        subprocess.run(
-            [
-                "git",
-                "-c",
-                "user.name=Test",
-                "-c",
-                "user.email=test@example.com",
-                "commit",
-                "--allow-empty",
-                "-m",
-                "initial",
-            ],
-            cwd=tmp_path,
-            capture_output=True,
-            check=True,
-        )
-
-        target, error = _git_history_target(tmp_path)
-
-        assert target == tmp_path.resolve()
-        assert error is None
-
-
 class TestGitleaksScanExecution:
     """Tests for gitleaks scan execution with mocked subprocess."""
 
@@ -630,71 +585,6 @@ class TestGitleaksScanExecution:
         assert result.success is False
         assert result.error is not None
         assert "timed out" in result.error.lower()
-
-    def test_scan_with_git_history_flag(self, mock_scanner: GitleaksScanner, tmp_path: Path):
-        """Git history uses the modern positional ``gitleaks git`` command."""
-        with patch.object(mock_scanner, "_find_binary", return_value=mock_scanner._binary_path):
-            with patch(
-                "envdrift.scanner.gitleaks._git_history_target",
-                return_value=(tmp_path, None),
-            ):
-                with patch("subprocess.run") as mock_run:
-                    mock_run.return_value = MagicMock(stdout="[]", stderr="", returncode=0)
-                    mock_scanner.scan([tmp_path], include_git_history=True)
-
-        call_args = mock_run.call_args[0][0]
-        assert call_args[1] == "git"
-        assert "detect" not in call_args
-        assert "--source" not in call_args
-        assert call_args[-1] == str(tmp_path)
-
-    def test_scan_without_git_history_flag(self, mock_scanner: GitleaksScanner, tmp_path: Path):
-        """Working-tree scans use the modern positional ``gitleaks dir`` command."""
-        with patch.object(mock_scanner, "_find_binary", return_value=mock_scanner._binary_path):
-            with patch("subprocess.run") as mock_run:
-                mock_run.return_value = MagicMock(stdout="[]", stderr="", returncode=0)
-                mock_scanner.scan([tmp_path], include_git_history=False)
-
-        call_args = mock_run.call_args[0][0]
-        assert call_args[1] == "dir"
-        assert "detect" not in call_args
-        assert "--no-git" not in call_args
-        assert call_args[-1] == str(tmp_path)
-
-    def test_history_outside_git_is_an_error(self, mock_scanner: GitleaksScanner, tmp_path: Path):
-        """A zero-commit Gitleaks false pass must not become a clean result."""
-        with patch.object(mock_scanner, "_find_binary", return_value=mock_scanner._binary_path):
-            with patch(
-                "envdrift.scanner.gitleaks._git_history_target",
-                return_value=(None, "not inside a Git repository"),
-            ):
-                with patch("subprocess.run") as mock_run:
-                    result = mock_scanner.scan([tmp_path], include_git_history=True)
-
-        assert result.success is False
-        assert result.error is not None
-        assert "not inside a Git repository" in result.error
-        mock_run.assert_not_called()
-
-    def test_history_scans_each_repository_once(
-        self, mock_scanner: GitleaksScanner, tmp_path: Path
-    ):
-        """Multiple requested paths in one repository do not duplicate the scan."""
-        first = tmp_path / "first"
-        second = tmp_path / "second"
-        first.mkdir()
-        second.mkdir()
-        with patch.object(mock_scanner, "_find_binary", return_value=mock_scanner._binary_path):
-            with patch(
-                "envdrift.scanner.gitleaks._git_history_target",
-                return_value=(tmp_path, None),
-            ):
-                with patch("subprocess.run") as mock_run:
-                    mock_run.return_value = MagicMock(stdout="[]", stderr="", returncode=0)
-                    result = mock_scanner.scan([first, second], include_git_history=True)
-
-        assert result.success is True
-        mock_run.assert_called_once()
 
     def test_scan_multiple_paths(self, mock_scanner: GitleaksScanner, tmp_path: Path):
         """Test scanning multiple paths."""
@@ -837,31 +727,3 @@ class TestGitleaksIntegration:
         assert result.success is True
         # gitleaks should detect this pattern
         # Note: may or may not trigger depending on gitleaks config
-
-    def test_scan_git_history_uses_modern_command_and_reports_commit(self, tmp_path: Path):
-        """The real Gitleaks 8.x history path returns commit-attributed findings."""
-        token = "ghp_" + "016C7eX9bQ2vYwN3kLmZpRtUaScDfGhJkL01"
-        subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True, check=True)
-        (tmp_path / "secret.txt").write_text(f"TOKEN={token}\n", encoding="utf-8")
-        subprocess.run(["git", "add", "secret.txt"], cwd=tmp_path, capture_output=True, check=True)
-        subprocess.run(
-            [
-                "git",
-                "-c",
-                "user.name=Test",
-                "-c",
-                "user.email=test@example.com",
-                "commit",
-                "-m",
-                "add secret",
-            ],
-            cwd=tmp_path,
-            capture_output=True,
-            check=True,
-        )
-
-        result = GitleaksScanner(auto_install=False).scan([tmp_path], include_git_history=True)
-
-        assert result.success is True, result.error
-        assert result.findings
-        assert all(finding.commit_sha for finding in result.findings)

--- a/tests/scanner/test_gitleaks_reporting.py
+++ b/tests/scanner/test_gitleaks_reporting.py
@@ -8,7 +8,11 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from envdrift.scanner.gitleaks import GitleaksScanner, _git_history_target
+from envdrift.scanner.gitleaks import (
+    GitleaksScanner,
+    _git_history_target,
+    _prepare_scan_targets,
+)
 
 
 @pytest.fixture
@@ -68,6 +72,44 @@ class TestGitHistoryTarget:
 
         assert target == tmp_path.resolve()
         assert error is None
+
+
+class TestMixedHistoryTargets:
+    """A preflight-failing target must not discard the valid targets (#641).
+
+    One non-git argument used to abort the whole prepared-target list —
+    regardless of argument order — silently suppressing the valid repository's
+    history findings while the run reported only the preflight error.
+    """
+
+    @pytest.mark.parametrize("invalid_first", [True, False], ids=["invalid-first", "valid-first"])
+    def test_valid_repository_survives_invalid_sibling(self, tmp_path: Path, invalid_first: bool):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _initial_commit(repo)
+        plain = tmp_path / "plain"
+        plain.mkdir()
+        paths = [plain, repo] if invalid_first else [repo, plain]
+
+        targets, errors = _prepare_scan_targets(paths, include_git_history=True)
+
+        assert [target for target, _base in targets] == [repo.resolve()]
+        assert len(errors) == 1
+        assert "not inside a Git repository" in errors[0]
+
+    def test_all_invalid_targets_yield_only_diagnostics(self, tmp_path: Path):
+        plain = tmp_path / "plain"
+        plain.mkdir()
+        no_commits = tmp_path / "empty-repo"
+        no_commits.mkdir()
+        subprocess.run(["git", "init"], cwd=no_commits, capture_output=True, check=True)
+
+        targets, errors = _prepare_scan_targets([plain, no_commits], include_git_history=True)
+
+        assert targets == []
+        assert len(errors) == 2
+        assert "not inside a Git repository" in errors[0]
+        assert "has no commits" in errors[1]
 
 
 @pytest.mark.parametrize(
@@ -170,3 +212,48 @@ def test_real_history_reports_commit(tmp_path: Path):
     assert result.success is True, result.error
     assert result.findings
     assert all(finding.commit_sha for finding in result.findings)
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not GitleaksScanner(auto_install=False).is_installed(),
+    reason="gitleaks not installed",
+)
+@pytest.mark.parametrize("invalid_first", [True, False], ids=["invalid-first", "valid-first"])
+def test_real_mixed_targets_keep_history_finding(tmp_path: Path, invalid_first: bool):
+    """A non-git sibling target must not suppress the repository's history
+    finding — in either argument order (#641).
+
+    The secret exists ONLY in git history (committed, then ``git rm``-ed), so a
+    surviving finding proves the history scan of the valid repository ran. The
+    invalid target stays visible as a per-target diagnostic in ``error``.
+    """
+    token = "ghp_" + "wJ2mX8kQ4tR7nY0cV5bL1sD3fG6hP9zA2eU4"
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _initial_commit(repo)
+    (repo / "creds.py").write_text(f'token = "{token}"\n', encoding="utf-8")
+    git_identity = ["git", "-c", "user.name=Test", "-c", "user.email=test@example.com"]
+    subprocess.run(["git", "add", "creds.py"], cwd=repo, capture_output=True, check=True)
+    subprocess.run(
+        [*git_identity, "commit", "-m", "add creds"], cwd=repo, capture_output=True, check=True
+    )
+    subprocess.run(["git", "rm", "-q", "creds.py"], cwd=repo, capture_output=True, check=True)
+    subprocess.run(
+        [*git_identity, "commit", "-m", "remove creds"], cwd=repo, capture_output=True, check=True
+    )
+
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    (plain / "readme.txt").write_text("nothing secret here\n", encoding="utf-8")
+    paths = [plain, repo] if invalid_first else [repo, plain]
+
+    result = GitleaksScanner(auto_install=False).scan(paths, include_git_history=True)
+
+    assert result.findings, (
+        "the valid repository's history finding must survive an invalid sibling target"
+    )
+    assert all(finding.commit_sha for finding in result.findings)
+    assert result.error is not None
+    assert "not inside a Git repository" in result.error
+    assert result.success is False, "the invalid target keeps the run truthfully incomplete"

--- a/tests/scanner/test_gitleaks_reporting.py
+++ b/tests/scanner/test_gitleaks_reporting.py
@@ -1,0 +1,172 @@
+"""Gitleaks execution-truthfulness and history-reporting regressions."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from envdrift.scanner.gitleaks import GitleaksScanner, _git_history_target
+
+
+@pytest.fixture
+def mock_scanner(tmp_path: Path) -> GitleaksScanner:
+    """Create a scanner with a harmless stand-in binary."""
+    scanner = GitleaksScanner(auto_install=False)
+    binary_path = tmp_path / "gitleaks"
+    binary_path.touch()
+    scanner._binary_path = binary_path
+    return scanner
+
+
+def _initial_commit(path: Path) -> None:
+    """Initialize ``path`` and create an empty commit without global Git config."""
+    subprocess.run(["git", "init"], cwd=path, capture_output=True, check=True)
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.name=Test",
+            "-c",
+            "user.email=test@example.com",
+            "commit",
+            "--allow-empty",
+            "-m",
+            "initial",
+        ],
+        cwd=path,
+        capture_output=True,
+        check=True,
+    )
+
+
+class TestGitHistoryTarget:
+    """The preflight prevents false-clean Gitleaks history scans."""
+
+    def test_rejects_non_git_directory(self, tmp_path: Path):
+        target, error = _git_history_target(tmp_path)
+
+        assert target is None
+        assert error is not None
+        assert "not inside a Git repository" in error
+
+    def test_rejects_repository_without_commits(self, tmp_path: Path):
+        subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True, check=True)
+
+        target, error = _git_history_target(tmp_path)
+
+        assert target is None
+        assert error is not None
+        assert "has no commits" in error
+
+    def test_returns_repository_root(self, tmp_path: Path):
+        _initial_commit(tmp_path)
+
+        target, error = _git_history_target(tmp_path)
+
+        assert target == tmp_path.resolve()
+        assert error is None
+
+
+@pytest.mark.parametrize(
+    ("include_history", "command"),
+    [(True, "git"), (False, "dir")],
+    ids=["history", "working-tree"],
+)
+def test_scan_uses_modern_positional_command(
+    mock_scanner: GitleaksScanner,
+    tmp_path: Path,
+    include_history: bool,
+    command: str,
+):
+    """Gitleaks 8.x uses ``git``/``dir`` instead of deprecated ``detect``."""
+    with (
+        patch.object(mock_scanner, "_find_binary", return_value=mock_scanner._binary_path),
+        patch(
+            "envdrift.scanner.gitleaks._git_history_target",
+            return_value=(tmp_path, None),
+        ),
+        patch("subprocess.run") as mock_run,
+    ):
+        mock_run.return_value = MagicMock(stdout="[]", stderr="", returncode=0)
+        mock_scanner.scan([tmp_path], include_git_history=include_history)
+
+    call_args = mock_run.call_args[0][0]
+    assert call_args[1] == command
+    assert "detect" not in call_args
+    assert "--source" not in call_args
+    assert "--no-git" not in call_args
+    assert call_args[-1] == str(tmp_path)
+
+
+def test_history_outside_git_is_an_error(mock_scanner: GitleaksScanner, tmp_path: Path):
+    """A zero-commit Gitleaks false pass must not become a clean result."""
+    with (
+        patch(
+            "envdrift.scanner.gitleaks._git_history_target",
+            return_value=(None, "not inside a Git repository"),
+        ),
+        patch("subprocess.run") as mock_run,
+    ):
+        result = mock_scanner.scan([tmp_path], include_git_history=True)
+
+    assert result.success is False
+    assert result.error is not None
+    assert "not inside a Git repository" in result.error
+    mock_run.assert_not_called()
+
+
+def test_history_scans_each_repository_once(mock_scanner: GitleaksScanner, tmp_path: Path):
+    """Multiple requested paths in one repository do not duplicate the scan."""
+    paths = [tmp_path / "first", tmp_path / "second"]
+    for path in paths:
+        path.mkdir()
+    with (
+        patch.object(mock_scanner, "_find_binary", return_value=mock_scanner._binary_path),
+        patch(
+            "envdrift.scanner.gitleaks._git_history_target",
+            return_value=(tmp_path, None),
+        ),
+        patch("subprocess.run") as mock_run,
+    ):
+        mock_run.return_value = MagicMock(stdout="[]", stderr="", returncode=0)
+        result = mock_scanner.scan(paths, include_git_history=True)
+
+    assert result.success is True
+    mock_run.assert_called_once()
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not GitleaksScanner(auto_install=False).is_installed(),
+    reason="gitleaks not installed",
+)
+def test_real_history_reports_commit(tmp_path: Path):
+    """The real Gitleaks 8.x history path returns commit-attributed findings."""
+    token = "ghp_" + "016C7eX9bQ2vYwN3kLmZpRtUaScDfGhJkL01"
+    _initial_commit(tmp_path)
+    (tmp_path / "secret.txt").write_text(f"TOKEN={token}\n", encoding="utf-8")
+    subprocess.run(["git", "add", "secret.txt"], cwd=tmp_path, capture_output=True, check=True)
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.name=Test",
+            "-c",
+            "user.email=test@example.com",
+            "commit",
+            "-m",
+            "add secret",
+        ],
+        cwd=tmp_path,
+        capture_output=True,
+        check=True,
+    )
+
+    result = GitleaksScanner(auto_install=False).scan([tmp_path], include_git_history=True)
+
+    assert result.success is True, result.error
+    assert result.findings
+    assert all(finding.commit_sha for finding in result.findings)

--- a/tests/scanner/test_output.py
+++ b/tests/scanner/test_output.py
@@ -177,6 +177,39 @@ class TestJsonOutput:
         assert len(data["scanner_results"]) == 2
         assert data["scanner_results"][1]["error"] == "boom"
 
+    def test_json_skip_record_distinguishable_from_clean_and_failed(self):
+        """A skipped default scanner is neither "ran clean" nor "failed" (#641)."""
+        result = AggregatedScanResult(
+            results=[
+                ScanResult(scanner_name="native", files_scanned=3, duration_ms=10),
+                ScanResult(
+                    scanner_name="gitleaks",
+                    skip_reason="gitleaks is not installed and auto-install is disabled",
+                ),
+            ],
+            total_findings=0,
+            unique_findings=[],
+            scanners_used=["native"],
+            total_duration_ms=15,
+        )
+        data = json.loads(format_json(result))
+
+        native, gitleaks = data["scanner_results"]
+        assert native == {
+            "name": "native",
+            "files_scanned": 3,
+            "duration_ms": 10,
+            "error": None,
+            "skipped": False,
+            "skip_reason": None,
+        }
+        assert gitleaks["skipped"] is True
+        assert gitleaks["error"] is None
+        assert "not installed" in gitleaks["skip_reason"]
+        # A skip is not a failure: the run stays a clean exit 0.
+        assert data["exit_code"] == 0
+        assert data["has_blocking_findings"] is False
+
 
 class TestSarifOutput:
     """Tests for SARIF output formatter."""
@@ -546,6 +579,33 @@ class TestRichOutput:
         assert "native" in output
         assert "boom" in output
         assert "Files with findings" in output
+
+    def test_format_rich_shows_skipped_scanners_without_failing_the_run(self):
+        """A skipped default scanner renders its own panel, run stays clean (#641)."""
+        result = AggregatedScanResult(
+            results=[
+                ScanResult(scanner_name="native", files_scanned=1, duration_ms=5),
+                ScanResult(
+                    scanner_name="gitleaks",
+                    skip_reason="gitleaks is not installed and auto-install is disabled",
+                ),
+            ],
+            total_findings=0,
+            unique_findings=[],
+            scanners_used=["native"],
+            total_duration_ms=5,
+        )
+        console = Console(record=True, force_terminal=True, width=120)
+        format_rich(result, console)
+        output = " ".join(console.export_text().split())
+
+        assert "Scanners Skipped" in output
+        assert "gitleaks" in output
+        assert "not installed" in output
+        # The skip must not masquerade as a failure or block the clean verdict.
+        assert "Scanner Errors" not in output
+        assert "No secrets or policy violations detected" in output
+        assert result.exit_code == 0
 
 
 def _aggregate(findings: list[ScanFinding]) -> AggregatedScanResult:

--- a/tests/scanner/test_output.py
+++ b/tests/scanner/test_output.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
@@ -102,6 +103,18 @@ class TestJsonOutput:
         assert by_severity["critical"] == 1
         assert by_severity["high"] == 1
         assert by_severity["medium"] == 0
+
+    def test_json_total_matches_reported_findings_and_preserves_raw_count(
+        self, sample_result: AggregatedScanResult
+    ):
+        """Filtered/deduplicated JSON totals agree with findings and severities."""
+        sample_result.total_findings = 7
+
+        data = json.loads(format_json(sample_result))
+
+        assert data["summary"]["total"] == len(data["findings"]) == 2
+        assert sum(data["summary"]["by_severity"].values()) == 2
+        assert data["summary"]["total_raw"] == 7
 
     def test_json_has_exit_code(self, sample_result: AggregatedScanResult):
         """Test that JSON contains exit code."""
@@ -440,15 +453,40 @@ class TestRichOutput:
         assert "AKIA1234" not in out  # Preview column dropped at narrow width
 
     def test_format_rich_non_interactive_keeps_all_columns(self):
-        """A non-interactive console (`guard --ci`, piped) keeps all five columns
-        even at the default width 80, so CI logs retain rule_id and the preview.
-        """
+        """Narrow CI/piped output stacks fields without dropping any data."""
         console = Console(record=True, force_terminal=False, no_color=True, width=80)
         format_rich(self._aws_finding_result(), console)
         out = console.export_text()
 
         assert "aws-access-key-id" in out  # Rule kept for CI triage
         assert "AKIA1234" in out  # Preview kept
+
+    def test_format_rich_very_narrow_non_interactive_is_readable(self):
+        """A 40-column redirected log uses complete stacked records, not stripes."""
+        console = Console(record=True, force_terminal=False, no_color=True, width=40)
+        format_rich(self._aws_finding_result(), console)
+        out = console.export_text()
+        normalized = " ".join(out.split())
+
+        assert "CRIT" in out
+        assert "Rule:" in out
+        assert "aws-access-key-id" in out
+        assert "Description:" in out
+        assert "version control history" in normalized
+        assert "Preview:" in out
+        assert "AKIA1234" in out
+
+    def test_format_rich_shows_history_commit(self):
+        """Human output identifies the commit that contains a historical leak."""
+        result = self._aws_finding_result()
+        result.unique_findings[0] = replace(
+            result.unique_findings[0], commit_sha="abcdef1234567890"
+        )
+        console = Console(record=True, force_terminal=False, no_color=True, width=80)
+
+        format_rich(result, console)
+
+        assert "abcdef12 @ .env" in console.export_text()
 
     def test_format_rich_wide_terminal_shows_all_columns(self):
         """Wide terminal shows the Rule and Preview columns too."""
@@ -462,16 +500,18 @@ class TestRichOutput:
 
     def test_build_findings_table_column_count(self):
         """Interactive narrow drops to 3 columns; interactive wide keeps 5;
-        non-interactive (CI/logs) always keeps all 5 regardless of width."""
+        narrow non-interactive logs stack one complete record per row."""
         from envdrift.scanner.output import _build_findings_table
 
         r = self._aws_finding_result()
         narrow = _build_findings_table(r, interactive=True, wide=False)
         wide = _build_findings_table(r, interactive=True, wide=True)
         ci = _build_findings_table(r, interactive=False, wide=False)
+        wide_ci = _build_findings_table(r, interactive=False, wide=True)
         assert len(narrow.columns) == 3
         assert len(wide.columns) == 5
-        assert len(ci.columns) == 5  # non-interactive keeps all columns even when narrow
+        assert len(ci.columns) == 1
+        assert len(wide_ci.columns) == 5
 
     def test_format_rich_threshold_99_is_narrow(self):
         """Width 99 (one below the threshold) drops the secondary Preview column."""

--- a/tests/scanner/test_talisman.py
+++ b/tests/scanner/test_talisman.py
@@ -460,6 +460,29 @@ class TestTalismanScanExecution:
         assert "talisman: command not found or invalid flag" in result.error
         assert result.success is False
 
+    def test_scan_explains_empty_repository_failure(
+        self, mock_scanner: TalismanScanner, tmp_path: Path
+    ):
+        """Talisman's opaque exit-status 128 names the actionable Git state."""
+        with (
+            patch.object(mock_scanner, "_find_binary", return_value=mock_scanner._binary_path),
+            patch("envdrift.scanner.talisman.get_git_root", return_value=tmp_path),
+            patch("envdrift.scanner.talisman.has_git_head", return_value=False),
+            patch("subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = MagicMock(
+                stdout="",
+                stderr="Error while scanning: exit status 128",
+                returncode=1,
+            )
+            result = mock_scanner.scan([tmp_path])
+
+        assert result.success is False
+        assert result.error is not None
+        assert "Git repository has no commits" in result.error
+        assert "initial commit" in result.error
+        assert "exit status 128" not in result.error
+
     def test_scan_ignores_nonzero_exit_with_valid_report(
         self, mock_scanner: TalismanScanner, tmp_path: Path
     ):

--- a/tests/scanner/test_talisman.py
+++ b/tests/scanner/test_talisman.py
@@ -483,6 +483,38 @@ class TestTalismanScanExecution:
         assert "initial commit" in result.error
         assert "exit status 128" not in result.error
 
+    def test_empty_repository_failure_names_the_file_target(
+        self, mock_scanner: TalismanScanner, tmp_path: Path
+    ):
+        """The no-commits diagnostic names the FILE the user asked to scan.
+
+        For a file target Talisman runs from the file's parent directory; the
+        Git-state check must use that directory (the check path), but the
+        message must name the requested file (the display path), not its
+        parent (#641).
+        """
+        target = tmp_path / ".env"
+        target.write_text("KEY=value\n", encoding="utf-8")
+        with (
+            patch.object(mock_scanner, "_find_binary", return_value=mock_scanner._binary_path),
+            patch("envdrift.scanner.talisman.get_git_root", return_value=tmp_path) as mock_root,
+            patch("envdrift.scanner.talisman.has_git_head", return_value=False),
+            patch("subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = MagicMock(
+                stdout="",
+                stderr="Error while scanning: exit status 128",
+                returncode=1,
+            )
+            result = mock_scanner.scan([target])
+
+        assert result.success is False
+        assert result.error is not None
+        assert f"Talisman cannot scan {target}:" in result.error
+        assert f"cannot scan {tmp_path}:" not in result.error
+        # Git context still resolves from the directory the scan ran in.
+        mock_root.assert_called_once_with(tmp_path)
+
     def test_scan_ignores_nonzero_exit_with_valid_report(
         self, mock_scanner: TalismanScanner, tmp_path: Path
     ):

--- a/tests/unit/coverage/test_cov_scanner_engine.py
+++ b/tests/unit/coverage/test_cov_scanner_engine.py
@@ -92,12 +92,18 @@ OPTIONAL_SCANNERS = {
 }
 
 
-def _off_config(*, enable: str | None = None, auto_install: bool = True) -> GuardConfig:
+def _off_config(
+    *,
+    enable: str | None = None,
+    auto_install: bool = True,
+    explicit_scanners: list[str] | None = None,
+) -> GuardConfig:
     """Build a GuardConfig with every scanner disabled, optionally enabling one.
 
     Args:
         enable: Name of a single ``use_*`` flag to turn on, or None for all off.
         auto_install: Value for the auto_install flag.
+        explicit_scanners: Scanner names the caller explicitly requested (#641).
     """
     flags = {
         "use_native": False,
@@ -123,6 +129,7 @@ def _off_config(*, enable: str | None = None, auto_install: bool = True) -> Guar
         use_trivy=flags["use_trivy"],
         use_infisical=flags["use_infisical"],
         auto_install=auto_install,
+        explicit_scanners=explicit_scanners or [],
     )
 
 
@@ -169,17 +176,38 @@ class TestOptionalScannerInitialization:
         ("flag", "module_path", "cls_attr", "scanner_name"),
         [(flag, mod, cls, name) for flag, (mod, cls, name) in OPTIONAL_SCANNERS.items()],
     )
-    def test_selected_scanner_is_retained_when_binary_is_unavailable(
+    def test_explicit_scanner_is_retained_when_binary_is_unavailable(
         self, flag, module_path, cls_attr, scanner_name, monkeypatch
     ):
-        """Disabled auto-install must not silently drop a selected scanner."""
+        """Disabled auto-install must not silently drop an EXPLICIT scanner."""
+        fake_cls = _make_scanner_class(cls_attr, scanner_name, installed=False)
+        fake_module = SimpleNamespace(**{cls_attr: fake_cls})
+        monkeypatch.setitem(sys.modules, module_path, fake_module)
+
+        engine = ScanEngine(
+            _off_config(enable=flag, auto_install=False, explicit_scanners=[scanner_name])
+        )
+
+        assert [scanner.name for scanner in engine.scanners] == [scanner_name]
+
+    @pytest.mark.parametrize(
+        ("flag", "module_path", "cls_attr", "scanner_name"),
+        [(flag, mod, cls, name) for flag, (mod, cls, name) in OPTIONAL_SCANNERS.items()],
+    )
+    def test_default_scanner_is_skipped_when_binary_is_unavailable(
+        self, flag, module_path, cls_attr, scanner_name, monkeypatch
+    ):
+        """A DEFAULT-set unavailable scanner is skipped with a truthful record (#641)."""
         fake_cls = _make_scanner_class(cls_attr, scanner_name, installed=False)
         fake_module = SimpleNamespace(**{cls_attr: fake_cls})
         monkeypatch.setitem(sys.modules, module_path, fake_module)
 
         engine = ScanEngine(_off_config(enable=flag, auto_install=False))
 
-        assert [scanner.name for scanner in engine.scanners] == [scanner_name]
+        assert engine.scanners == []
+        assert [r.scanner_name for r in engine.skipped_results] == [scanner_name]
+        assert engine.skipped_results[0].skipped is True
+        assert engine.skipped_results[0].error is None
 
     def test_kingfisher_receives_expected_kwargs(self, monkeypatch):
         """Kingfisher is constructed with its rich set of detection kwargs."""

--- a/tests/unit/coverage/test_cov_scanner_engine.py
+++ b/tests/unit/coverage/test_cov_scanner_engine.py
@@ -2,8 +2,8 @@
 
 These tests target previously-uncovered branches in ScanEngine:
 - ImportError fall-throughs for every optional external scanner.
-- Successful initialization of the kingfisher/git-secrets/talisman/trivy/
-  infisical scanners (the constructor + is_installed branches).
+- Successful initialization of every selected external scanner, including the
+  unavailable-binary path that must remain visible in scan results.
 - The scan() early-return when no scanners are configured.
 - The scan() loop's future.result() exception handler and progress callback.
 - The per-scanner timeout branch.
@@ -31,12 +31,12 @@ from envdrift.scanner.base import (
 from envdrift.scanner.engine import GuardConfig, ScanEngine
 
 
-def _make_scanner_class(class_name: str, scanner_name: str):
+def _make_scanner_class(class_name: str, scanner_name: str, *, installed: bool = True):
     """Build a concrete ScannerBackend subclass that records its kwargs."""
 
     def __init__(self, **kwargs) -> None:
         self.init_kwargs = kwargs
-        self._installed = True
+        self._installed = installed
 
     def name(self) -> str:
         return scanner_name
@@ -164,6 +164,22 @@ class TestOptionalScannerInitialization:
 
         names = [s.name for s in engine.scanners]
         assert names == [scanner_name]
+
+    @pytest.mark.parametrize(
+        ("flag", "module_path", "cls_attr", "scanner_name"),
+        [(flag, mod, cls, name) for flag, (mod, cls, name) in OPTIONAL_SCANNERS.items()],
+    )
+    def test_selected_scanner_is_retained_when_binary_is_unavailable(
+        self, flag, module_path, cls_attr, scanner_name, monkeypatch
+    ):
+        """Disabled auto-install must not silently drop a selected scanner."""
+        fake_cls = _make_scanner_class(cls_attr, scanner_name, installed=False)
+        fake_module = SimpleNamespace(**{cls_attr: fake_cls})
+        monkeypatch.setitem(sys.modules, module_path, fake_module)
+
+        engine = ScanEngine(_off_config(enable=flag, auto_install=False))
+
+        assert [scanner.name for scanner in engine.scanners] == [scanner_name]
 
     def test_kingfisher_receives_expected_kwargs(self, monkeypatch):
         """Kingfisher is constructed with its rich set of detection kwargs."""

--- a/tests/unit/test_git_utils.py
+++ b/tests/unit/test_git_utils.py
@@ -12,6 +12,7 @@ from envdrift.utils.git import (
     ensure_gitignore_entries,
     get_file_from_git,
     get_git_root,
+    has_git_head,
     is_file_modified,
     is_file_tracked,
     is_git_repo,
@@ -52,6 +53,39 @@ class TestGetGitRoot:
     def test_returns_none_for_non_git_directory(self, tmp_path: Path):
         """Should return None when not in a git repo."""
         assert get_git_root(tmp_path) is None
+
+
+class TestHasGitHead:
+    """Tests for distinguishing an initialized repository from committed history."""
+
+    def test_false_for_repository_without_commits(self, tmp_path: Path):
+        subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True, check=True)
+
+        assert has_git_head(tmp_path) is False
+
+    def test_true_after_initial_commit(self, tmp_path: Path):
+        subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True, check=True)
+        subprocess.run(
+            [
+                "git",
+                "-c",
+                "user.name=Test",
+                "-c",
+                "user.email=test@example.com",
+                "commit",
+                "--allow-empty",
+                "-m",
+                "initial",
+            ],
+            cwd=tmp_path,
+            capture_output=True,
+            check=True,
+        )
+
+        assert has_git_head(tmp_path) is True
+
+    def test_false_outside_repository(self, tmp_path: Path):
+        assert has_git_head(tmp_path) is False
 
 
 class TestIsFileTracked:

--- a/tests/unit/test_guard_exit_truthfulness.py
+++ b/tests/unit/test_guard_exit_truthfulness.py
@@ -522,6 +522,96 @@ class TestGitDiscoveryErrorMachineOutput:
         assert "Invalid env_file" in payload["error"]
 
 
+# --- 7. missing binary: default-set scanner skips, explicit selection fails -----
+
+
+class TestDefaultScannerUnavailableSkips:
+    """#641: gitleaks in the DEFAULT set with a missing binary and auto-install
+    disabled must SKIP with a visible warning (exit unaffected); the same
+    scanner selected EXPLICITLY (CLI flag or a config ``scanners`` list) keeps
+    failing closed with the scan-incomplete exit 5.
+
+    These drive the real engine and the real native scanner; only the binary
+    discovery environment (``PATH`` / ``VIRTUAL_ENV``) is pointed away from any
+    gitleaks binary, so the missing-binary condition is real, not mocked.
+    """
+
+    @staticmethod
+    def _hide_gitleaks(monkeypatch, tmp_path: Path) -> Path:
+        """Make gitleaks genuinely undiscoverable, return a clean scan dir."""
+        empty_bin = tmp_path / "empty-bin"
+        empty_bin.mkdir()
+        monkeypatch.setenv("PATH", str(empty_bin))
+        monkeypatch.setenv("VIRTUAL_ENV", str(tmp_path / "no-venv"))
+        monkeypatch.chdir(tmp_path)
+        scan_dir = tmp_path / "clean"
+        scan_dir.mkdir()
+        (scan_dir / "note.txt").write_text("nothing secret here\n", encoding="utf-8")
+        return scan_dir
+
+    def test_default_set_missing_binary_skips_and_exits_zero(self, tmp_path: Path, monkeypatch):
+        scan_dir = self._hide_gitleaks(monkeypatch, tmp_path)
+        result = runner.invoke(app, ["guard", "--no-auto-install", "--json", str(scan_dir)])
+        assert result.exit_code == 0, (
+            f"a skipped default scanner must not fail the run, got {result.exit_code}\n"
+            f"{result.output}"
+        )
+        payload = json.loads(result.stdout)
+        assert payload["exit_code"] == 0
+        assert payload["has_blocking_findings"] is False
+        gitleaks = next(r for r in payload["scanner_results"] if r["name"] == "gitleaks")
+        assert gitleaks["skipped"] is True
+        assert gitleaks["error"] is None
+        assert gitleaks["skip_reason"] is not None
+        assert "not installed" in gitleaks["skip_reason"]
+        assert "gitleaks" not in payload["scanners"], "a skipped scanner did not run"
+        assert "skipping this default-selection scanner" in result.stderr, (
+            "the skip must be visible on stderr in machine modes"
+        )
+
+    def test_default_set_missing_binary_skip_visible_in_human_output(
+        self, tmp_path: Path, monkeypatch
+    ):
+        scan_dir = self._hide_gitleaks(monkeypatch, tmp_path)
+        result = runner.invoke(app, ["guard", "--no-auto-install", str(scan_dir)])
+        assert result.exit_code == 0
+        normalized = " ".join(result.output.split())
+        assert "Scanners Skipped" in normalized
+        assert "gitleaks" in normalized
+        assert "No secrets or policy violations detected" in normalized
+
+    def test_explicit_flag_missing_binary_fails_closed(self, tmp_path: Path, monkeypatch):
+        scan_dir = self._hide_gitleaks(monkeypatch, tmp_path)
+        result = runner.invoke(
+            app, ["guard", "--gitleaks", "--no-auto-install", "--json", str(scan_dir)]
+        )
+        assert result.exit_code == 5, (
+            f"an explicit scanner with a missing binary must exit 5, got {result.exit_code}\n"
+            f"{result.output}"
+        )
+        payload = json.loads(result.stdout)
+        assert payload["exit_code"] == 5
+        gitleaks = next(r for r in payload["scanner_results"] if r["name"] == "gitleaks")
+        assert gitleaks["skipped"] is False
+        assert gitleaks["error"], "the explicit scanner's failure must be recorded"
+
+    def test_config_listed_scanner_missing_binary_fails_closed(self, tmp_path: Path, monkeypatch):
+        """A ``scanners`` list written in envdrift.toml is an explicit selection."""
+        scan_dir = self._hide_gitleaks(monkeypatch, tmp_path)
+        (tmp_path / "envdrift.toml").write_text(
+            '[guard]\nscanners = ["native", "gitleaks"]\n', encoding="utf-8"
+        )
+        result = runner.invoke(app, ["guard", "--no-auto-install", "--json", str(scan_dir)])
+        assert result.exit_code == 5, (
+            f"a config-listed scanner with a missing binary must exit 5, got {result.exit_code}\n"
+            f"{result.output}"
+        )
+        payload = json.loads(result.stdout)
+        gitleaks = next(r for r in payload["scanner_results"] if r["name"] == "gitleaks")
+        assert gitleaks["skipped"] is False
+        assert gitleaks["error"]
+
+
 # --- pure exit-semantics unit coverage on the single source of truth ------------
 
 

--- a/tests/unit/test_guard_exit_truthfulness.py
+++ b/tests/unit/test_guard_exit_truthfulness.py
@@ -24,6 +24,10 @@ engine's *result* (the behavior under test is the CLI's exit-code derivation).
 from __future__ import annotations
 
 import json
+import os
+import shutil
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -579,6 +583,55 @@ class TestDefaultScannerUnavailableSkips:
         assert "Scanners Skipped" in normalized
         assert "gitleaks" in normalized
         assert "No secrets or policy violations detected" in normalized
+
+    def test_default_set_skip_reason_prints_once_on_stderr(self, tmp_path: Path):
+        """#641 review: the skip reason must reach stderr exactly once — the
+        CLI's ``Warning:`` line. Before the package-level ``NullHandler``, the
+        engine's ``logger.warning`` ALSO escaped through logging's lastResort
+        handler (the CLI configures no handlers), printing the same reason
+        twice. Runs the real CLI as a subprocess: an in-process runner shares
+        the test session's logging state and cannot prove the leak.
+        """
+        git = shutil.which("git")
+        if git is None:
+            pytest.skip("git is required to build the clean scan repo")
+        # A PATH dir exposing ONLY git, so gitleaks is genuinely undiscoverable
+        # while repo discovery inside the CLI subprocess still works.
+        bin_dir = tmp_path / "git-only-bin"
+        bin_dir.mkdir()
+        try:
+            (bin_dir / Path(git).name).symlink_to(git)
+        except (OSError, NotImplementedError):
+            pytest.skip("cannot build a git-only PATH dir on this platform")
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        subprocess.run([git, "init", "--quiet", str(repo)], check=True, timeout=60)
+        (repo / "note.txt").write_text("nothing secret here\n", encoding="utf-8")
+
+        env = os.environ.copy()
+        env.pop("FORCE_COLOR", None)  # keep --json machine-readable under CI
+        env["PATH"] = str(bin_dir)
+        env["VIRTUAL_ENV"] = str(tmp_path / "no-venv")  # defeat venv-bin discovery
+        result = subprocess.run(
+            [sys.executable, "-m", "envdrift", "guard", "--no-auto-install", "--json", "."],
+            cwd=repo,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=180,
+        )
+
+        assert result.returncode == 0, result.stderr
+        payload = json.loads(result.stdout)  # stdout must stay parseable JSON
+        gitleaks = next(r for r in payload["scanner_results"] if r["name"] == "gitleaks")
+        assert gitleaks["skipped"] is True
+        reason = gitleaks["skip_reason"]
+        assert reason and "skipping this default-selection scanner" in reason
+        assert result.stderr.count(reason) == 1, (
+            f"the skip reason must print exactly once on stderr:\n{result.stderr}"
+        )
+        reason_lines = [line for line in result.stderr.splitlines() if reason in line]
+        assert reason_lines == [f"Warning: {reason}"], result.stderr
 
     def test_explicit_flag_missing_binary_fails_closed(self, tmp_path: Path, monkeypatch):
         scan_dir = self._hide_gitleaks(monkeypatch, tmp_path)


### PR DESCRIPTION
## Summary

- retain every explicitly selected external scanner so a missing binary is reported as an incomplete scan instead of disappearing from human and JSON output
- preflight Git history, migrate Gitleaks 8.x from deprecated `detect` to positional `git`/`dir`, scan each repository once, and expose short commit context in human findings
- keep narrow non-TTY/CI output readable with complete stacked records, make JSON totals coherent while preserving `total_raw`, and translate Talismans empty-repository exit 128 into an actionable diagnostic

This is consolidation item 2 from #441. The umbrella remains open for unrelated vault, sync, parser, agent, and CLI findings.

## Dogfood evidence

- unavailable requested TruffleHog with `--no-auto-install --json`: now lists `trufflehog`, reports the missing binary, and exits 5; previously it listed only native and exited 0
- real Gitleaks 8.30 history outside Git: now reports `not inside a Git repository` and exits 5; previously Gitleaks logged 0 commits/no leaks and envdrift exited 0
- real Gitleaks 8.30 history over a committed GitHub-token-shaped fixture returns a finding with its commit SHA
- real 40-column `--ci` output shows complete stacked severity/location/rule/description/preview records instead of collapsed vertical columns

## Validation

- `uv sync --all-extras`
- `uv run ruff check src tests`
- `uv run ruff format --check .`
- `uv run pyrefly check`
- `uv run bandit -r src -c pyproject.toml`
- `uv run pytest -q tests/scanner`: 758 passed, 4 existing skips
- focused scanner/orchestration regression set: 299 passed, 1 existing skip
- guard/external-binary integration set: 39 passed, 6 environment-gated skips
- `uv run pytest -q -m "not integration"`: 3,381 passed, 6 existing skips, 544 deselected, 1 existing XPASS
- full integration lane: 390 passed, 152 environment-gated skips; the only two failures are untouched dotenvx recipe tests because this workstation has global dotenvx 1.70.0 while `constants.json` pins 2.6.0 (bare-key fallback and removed `rotate` behavior differ)

No test was skipped, xfailed, or weakened by this PR.

Refs #441

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jainal09/envdrift/pull/641?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of unavailable external scanners when automatic installation is disabled.
  * Explicitly selected scanners now report failures and incomplete scans, while default scanners are skipped with visible warnings.
  * JSON output now distinguishes skipped scanners and includes raw finding totals.
  * Enhanced Git-history scanning and clearer guidance for empty repositories.

* **Documentation**
  * Clarified scanner selection behavior and exit code guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes scanner results report incomplete runs more accurately. The main changes are:

- Default missing external scanners are skipped instead of failing the run.
- Explicitly selected missing scanners still fail closed.
- Gitleaks history scans keep valid repositories when sibling paths fail preflight.
- Human and JSON output now show skipped scanners and clearer totals.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/envdrift/scanner/engine.py | Adds scanner retention and skip handling for explicit and default scanner selections. |
| src/envdrift/cli_commands/guard.py | Passes explicit scanner selections into the engine and reports skipped scanners on stderr. |
| src/envdrift/scanner/gitleaks.py | Preflights history targets per path and preserves valid repository scans with diagnostics. |
| src/envdrift/scanner/output.py | Adds skipped-scanner fields to JSON and visible skipped-scanner output for human runs. |
| src/envdrift/config.py | Tracks whether scanner selection came from an explicit config list. |

<sub>Reviews (4): Last reviewed commit: ["fix(scanner): single skip warning and pr..."](https://github.com/jainal09/envdrift/commit/2343a606d7368c7fb7668efc49c3d0d50838b75b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43606105)</sub>

<!-- /greptile_comment -->