### PR TITLE
fix(partial): point secrets-only tip to pull-partial

### DIFF
--- a/src/envdrift/cli_commands/partial.py
+++ b/src/envdrift/cli_commands/partial.py
@@ -249,7 +249,7 @@ def push(
     if total_encrypted_files:
         console.print(
             "[dim]Secrets-only files are encrypted in place; "
-            "run 'envdrift pull' to edit them.[/dim]"
+            "run 'envdrift pull-partial' to edit them.[/dim]"
         )
 
 

--- a/tests/unit/test_partial_cli.py
+++ b/tests/unit/test_partial_cli.py
@@ -664,10 +664,14 @@ def test_push_message_secrets_only_omits_combined_wording(monkeypatch, tmp_path:
     result = runner.invoke(app, ["push"])
 
     assert result.exit_code == 0
-    assert "Source files are encrypted" in result.output
-    assert "Secrets-only files are encrypted in place" in result.output
+    output = " ".join(result.output.split())
+    assert "Source files are encrypted" in output
+    assert (
+        "Secrets-only files are encrypted in place; run 'envdrift pull-partial' to edit them."
+    ) in output
+    assert "run 'envdrift pull' to edit them." not in output
     # No combined file was produced, so the combined-artifact line must be absent.
-    assert "runtime artifact" not in result.output
+    assert "runtime artifact" not in output
 
 
 def test_load_partial_encryption_paths_skips_secrets_only(monkeypatch, tmp_path: Path):


### PR DESCRIPTION
## What was broken

With a `secrets_only = true` partial-encryption environment containing
`secrets/prod.env`, this deterministic command reproduced the audit finding:

```text
env TERM=dumb COLUMNS=80 NO_COLOR=1 FORCE_COLOR=0 uv run envdrift push --env production
```

It exited 0 but ended with:

```text
Secrets-only files are encrypted in place; run 'envdrift pull' to edit them.
```

`envdrift pull` is the vault-sync command; editing these partial-encryption files
requires `envdrift pull-partial`.

## What changed

- Point the secrets-only push success tip to `envdrift pull-partial`.
- Strengthen the existing CLI regression test to assert the complete corrected tip,
  reject the old command, normalize output whitespace, and check the exit code.
- Grep source, tests, and docs for the tip; there was no docs copy to update.

## Regression proof

- Before the source change, the tightened test failed because output still contained
  `run 'envdrift pull'` and lacked `run 'envdrift pull-partial'`.
- After the fix, the focused test passes and a real dotenvx-backed CLI run exits 0
  with the corrected `pull-partial` tip.
- `tests/unit/test_partial_cli.py`: 29 passed.

## Gates run

- `uv sync --all-extras`: passed.
- `uv run ruff check src tests`: passed.
- `uv run ruff format --check .`: passed (239 files formatted).
- `uv run pyrefly check`: passed (0 errors).
- `uv run bandit -r src -c pyproject.toml`: passed (0 issues).
- `uv run pytest -m "not integration"`: passed in a clean temporary mount namespace
  (3400 passed, 8 skipped, 546 deselected, 1 xpassed). The two permission-gated
  tests skipped under namespace root had passed in the initial non-root run.

🤖 Generated with Codex (gpt-5.6-sol) orchestrated by Claude Code

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jainal09/envdrift/pull/645?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR corrects the CLI guidance for secrets-only partial-encryption pushes.

- Updates the success tip to use `envdrift pull-partial`.
- Strengthens the CLI regression test for the full corrected message.
- Checks that the old `envdrift pull` editing tip is no longer shown.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/envdrift/cli_commands/partial.py | Updates the secrets-only push completion tip to point at the partial pull command. |
| tests/unit/test_partial_cli.py | Adds stronger regression coverage for the corrected secrets-only push message. |

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/partial-pul..."](https://github.com/jainal09/envdrift/commit/e93b744de929a02b1360ab1e61fd1934d76c7e71) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43836572)</sub>

<!-- /greptile_comment -->