### PR TITLE
test: isolate environment-dependent test gates

### DIFF
--- a/tests/integration/test_docs_recipes.py
+++ b/tests/integration/test_docs_recipes.py
@@ -54,10 +54,33 @@ def _pinned_dotenvx_version() -> str:
 
 
 def _version_parts(version: str) -> tuple[int, ...]:
-    match = re.fullmatch(r"v?(\d+)\.(\d+)\.(\d+)", version.strip())
+    match = re.search(r"\bv?(\d+)\.(\d+)\.(\d+)\b", version)
     if match is None:
-        raise ValueError(f"unexpected dotenvx version: {version!r}")
+        pytest.fail(f"could not parse dotenvx version from output: {version!r}")
     return tuple(int(part) for part in match.groups())
+
+
+@pytest.mark.parametrize(
+    ("raw_version", "expected"),
+    [
+        ("2.6.0", (2, 6, 0)),
+        ("v2.6.0", (2, 6, 0)),
+        ("dotenvx 2.6.0", (2, 6, 0)),
+        ("2.6.0+build", (2, 6, 0)),
+    ],
+)
+def test_version_parts_parses_bounded_version_token(
+    raw_version: str, expected: tuple[int, ...]
+) -> None:
+    assert _version_parts(raw_version) == expected
+
+
+def test_version_parts_fails_loudly_when_token_is_missing() -> None:
+    with pytest.raises(
+        pytest.fail.Exception,
+        match="could not parse dotenvx version from output: 'garbage'",
+    ):
+        _version_parts("garbage")
 
 
 @pytest.fixture

--- a/tests/integration/test_docs_recipes.py
+++ b/tests/integration/test_docs_recipes.py
@@ -20,6 +20,7 @@ No mocking of the behavior under test.
 
 from __future__ import annotations
 
+import json
 import re
 import shutil
 import subprocess
@@ -43,6 +44,45 @@ def dotenvx_bin() -> str:
     if path is None:
         pytest.skip("dotenvx binary not found on PATH")
     return path
