### PR TITLE
fix(encrypt): exclude SOPS metadata from plaintext count in --check

### DIFF
--- a/docs/cli/encrypt.md
+++ b/docs/cli/encrypt.md
@@ -216,6 +216,13 @@ The `--check` option provides a detailed report:
 | Plaintext Secrets | Variables detected as secrets but not encrypted        |
 | Warnings          | Additional concerns (e.g., credentials in URLs)        |
 
+Encryption-tool bookkeeping is excluded from the counts: dotenvx's plaintext
+`DOTENV_PUBLIC_KEY_*` line and SOPS's `sops_*` metadata trailer (`sops_version=`,
+`sops_lastmodified=`, the recipient key, `sops_mac=`, …) are neither encrypted nor
+plaintext variables, so a fully SOPS-encrypted file reports as fully encrypted. A real
+user variable that merely starts with `sops_` (e.g. `sops_token`) is still counted
+and scanned.
+
 ## How dotenvx Encryption Works
 
 envdrift integrates with [dotenvx](https://dotenvx.com/) for encryption:

--- a/src/envdrift/core/encryption.py
+++ b/src/envdrift/core/encryption.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from envdrift.core.parser import EncryptionStatus, EnvFile
+from envdrift.core.partial_encryption import _is_sops_metadata_key
 from envdrift.core.schema import SchemaMetadata
 from envdrift.encryption.sops import SOPSEncryptionBackend
 
@@ -185,6 +186,17 @@ class EncryptionDetector:
             # ``DOTENV_PUBLIC_KEY_<ENV>_SECRET``, which matches the ``*_SECRET``
             # pattern and would otherwise be reported as a plaintext secret.
             if is_dotenvx_public_key_var(var_name):
+                continue
+            # SOPS appends a flat metadata trailer to an encrypted dotenv file
+            # (sops_version= / sops_lastmodified= / the recipient public key /
+            # sops_mac=). It is bookkeeping, not user data: the plaintext entries
+            # are not secrets and sops_mac's ciphertext is not a user variable, so
+            # none of it may sway the encrypted/plaintext tallies — counting it
+            # reported a fully SOPS-encrypted file as "partially encrypted" in
+            # `encrypt --check`. Matches the EXACT metadata key family shared with
+            # partial_encryption (#416), so a user var merely named sops_token=…
+            # is still scanned.
+            if _is_sops_metadata_key(var_name):
                 continue
             if env_var.encryption_status == EncryptionStatus.ENCRYPTED:
                 report.encrypted_vars.add(var_name)

--- a/src/envdrift/core/encryption.py
+++ b/src/envdrift/core/encryption.py
@@ -194,8 +194,10 @@ class EncryptionDetector:
             # none of it may sway the encrypted/plaintext tallies — counting it
             # reported a fully SOPS-encrypted file as "partially encrypted" in
             # `encrypt --check`. Matches the EXACT metadata key family shared with
-            # partial_encryption (#416), so a user var merely named sops_token=…
-            # is still scanned.
+            # partial_encryption (#416) — the fixed scalars plus the
+            # double-underscore-flattened key-group entries — so a user var merely
+            # named sops_token=…, or even one literally named sops_age=…, is
+            # still scanned.
             if _is_sops_metadata_key(var_name):
                 continue
             if env_var.encryption_status == EncryptionStatus.ENCRYPTED:

--- a/src/envdrift/core/partial_encryption.py
+++ b/src/envdrift/core/partial_encryption.py
@@ -64,9 +64,11 @@ _DOTENVX_PUBLIC_KEY_PREFIX = "DOTENV_PUBLIC_KEY"
 # scan, silently dropping a genuine secret. The flat scalar keys are a fixed set
 # (``sops_version``/``sops_mac``/``sops_lastmodified``/the *_suffix/*_regex
 # toggles/``sops_mac_only_encrypted``/``sops_shamir_threshold``); the key-group
-# providers (age/pgp/kms/gcp_kms/azure_kv/hc_vault) appear as nested
-# ``sops_<provider>__list_N__map_M_<field>`` (or flat ``sops_<provider>_<field>``)
-# entries. Only a key in that family is treated as bookkeeping.
+# providers (age/pgp/kms/gcp_kms/azure_kv/hc_vault) appear ONLY as
+# double-underscore-flattened ``sops_<provider>__list_N__map_M_<field>`` entries
+# (verified against the pinned sops binary — it never emits a bare
+# ``sops_<provider>`` nor a single-underscore ``sops_<provider>_<field>`` key).
+# Only a key in that family is treated as bookkeeping.
 _SOPS_METADATA_SCALAR_KEYS = frozenset(
     {
         "sops_version",
@@ -83,20 +85,23 @@ _SOPS_METADATA_SCALAR_KEYS = frozenset(
     }
 )
 # Key-group providers SOPS records (one nested block per recipient). In dotenv
-# output these flatten to ``sops_<provider>__list_N__map_M_<field>`` (or, for a
-# single flat field, ``sops_<provider>_<field>``). Anchor on the provider token
-# so ``sops_age…`` matches but ``sops_agent`` / ``sops_token`` do not.
-_SOPS_METADATA_GROUP_KEY = re.compile(r"^sops_(?:age|pgp|kms|gcp_kms|azure_kv|hc_vault)(?:_|__|$)")
+# output these ALWAYS flatten with a double-underscore separator
+# (``sops_<provider>__list_N__map_M_<field>``), so require ``__`` right after
+# the provider token: a user var literally named ``sops_age`` or a lookalike
+# such as ``sops_age_backup`` / ``sops_agent`` / ``sops_token`` is NOT metadata
+# and stays in the plaintext scan.
+_SOPS_METADATA_GROUP_KEY = re.compile(r"^sops_(?:age|pgp|kms|gcp_kms|azure_kv|hc_vault)__")
 
 
 def _is_sops_metadata_key(key: str) -> bool:
     """Return True if ``key`` is a genuine SOPS metadata key, not a user var.
 
     Matches the EXACT SOPS metadata family — the fixed scalar bookkeeping keys
-    and the nested key-group provider entries (``sops_age*``/``sops_pgp*``/…) —
-    rather than a bare ``sops_`` prefix, so a real user variable that happens to
-    start with ``sops_`` (e.g. ``sops_token``) is NOT misclassified as
-    bookkeeping and stays in the plaintext-secret scan (#416).
+    and the double-underscore-flattened key-group provider entries
+    (``sops_age__*``/``sops_pgp__*``/…) — rather than a bare ``sops_`` prefix,
+    so a real user variable that happens to start with ``sops_`` (e.g.
+    ``sops_token``, or one literally named ``sops_age``) is NOT misclassified
+    as bookkeeping and stays in the plaintext-secret scan (#416).
     """
     return key in _SOPS_METADATA_SCALAR_KEYS or bool(_SOPS_METADATA_GROUP_KEY.match(key))
 

--- a/src/envdrift/encryption/sops.py
+++ b/src/envdrift/encryption/sops.py
@@ -504,9 +504,10 @@ class SOPSEncryptionBackend(EncryptionBackend):
     def _metadata_line_has_value(content: str, value: str) -> bool:
         """Exact match of ``value`` against a SOPS *key-group* metadata entry.
 
-        Only the recipient-carrying key-group family counts (``sops_age*`` /
-        ``sops_pgp*`` / ``sops_kms*`` / ``sops_gcp_kms*`` / ``sops_azure_kv*`` /
-        ``sops_hc_vault*``, via the canonical ``_SOPS_METADATA_GROUP_KEY``):
+        Only the recipient-carrying key-group family counts (``sops_age__*`` /
+        ``sops_pgp__*`` / ``sops_kms__*`` / ``sops_gcp_kms__*`` /
+        ``sops_azure_kv__*`` / ``sops_hc_vault__*``, via the canonical
+        ``_SOPS_METADATA_GROUP_KEY``):
         recipients are never recorded in scalar bookkeeping, so an unrelated
         scalar value (``sops_shamir_threshold=1``) must not satisfy a short
         component like an Azure key version ``1``. Whole-line equality kills the

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -680,13 +680,8 @@ class TestEncryptCommand:
         assert "Encrypted: 2" in output
         assert "Plaintext: 0" in output
 
-    @pytest.mark.xfail(
-        strict=False,
-        reason="--check reads the last-wins parsed map, so a plaintext line shadowed "
-        "by a later duplicate encrypted assignment is missed (see #583)",
-    )
     def test_encrypt_check_blocks_plaintext_shadowed_by_encrypted_duplicate(self, tmp_path: Path):
-        """A plaintext secret must block even when a later duplicate is encrypted."""
+        """A plaintext secret must block even when a later duplicate is encrypted (#583)."""
         env_file = tmp_path / ".env"
         env_file.write_text(
             'SECRET_KEY=plaintext-value-123\nSECRET_KEY="encrypted:abcdef1234567890"\n'

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -649,6 +649,37 @@ class TestEncryptCommand:
         # Should pass for encrypted file
         assert result.exit_code == 0 or "encrypt" in result.output.lower()
 
+    def test_encrypt_check_fully_sops_encrypted_reports_fully_encrypted(self, tmp_path: Path):
+        """--check reports a genuine fully-SOPS-encrypted file as fully encrypted (#441).
+
+        The SOPS dotenv output carries a flat metadata trailer (plaintext
+        bookkeeping lines + the ciphertext sops_mac=). Pre-fix, the trailer was
+        counted in the variable tallies, so --check printed "File is partially
+        encrypted / Encrypted: 3 / Plaintext: 4 / ratio 43%" for a file whose
+        every user value is ciphertext.
+        """
+        enc_iv_tag = ",iv:" + "ab" * 16 + ",tag:" + "cd" * 8 + ",type:str]"
+        env_file = tmp_path / ".env"
+        env_file.write_text(
+            "DB_PASSWORD=ENC[AES256_GCM,data:U5dotp3cMQ==" + enc_iv_tag + "\n"
+            "API_KEY=ENC[AES256_GCM,data:oNgtRJRCHtOh669puic=" + enc_iv_tag + "\n"
+            "sops_age__list_0__map_recipient="
+            "age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p\n"
+            "sops_lastmodified=2026-06-08T14:15:34Z\n"
+            "sops_mac=ENC[AES256_GCM,data:iBjKMupTM" + enc_iv_tag + "\n"
+            "sops_unencrypted_suffix=_unencrypted\n"
+            "sops_version=3.13.1\n"
+        )
+
+        result = runner.invoke(app, ["encrypt", str(env_file), "--check", "--backend", "sops"])
+
+        output = _plain_cli_output(result.output)
+        assert result.exit_code == 0
+        assert "File is fully encrypted" in output
+        assert "partially encrypted" not in output
+        assert "Encrypted: 2" in output
+        assert "Plaintext: 0" in output
+
     @pytest.mark.xfail(
         strict=False,
         reason="--check reads the last-wins parsed map, so a plaintext line shadowed "

--- a/tests/unit/test_encryption.py
+++ b/tests/unit/test_encryption.py
@@ -177,6 +177,35 @@ DEBUG=true
         assert report.is_fully_encrypted is False
         assert detector.should_block_commit(report) is True
 
+    def test_bare_sops_provider_named_user_var_counted_as_plaintext(self, tmp_path):
+        """A user var literally named ``sops_age`` stays in the plaintext scan.
+
+        Real sops (verified against the pinned 3.13.2 binary) never emits a
+        bare ``sops_<provider>`` key nor a single-underscore
+        ``sops_<provider>_<field>`` one — key groups only appear
+        double-underscore flattened (``sops_age__list_0__map_enc``). Pre-fix,
+        the group matcher's ``$``/single-``_`` alternatives skipped such user
+        vars, so ``encrypt --check`` reported the file fully encrypted and
+        ``should_block_commit`` failed open on a plaintext credential.
+        """
+        # Secret-looking value built by concatenation (push-protection).
+        content = (
+            "API_KEY=" + _sops_value("oNgtRJRCHtOh669puic=") + "\nsops_age=sk-" + "plain-cred\n"
+        )
+        env_file = tmp_path / ".env"
+        env_file.write_text(content)
+
+        parser = EnvParser()
+        env = parser.parse(env_file)
+
+        detector = EncryptionDetector()
+        report = detector.analyze(env)
+
+        assert "sops_age" in report.plaintext_vars
+        assert "sops_age" in report.plaintext_secrets
+        assert report.is_fully_encrypted is False
+        assert detector.should_block_commit(report) is True
+
     def test_has_encrypted_header(self):
         """Check for dotenvx encryption header."""
         detector = EncryptionDetector()

--- a/tests/unit/test_encryption.py
+++ b/tests/unit/test_encryption.py
@@ -4,6 +4,11 @@ from envdrift.core.encryption import EncryptionDetector
 from envdrift.core.parser import EnvParser
 
 
+def _sops_value(data: str) -> str:
+    """Build a SOPS ENC[...] value of the canonical shape (no real secret)."""
+    return "ENC[AES256_GCM,data:" + data + ",iv:" + "ab" * 16 + ",tag:" + "cd" * 8 + ",type:str]"
+
+
 class TestEncryptionDetector:
     """Test cases for EncryptionDetector."""
 
@@ -112,6 +117,65 @@ DEBUG=true
         assert "DOTENV_PUBLIC_KEY_PRODUCTION_SECRET" not in report.plaintext_vars
         assert detector.should_block_commit(report) is False
         assert report.is_fully_encrypted is True
+
+    def test_sops_metadata_trailer_not_counted_in_tallies(self, tmp_path):
+        """A fully SOPS-encrypted file reports as fully encrypted (#441).
+
+        `sops --encrypt --input-type dotenv --output-type dotenv` appends a flat
+        metadata trailer: sops_version= / sops_lastmodified= /
+        sops_unencrypted_suffix= / the recipient public key are PLAINTEXT lines
+        and sops_mac= is ciphertext (the fixture mirrors byte-for-byte what the
+        real sops binary writes — see tests/unit/test_partial_encryption_sops.py).
+        Pre-fix, analyze() counted the trailer in the tallies, so `encrypt
+        --check` reported a genuine fully-SOPS-encrypted file as "partially
+        encrypted" (Encrypted: 3, Plaintext: 4, ratio 43%). The trailer is SOPS
+        bookkeeping, not user data — it must not sway the tallies.
+        """
+        content = (
+            "DB_PASSWORD=" + _sops_value("U5dotp3cMQ==") + "\n"
+            "API_KEY=" + _sops_value("oNgtRJRCHtOh669puic=") + "\n"
+            "sops_age__list_0__map_recipient="
+            "age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p\n"
+            "sops_lastmodified=2026-06-08T14:15:34Z\n"
+            "sops_mac=" + _sops_value("iBjKMupTM") + "\n"
+            "sops_unencrypted_suffix=_unencrypted\n"
+            "sops_version=3.13.1\n"
+        )
+        env_file = tmp_path / ".env"
+        env_file.write_text(content)
+
+        parser = EnvParser()
+        env = parser.parse(env_file)
+
+        detector = EncryptionDetector()
+        report = detector.analyze(env)
+
+        assert report.encrypted_vars == {"DB_PASSWORD", "API_KEY"}
+        assert report.plaintext_vars == set()
+        assert report.is_fully_encrypted is True
+        assert detector.should_block_commit(report) is False
+
+    def test_sops_prefixed_user_var_still_counted_as_plaintext(self, tmp_path):
+        """A user var merely named ``sops_<x>`` stays in the plaintext scan (#441).
+
+        The SOPS-metadata skip matches the EXACT metadata key family shared with
+        partial_encryption (#416), not a bare ``sops_`` prefix — a real user
+        secret such as ``sops_token=…`` must still count as a plaintext secret.
+        """
+        content = "API_KEY=" + _sops_value("oNgtRJRCHtOh669puic=") + "\nsops_token=plain-cred\n"
+        env_file = tmp_path / ".env"
+        env_file.write_text(content)
+
+        parser = EnvParser()
+        env = parser.parse(env_file)
+
+        detector = EncryptionDetector()
+        report = detector.analyze(env)
+
+        assert "sops_token" in report.plaintext_vars
+        assert "sops_token" in report.plaintext_secrets
+        assert report.is_fully_encrypted is False
+        assert detector.should_block_commit(report) is True
 
     def test_has_encrypted_header(self):
         """Check for dotenvx encryption header."""

--- a/tests/unit/test_partial_encryption_sops.py
+++ b/tests/unit/test_partial_encryption_sops.py
@@ -238,14 +238,31 @@ def test_is_sops_metadata_key_exact_family(tmp_path: Path):
     assert _is_sops_metadata_key("sops_version") is True
     assert _is_sops_metadata_key("sops_mac") is True
     assert _is_sops_metadata_key("sops_age__list_0__map_recipient") is True
+    assert _is_sops_metadata_key("sops_age__list_0__map_enc") is True
     assert _is_sops_metadata_key("sops_pgp__list_0__map_fp") is True
     assert _is_sops_metadata_key("sops_kms__list_0__map_arn") is True
+    assert _is_sops_metadata_key("sops_gcp_kms__list_0__map_resource_id") is True
     # User vars that merely start with ``sops_`` are NOT metadata.
     assert _is_sops_metadata_key("sops_token") is False
     assert _is_sops_metadata_key("sops_api_key") is False
     assert _is_sops_metadata_key("sops_config") is False
     assert _is_sops_metadata_key("sops_agent") is False  # not the ``age`` provider
     assert _is_sops_metadata_key("sops_version_override") is False
+    # A user var literally named after a provider is NOT metadata either: real
+    # sops (verified against the pinned 3.13.2 binary) never emits a bare
+    # ``sops_<provider>`` key — key groups only appear double-underscore
+    # flattened (``sops_age__list_0__map_enc``) — so a plaintext credential
+    # stored under such a name must stay in the plaintext scan.
+    assert _is_sops_metadata_key("sops_age") is False
+    assert _is_sops_metadata_key("sops_pgp") is False
+    assert _is_sops_metadata_key("sops_kms") is False
+    assert _is_sops_metadata_key("sops_gcp_kms") is False
+    assert _is_sops_metadata_key("sops_azure_kv") is False
+    assert _is_sops_metadata_key("sops_hc_vault") is False
+    # Single-underscore lookalikes are user vars too — the dotenv flattening
+    # separator is always a DOUBLE underscore, never a single one.
+    assert _is_sops_metadata_key("sops_age_backup") is False
+    assert _is_sops_metadata_key("sops_kms_arn") is False
 
 
 def test_is_fully_encrypted_true_for_sops_metadata_trailer(tmp_path: Path):


### PR DESCRIPTION
## Finding (triage index 3, live-441 campaign)

**\`encrypt --check\` reports a fully SOPS-encrypted file as "partially encrypted"** — it counts
the SOPS metadata trailer in the variable tallies.

### Repro (confirmed on origin/main)

Canonical SOPS dotenv output (2 \`ENC[AES256_GCM,...]\` values + the flat trailer
\`sops_age__list_0__map_recipient\` / \`sops_lastmodified\` / \`sops_unencrypted_suffix\` /
\`sops_version\` in plaintext, \`sops_mac\` as ciphertext — the byte-verified fixture from
\`tests/unit/test_partial_encryption_sops.py\`):

```text
$ envdrift encrypt .env --check --backend sops
File is partially encrypted
  Encrypted:  3
  Plaintext:  4
  Encryption ratio: 43%
```

Every user value is ciphertext, yet the report claims the file is only 43% encrypted.

### Root cause

\`EncryptionDetector.analyze()\` (src/envdrift/core/encryption.py) skipped dotenvx's
\`DOTENV_PUBLIC_KEY*\` artifact but had no equivalent skip for SOPS bookkeeping: the four
plaintext trailer lines landed in \`plaintext_vars\` (and \`sops_mac\`'s ciphertext inflated
\`encrypted_vars\`), keeping \`is_fully_encrypted\` False.

### Fix

\`analyze()\` now skips the exact SOPS metadata key family via \`_is_sops_metadata_key()\`
shared from \`core/partial_encryption.py\` — the single source of truth established by #416 —
alongside the existing dotenvx public-key skip. \`sops_mac\` semantics stay consistent with
partial_encryption: the whole trailer is bookkeeping and sways no tally. The matcher is the
exact family, **not** a bare \`sops_\` prefix, so a real user variable merely named
\`sops_token=…\` is still counted and flagged as a plaintext secret (verified: still exits 1).

### Tests (fail pre-fix, proven by stashing the src change)

- \`tests/unit/test_encryption.py::test_sops_metadata_trailer_not_counted_in_tallies\` —
  detector-level: byte-verified SOPS fixture yields \`encrypted_vars == {DB_PASSWORD, API_KEY}\`,
  no plaintext vars, \`is_fully_encrypted is True\` (pre-fix: 3 encrypted / 4 plaintext).
- \`tests/unit/test_encryption.py::test_sops_prefixed_user_var_still_counted_as_plaintext\` —
  guard: \`sops_token\` stays in the plaintext scan and blocks the commit.
- \`tests/unit/test_cli.py::test_encrypt_check_fully_sops_encrypted_reports_fully_encrypted\` —
  CLI output pinning (ANSI-stripped, whitespace-collapsed, explicit exit code): asserts
  "File is fully encrypted", "Encrypted: 2", "Plaintext: 0" (pre-fix: "partially encrypted").

Also verified end-to-end against the real pinned **sops 3.13.2** binary: a file encrypted by
\`sops --encrypt --input-type dotenv --output-type dotenv\` (whose genuine trailer includes the
extra \`sops_age__list_0__map_enc\` key, covered by the group-key regex) now reports
"File is fully encrypted / 2 / 0 / 100%".

### Docs

\`docs/cli/encrypt.md\` Encryption Report section now documents that encryption-tool
bookkeeping (dotenvx \`DOTENV_PUBLIC_KEY_*\`, SOPS \`sops_*\` trailer) is excluded from the
counts, matching the existing \`docs/cli/lock.md\` wording.

### Gates

ruff check / ruff format / pyrefly (full) / bandit: clean.
\`pytest -m "not integration"\`: 3405 passed, 6 skipped (1 pre-existing xpass, #583, present on
unmodified origin/main). \`make lint-docs\`: 0 errors. Focused integration subset with real
binaries (pinned dotenvx 2.6.0 + sops 3.13.2): test_encryption_tools, test_lock_encryption_state,
test_encryption_edge_cases, test_hook_generated_config, test_partial_encryption_sops_e2e,
test_sops_backend_e2e — 99 passed, 1 skipped (skip-gated).

Partial #441

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PmjB1wAMY8zyHpkF2zzmCj

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jainal09/envdrift/pull/643?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected encryption checks for fully SOPS-encrypted `.env` files.
  - SOPS bookkeeping metadata is now excluded from encrypted and plaintext variable counts.
  - User-defined variables beginning with `sops_` continue to be detected and counted correctly.

- **Documentation**
  - Clarified encryption report behavior and SOPS metadata handling.

- **Tests**
  - Added coverage for fully encrypted SOPS files and user-defined `sops_` variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes SOPS metadata handling in encryption checks. The main changes are:

- Excludes genuine SOPS trailer keys from encrypted and plaintext counts.
- Keeps user variables like `sops_token` and `sops_age` in the plaintext scan.
- Reuses the shared SOPS metadata matcher in the encryption detector.
- Adds CLI and detector tests for fully encrypted SOPS dotenv files.
- Updates the encrypt command docs for bookkeeping exclusions.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/envdrift/core/encryption.py | Adds SOPS metadata exclusion to the encryption report tally path. |
| src/envdrift/core/partial_encryption.py | Narrows SOPS metadata matching to exact scalar keys and double-underscore provider entries. |
| src/envdrift/encryption/sops.py | Aligns SOPS metadata comments with the narrowed provider-key matcher. |
| tests/unit/test_encryption.py | Adds detector coverage for SOPS trailer exclusion and `sops_` user-variable scanning. |
| tests/unit/test_cli.py | Adds CLI coverage for fully encrypted SOPS dotenv reporting. |
| tests/unit/test_partial_encryption_sops.py | Adds exact-family matcher coverage for SOPS metadata and lookalike user keys. |
| docs/cli/encrypt.md | Documents that encryption-tool bookkeeping is excluded from report counts. |

<sub>Reviews (2): Last reviewed commit: ["fix(encrypt): count bare sops-provider-n..."](https://github.com/jainal09/envdrift/commit/b8735528f668f2c71f466949430edde1e87f4d10) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43637442)</sub>

<!-- /greptile_comment -->