+
+
+def _pinned_dotenvx_version() -> str:
+    constants_path = Path(__file__).parents[2] / "src" / "envdrift" / "constants.json"
+    with constants_path.open(encoding="utf-8") as constants_file:
+        constants = json.load(constants_file)
+    return str(constants["dotenvx_version"])
+
+
+def _version_parts(version: str) -> tuple[int, ...]:
+    match = re.fullmatch(r"v?(\d+)\.(\d+)\.(\d+)", version.strip())
+    if match is None:
+        raise ValueError(f"unexpected dotenvx version: {version!r}")
+    return tuple(int(part) for part in match.groups())
+
+
+@pytest.fixture
+def pinned_dotenvx_bin(dotenvx_bin: str) -> str:
+    """Path to dotenvx when it is at least the dynamically pinned version."""
+    result = subprocess.run(
+        [dotenvx_bin, "--version"],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=30,
+        check=False,
+    )
+    if result.returncode != 0:
+        pytest.fail(f"dotenvx --version failed: {result.stdout}{result.stderr}")
+
+    installed_version = result.stdout.strip()
+    pinned_version = _pinned_dotenvx_version()
+    if _version_parts(installed_version) < _version_parts(pinned_version):
+        pytest.skip(
+            f"dotenvx {installed_version} is older than pinned {pinned_version}; "
+            "install the pinned version to run dotenvx v2 behavior tests"
+        )
+    return dotenvx_bin
 
 
 def _run(
@@ -113,7 +153,7 @@ def test_dotenvx_encryption_recipe_encrypts_every_value(
 
 def test_faq_ci_decrypt_recipe_round_trips(
     envdrift_cmd: list[str],
-    dotenvx_bin: str,
+    pinned_dotenvx_bin: str,
     work_dir: Path,
     integration_env: dict[str, str],
 ) -> None:
@@ -129,6 +169,7 @@ def test_faq_ci_decrypt_recipe_round_trips(
     key as a fallback for any file — so this test no longer asserts the bare key
     *fails*; it pins that the suffixed recipe works and documents the v2 fallback.
     """
+    del pinned_dotenvx_bin  # The fixture gates this v2-specific behavior against the pin.
     private_key = _encrypt_production(envdrift_cmd, work_dir, integration_env)
     encrypted = (work_dir / ".env.production").read_text(encoding="utf-8")
 
@@ -161,7 +202,7 @@ def test_faq_ci_decrypt_recipe_round_trips(
 
 def test_env_file_sync_rotation_command_is_a_noop_in_dotenvx_v2(
     envdrift_cmd: list[str],
-    dotenvx_bin: str,
+    pinned_dotenvx_bin: str,
     work_dir: Path,
     integration_env: dict[str, str],
 ) -> None:
@@ -172,7 +213,9 @@ def test_env_file_sync_rotation_command_is_a_noop_in_dotenvx_v2(
     encrypted_before = env_file.read_bytes()
     keys_before = keys_file.read_bytes()
 
-    result = _run([dotenvx_bin, "rotate", "-f", ".env.production"], work_dir, integration_env)
+    result = _run(
+        [pinned_dotenvx_bin, "rotate", "-f", ".env.production"], work_dir, integration_env
+    )
     output = result.stdout + result.stderr
     assert result.returncode == 0, output
     assert "unknown command 'rotate'" in output

--- a/tests/scanner/test_trufflehog.py
+++ b/tests/scanner/test_trufflehog.py
@@ -704,8 +704,24 @@ class TestGitRepoDetection:
         (tmp_path / ".git").mkdir()
         assert scanner._is_git_repo(tmp_path) is True
 
-    def test_is_git_repo_without_git_dir(self, scanner: TrufflehogScanner, tmp_path: Path):
+    def test_is_git_repo_without_git_dir(
+        self,
+        scanner: TrufflehogScanner,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
         """Test detection when no .git directory."""
+        real_parents = Path.parents
+
+        def bounded_parents(path: Path):
+            if path == tmp_path:
+                return ()
+            return real_parents.__get__(path, type(path))
+
+        # Treat the isolated test directory as the walk root. Host ancestors
+        # may contain unrelated git metadata (for example, a mounted /tmp/.git).
+        monkeypatch.setattr(Path, "parents", property(bounded_parents))
+
         assert scanner._is_git_repo(tmp_path) is False
 
     def test_is_git_repo_with_parent_git_dir(self, scanner: TrufflehogScanner, tmp_path: Path):

--- a/tests/unit/coverage/test_cov_cli_commands_sync.py
+++ b/tests/unit/coverage/test_cov_cli_commands_sync.py
@@ -776,7 +776,7 @@ class TestLockCommand:
 
         result = runner.invoke(app, ["lock", "--verify-vault", "--force"])
         assert result.exit_code == 0, result.output
-        assert "keys match vault" in result.output
+        assert "keys match vault" in " ".join(result.output.split())
 
     @patch("envdrift.cli_commands.encryption_helpers.resolve_encryption_backend")
     def test_lock_verify_vault_key_mismatch_exits(

--- a/tests/unit/coverage/test_cov_integrations_hook_check.py
+++ b/tests/unit/coverage/test_cov_integrations_hook_check.py
@@ -163,11 +163,24 @@ class TestResolveGitHooksPathAbsolute:
 class TestFindGitDirWalkToRoot:
     """Cover the walk-up-to-filesystem-root branch (lines 248-250)."""
 
-    def test_walks_up_and_returns_none_at_root(self, tmp_path: Path):
+    def test_walks_up_and_returns_none_at_root(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
         nested = tmp_path / "a" / "b" / "c"
         nested.mkdir(parents=True)
 
-        # No .git anywhere up the tree under tmp_path; eventually reaches the
+        real_parent = Path.parent
+
+        def bounded_parent(path: Path) -> Path:
+            if path == tmp_path:
+                return path
+            return real_parent.__get__(path, type(path))
+
+        # Treat the isolated test directory as the filesystem root so host
+        # ancestors cannot contribute unrelated git metadata.
+        monkeypatch.setattr(Path, "parent", property(bounded_parent))
+
+        # No .git anywhere up the isolated tree; eventually reaches the fake
         # filesystem root (current == current.parent) and returns None.
         assert hook_check._find_git_dir(nested) is None
 


### PR DESCRIPTION
## What was broken

- The two git ancestor tests assumed pytest's temporary root had no `.git` ancestor. In this sandbox, `/tmp/.git` is a read-only mount, so the focused baseline run failed 2/2: trufflehog returned `True`, and `_find_git_dir` returned `/tmp/.git`.
- The two dotenvx-v2 docs-recipe tests used any `dotenvx` found on `PATH`. With the host's `dotenvx 1.70.0` versus the dynamic `2.6.0` pin, the focused baseline run failed 2/2 on v2-only behavior.
- The final 80-column gate also exposed a pre-existing Rich wrapping failure in the `keys match vault` assertion.

## What changed

- Bound the no-repository tests to their controlled temporary roots, excluding host ancestor metadata without weakening their false/none assertions.
- Added a real-binary version fixture that reads `dotenvx_version` from `src/envdrift/constants.json`, runs `dotenvx --version`, and skips only the v2-specific tests when the installed binary is older.
- Made the vault verification assertion width-independent by collapsing output whitespace; its exit-code assertion remains intact.
- Kept the change test-only; `src/` is untouched.

## Verification

- Focused git ancestor regression tests: 2 passed inside the `/tmp/.git` sandbox.
- Affected git-detection classes: 6 passed.
- Focused v2 recipe tests on dotenvx 1.70.0: 2 skipped with `older than pinned 2.6.0` reasons.
- `uv run pytest tests/integration/test_docs_recipes.py -m integration -q`: 4 passed, 2 skipped.
- 80-column vault assertion regression: 1 passed.

## Gates

- `uv run ruff check src tests`
- `uv run ruff format --check .`
- `uv run pyrefly check`
- `uv run bandit -r src -c pyproject.toml`
- `uv run pytest -m "not integration"`: 3,457 passed, 6 skipped, 2 xfailed.

Closes #646
Closes #651

🤖 Generated with Codex (gpt-5.6-sol) orchestrated by Claude Code

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jainal09/envdrift/pull/660?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR isolates tests from host-dependent environment state. The main changes are:

- Bounds git ancestor tests to controlled temporary roots.
- Gates dotenvx v2 recipe tests on the pinned binary version.
- Parses common dotenvx version output forms.
- Normalizes one Rich-wrapped vault output assertion.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| tests/integration/test_docs_recipes.py | Adds pinned dotenvx version gating and version-token parsing for v2-specific recipe tests. |
| tests/scanner/test_trufflehog.py | Bounds the no-repository git detection test to its temporary root. |
| tests/unit/coverage/test_cov_integrations_hook_check.py | Bounds the hook git-dir walk test to its temporary root. |
| tests/unit/coverage/test_cov_cli_commands_sync.py | Normalizes the vault success assertion so Rich wrapping does not affect the test. |

<sub>Reviews (2): Last reviewed commit: ["test: parse wrapped dotenvx versions"](https://github.com/jainal09/envdrift/commit/5e292438005aa567c918a2230b317045d2f63e14) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43933977)</sub>

<!-- /greptile_comment -->