### PR TITLE
fix(decrypt): share vault setting resolution for verification

### DIFF
--- a/docs/cli/decrypt.md
+++ b/docs/cli/decrypt.md
@@ -82,16 +82,23 @@ envdrift decrypt .env.production --backend sops
 
 Vault verification is only supported with the dotenvx backend. `--provider` and
 `--secret` are always required with `--verify-vault` (they are not read from
-`envdrift.toml`); `--vault-url` is also required for azure/hashicorp and
-`--project-id` for gcp.
+`envdrift.toml`). Provider settings use the explicit CLI flag first, then the
+matching `[vault.<provider>]` configuration. HashiCorp additionally falls back
+to `VAULT_ADDR` when neither `--vault-url` nor `[vault.hashicorp] url` is set;
+surrounding whitespace is stripped and a whitespace-only value is treated as
+unset.
 
 ```bash
-# Azure Key Vault (or HashiCorp): --vault-url is required
+# Azure Key Vault: pass the URL explicitly or configure [vault.azure]
 envdrift decrypt .env.production --verify-vault --ci \
   -p azure --vault-url https://myvault.vault.azure.net \
   --secret myapp-dotenvx-key
 
-# GCP Secret Manager: --project-id is required
+# HashiCorp Vault: VAULT_ADDR can supply the URL
+VAULT_ADDR=https://vault.example.com envdrift decrypt .env.production \
+  --verify-vault --ci -p hashicorp --secret myapp-dotenvx-key
+
+# GCP Secret Manager: pass the project explicitly or configure [vault.gcp]
 envdrift decrypt .env.production --verify-vault --ci \
   -p gcp --project-id my-gcp-project \
   --secret myapp-dotenvx-key
@@ -199,8 +206,8 @@ steps:
 - `git restore <file>`
 - `envdrift sync --force -p <provider>` to restore the vault key locally. When
   the current command discovered a TOML config, the hint includes
-  `-c <resolved-config>`; `--vault-url`/`--region`/`--project-id` are appended
-  when those flags were passed.
+  `-c <resolved-config>`; the effective `--vault-url`/`--region`/`--project-id`
+  values are appended after CLI/config/environment resolution.
 - `envdrift encrypt <file>` to re-encrypt with the vault key
 
 !!! note "`--verify-vault` only verifies — it does not fetch the key"

--- a/src/envdrift/cli_commands/encryption.py
+++ b/src/envdrift/cli_commands/encryption.py
@@ -1054,19 +1054,29 @@ def decrypt_cmd(
         if not vault_secret:
             print_error("--verify-vault requires --secret (vault secret name)")
             raise typer.Exit(code=1)
-        if vault_provider in ("azure", "hashicorp") and not vault_url:
-            print_error(f"--verify-vault with {vault_provider} requires --vault-url")
-            raise typer.Exit(code=1)
-        if vault_provider == "gcp" and not vault_project_id:
-            print_error("--verify-vault with gcp requires --project-id")
-            raise typer.Exit(code=1)
+
+        from envdrift.cli_commands.vault_helpers import (
+            VaultConnectionOptions,
+            resolve_vault_settings,
+        )
+
+        vault_settings = resolve_vault_settings(
+            VaultConnectionOptions(
+                config=config_path,
+                provider=vault_provider,
+                vault_url=vault_url,
+                region=vault_region,
+                project_id=vault_project_id,
+            ),
+            envdrift_config,
+        )
 
         vault_check_passed = _verify_decryption_with_vault(
             env_file=env_file,
-            provider=vault_provider,
-            vault_url=vault_url,
-            region=vault_region,
-            project_id=vault_project_id,
+            provider=vault_settings.provider,
+            vault_url=vault_settings.vault_url,
+            region=vault_settings.region,
+            project_id=vault_settings.project_id,
             secret_name=vault_secret,
             ci=ci,
             auto_install=encryption_config.dotenvx_auto_install if encryption_config else False,

--- a/src/envdrift/cli_commands/sync_config_helpers.py
+++ b/src/envdrift/cli_commands/sync_config_helpers.py
@@ -14,9 +14,9 @@ from envdrift.output.rich import print_error, print_warning
 if TYPE_CHECKING:
     from envdrift.sync.config import ServiceMapping, SyncConfig
 
-# Missing-setting messages shared with the vault-push/vault-pull seam
-# (envdrift.cli_commands.vault_helpers) so the same condition cannot drift
-# into two phrasings again (#441 audit).
+# Missing-setting messages shared by the sync family, vault-push/vault-pull,
+# and decrypt --verify-vault so the same condition cannot drift into multiple
+# phrasings again (#441 audit, #653).
 AZURE_VAULT_URL_REQUIRED = (
     "Azure provider requires --vault-url (or [vault.azure] vault_url in config)"
 )
@@ -81,9 +81,10 @@ def _load_defaults(request: SyncLoadRequest) -> _ConfigDefaults:
     return _ConfigDefaults(path=path, config=_load_envdrift_config(path))
 
 
-def _provider_vault_url(
+def resolve_provider_vault_url(
     provider: str | None, explicit_url: str | None, vault_config: Any | None
 ) -> str | None:
+    """Resolve a provider URL from CLI, config, then HashiCorp's environment."""
     if explicit_url is not None:
         return explicit_url
     attribute = {"azure": "azure_vault_url", "hashicorp": "hashicorp_url"}.get(provider or "")
@@ -107,7 +108,7 @@ def _resolve_vault_settings(request: SyncLoadRequest, defaults: _ConfigDefaults)
     provider = request.provider or getattr(vault_config, "provider", None)
     return _VaultSettings(
         provider=provider,
-        vault_url=_provider_vault_url(provider, request.vault_url, vault_config),
+        vault_url=resolve_provider_vault_url(provider, request.vault_url, vault_config),
         region=_config_default(request.region, vault_config, "aws_region"),
         project_id=_config_default(request.project_id, vault_config, "gcp_project_id"),
     )

--- a/src/envdrift/cli_commands/vault_helpers.py
+++ b/src/envdrift/cli_commands/vault_helpers.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Never
@@ -13,6 +12,7 @@ from envdrift.cli_commands.sync_config_helpers import (
     AZURE_VAULT_URL_REQUIRED,
     GCP_PROJECT_ID_REQUIRED,
     HASHICORP_VAULT_URL_REQUIRED,
+    resolve_provider_vault_url,
 )
 from envdrift.env_files import EnvFileDetection, resolve_custom_env_file, resolve_mapping_env_file
 from envdrift.output.rich import console, print_error, print_success, print_warning
@@ -117,24 +117,6 @@ def _load_vault_config(config: Path | None) -> Any | None:
         raise typer.Exit(code=1) from None
 
 
-def _provider_vault_url(
-    provider: str,
-    explicit_url: str | None,
-    vault_config: Any | None,
-) -> str | None:
-    """Resolve provider-specific URL, preserving explicit CLI precedence."""
-    if explicit_url is not None:
-        return explicit_url
-    attribute = {"azure": "azure_vault_url", "hashicorp": "hashicorp_url"}.get(provider)
-    url = getattr(vault_config, attribute, None) if attribute is not None else None
-    if url is None and provider == "hashicorp":
-        # Honor the standard env var every HashiCorp tool reads (#441 audit).
-        # Strip so a padded value is usable and a whitespace-only value still
-        # hits the missing-URL guard instead of a late connection failure.
-        return (os.environ.get("VAULT_ADDR") or "").strip() or None
-    return url
-
-
 def _validate_vault_settings(settings: VaultSettings) -> None:
     """Reject missing provider-specific settings with CLI-facing errors.
 
@@ -154,9 +136,12 @@ def _validate_vault_settings(settings: VaultSettings) -> None:
         raise typer.Exit(code=1)
 
 
-def resolve_vault_settings(options: VaultConnectionOptions) -> VaultSettings:
+def resolve_vault_settings(
+    options: VaultConnectionOptions, envdrift_config: Any | None = None
+) -> VaultSettings:
     """Merge CLI flags with the config's vault settings and validate them."""
-    envdrift_config = _load_vault_config(options.config)
+    if envdrift_config is None:
+        envdrift_config = _load_vault_config(options.config)
     vault_config = getattr(envdrift_config, "vault", None)
     effective_provider = options.provider or getattr(vault_config, "provider", None)
     if not effective_provider:
@@ -165,7 +150,7 @@ def resolve_vault_settings(options: VaultConnectionOptions) -> VaultSettings:
 
     settings = VaultSettings(
         provider=effective_provider,
-        vault_url=_provider_vault_url(effective_provider, options.vault_url, vault_config),
+        vault_url=resolve_provider_vault_url(effective_provider, options.vault_url, vault_config),
         region=options.region or getattr(vault_config, "aws_region", None),
         project_id=options.project_id or getattr(vault_config, "gcp_project_id", None),
     )

--- a/tests/unit/test_vault_error_ux.py
+++ b/tests/unit/test_vault_error_ux.py
@@ -18,11 +18,14 @@ import typer
 from typer.testing import CliRunner
 
 from envdrift.cli import app
+from envdrift.cli_commands.sync_config_helpers import (
+    AZURE_VAULT_URL_REQUIRED,
+    GCP_PROJECT_ID_REQUIRED,
+    HASHICORP_VAULT_URL_REQUIRED,
+)
 from envdrift.vault.base import AuthenticationError, SecretNotFoundError, VaultError
 
 runner = CliRunner()
-
-AZURE_URL_MESSAGE = "Azure provider requires --vault-url (or [vault.azure] vault_url in config)"
 
 
 def _flat(output: str) -> str:
@@ -249,19 +252,182 @@ class TestVaultAddrFallback:
 class TestMissingUrlMessageParity:
     """The same missing-URL condition must read identically across commands."""
 
-    def test_sync_and_vault_pull_emit_same_azure_message(self, tmp_path, monkeypatch):
+    @pytest.mark.parametrize(
+        ("provider", "required_message"),
+        [
+            ("azure", AZURE_VAULT_URL_REQUIRED),
+            ("hashicorp", HASHICORP_VAULT_URL_REQUIRED),
+            ("gcp", GCP_PROJECT_ID_REQUIRED),
+        ],
+    )
+    def test_sync_vault_pull_and_decrypt_emit_same_message(
+        self, tmp_path, monkeypatch, provider, required_message
+    ):
+        """All three CLI seams use the shared provider-setting message."""
         (tmp_path / "envdrift.toml").write_text(
-            '[vault]\nprovider = "azure"\n\n'
+            f'[vault]\nprovider = "{provider}"\n\n'
             '[[vault.sync.mappings]]\nsecret_name = "s"\nfolder_path = "."\n'
             'environment = "production"\n',
             encoding="utf-8",
         )
+        env_file = tmp_path / ".env.production"
+        env_file.write_text("SECRET=encrypted\n", encoding="utf-8")
         monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("VAULT_ADDR", raising=False)
 
         sync_result = runner.invoke(app, ["sync", "--verify"])
         pull_result = runner.invoke(app, ["vault-pull", ".", "s", "--env", "production"])
+        decrypt_result = runner.invoke(
+            app,
+            [
+                "decrypt",
+                str(env_file),
+                "--backend",
+                "dotenvx",
+                "--verify-vault",
+                "--provider",
+                provider,
+                "--secret",
+                "s",
+            ],
+        )
 
         assert sync_result.exit_code == 1
         assert pull_result.exit_code == 1
-        assert AZURE_URL_MESSAGE in _flat(sync_result.output)
-        assert AZURE_URL_MESSAGE in _flat(pull_result.output)
+        assert decrypt_result.exit_code == 1
+        assert required_message in _flat(sync_result.output)
+        assert required_message in _flat(pull_result.output)
+        assert required_message in _flat(decrypt_result.output)
+
+
+class TestDecryptVerifyVaultSettings:
+    """decrypt --verify-vault shares provider-setting resolution with vault commands."""
+
+    @staticmethod
+    def _invoke(tmp_path, provider, monkeypatch, *extra_args):
+        env_file = tmp_path / ".env.production"
+        env_file.write_text("SECRET=encrypted\n", encoding="utf-8")
+        monkeypatch.chdir(tmp_path)
+        return runner.invoke(
+            app,
+            [
+                "decrypt",
+                str(env_file),
+                "--backend",
+                "dotenvx",
+                "--verify-vault",
+                "--provider",
+                provider,
+                "--secret",
+                "s",
+                *extra_args,
+            ],
+        )
+
+    @pytest.mark.parametrize(
+        ("provider", "provider_config", "setting_name", "expected"),
+        [
+            (
+                "azure",
+                '[vault.azure]\nvault_url = "https://config.vault.azure.net"\n',
+                "vault_url",
+                "https://config.vault.azure.net",
+            ),
+            (
+                "aws",
+                '[vault.aws]\nregion = "eu-west-2"\n',
+                "region",
+                "eu-west-2",
+            ),
+            (
+                "hashicorp",
+                '[vault.hashicorp]\nurl = "http://config-vault:8200"\n',
+                "vault_url",
+                "http://config-vault:8200",
+            ),
+            (
+                "gcp",
+                '[vault.gcp]\nproject_id = "config-project"\n',
+                "project_id",
+                "config-project",
+            ),
+        ],
+    )
+    def test_provider_settings_resolve_from_config(
+        self, tmp_path, monkeypatch, provider, provider_config, setting_name, expected
+    ):
+        """Every verify-vault provider consumes its setting from config."""
+        (tmp_path / "envdrift.toml").write_text(
+            f'[vault]\nprovider = "{provider}"\n\n{provider_config}',
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("VAULT_ADDR", "http://environment-vault:8200")
+        verify = MagicMock(return_value=True)
+        monkeypatch.setattr(
+            "envdrift.cli_commands.encryption._verify_decryption_with_vault",
+            verify,
+        )
+
+        result = self._invoke(tmp_path, provider, monkeypatch)
+
+        assert result.exit_code == 0
+        assert verify.call_args.kwargs[setting_name] == expected
+
+    @pytest.mark.parametrize(
+        "vault_addr",
+        ["http://environment-vault:8200", "  http://environment-vault:8200  "],
+        ids=["plain", "padded"],
+    )
+    def test_hashicorp_falls_back_to_vault_addr(self, tmp_path, monkeypatch, vault_addr):
+        """VAULT_ADDR supplies and normalizes the HashiCorp URL on this seam."""
+        monkeypatch.setenv("VAULT_ADDR", vault_addr)
+        verify = MagicMock(return_value=True)
+        monkeypatch.setattr(
+            "envdrift.cli_commands.encryption._verify_decryption_with_vault",
+            verify,
+        )
+
+        result = self._invoke(tmp_path, "hashicorp", monkeypatch)
+
+        assert result.exit_code == 0
+        assert verify.call_args.kwargs["vault_url"] == "http://environment-vault:8200"
+
+    def test_hashicorp_explicit_url_beats_config_and_vault_addr(self, tmp_path, monkeypatch):
+        """The explicit URL retains precedence over both lower-priority sources."""
+        (tmp_path / "envdrift.toml").write_text(
+            '[vault]\nprovider = "hashicorp"\n\n'
+            '[vault.hashicorp]\nurl = "http://config-vault:8200"\n',
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("VAULT_ADDR", "http://environment-vault:8200")
+        verify = MagicMock(return_value=True)
+        monkeypatch.setattr(
+            "envdrift.cli_commands.encryption._verify_decryption_with_vault",
+            verify,
+        )
+
+        result = self._invoke(
+            tmp_path,
+            "hashicorp",
+            monkeypatch,
+            "--vault-url",
+            "http://explicit-vault:8200",
+        )
+
+        assert result.exit_code == 0
+        assert verify.call_args.kwargs["vault_url"] == "http://explicit-vault:8200"
+
+    def test_hashicorp_whitespace_only_vault_addr_is_missing(self, tmp_path, monkeypatch):
+        """Whitespace-only VAULT_ADDR fails at validation before client creation."""
+        monkeypatch.setenv("VAULT_ADDR", "   ")
+        verify = MagicMock(return_value=True)
+        monkeypatch.setattr(
+            "envdrift.cli_commands.encryption._verify_decryption_with_vault",
+            verify,
+        )
+
+        result = self._invoke(tmp_path, "hashicorp", monkeypatch)
+
+        assert result.exit_code == 1
+        assert HASHICORP_VAULT_URL_REQUIRED in _flat(result.output)
+        verify.assert_not_called()

--- a/tests/unit/test_vault_error_ux.py
+++ b/tests/unit/test_vault_error_ux.py
@@ -11,6 +11,7 @@ Each test pins one confirmed finding:
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -26,6 +27,16 @@ from envdrift.cli_commands.sync_config_helpers import (
 from envdrift.vault.base import AuthenticationError, SecretNotFoundError, VaultError
 
 runner = CliRunner()
+
+
+@dataclass(frozen=True)
+class _ProviderCase:
+    """One provider-specific config resolution case."""
+
+    provider: str
+    config_text: str
+    setting_name: str
+    expected_value: str
 
 
 def _flat(output: str) -> str:
@@ -325,40 +336,50 @@ class TestDecryptVerifyVaultSettings:
         )
 
     @pytest.mark.parametrize(
-        ("provider", "provider_config", "setting_name", "expected"),
+        "case",
         [
-            (
-                "azure",
-                '[vault.azure]\nvault_url = "https://config.vault.azure.net"\n',
-                "vault_url",
-                "https://config.vault.azure.net",
+            pytest.param(
+                _ProviderCase(
+                    provider="azure",
+                    config_text='[vault.azure]\nvault_url = "https://config.vault.azure.net"\n',
+                    setting_name="vault_url",
+                    expected_value="https://config.vault.azure.net",
+                ),
+                id="azure",
             ),
-            (
-                "aws",
-                '[vault.aws]\nregion = "eu-west-2"\n',
-                "region",
-                "eu-west-2",
+            pytest.param(
+                _ProviderCase(
+                    provider="aws",
+                    config_text='[vault.aws]\nregion = "eu-west-2"\n',
+                    setting_name="region",
+                    expected_value="eu-west-2",
+                ),
+                id="aws",
             ),
-            (
-                "hashicorp",
-                '[vault.hashicorp]\nurl = "http://config-vault:8200"\n',
-                "vault_url",
-                "http://config-vault:8200",
+            pytest.param(
+                _ProviderCase(
+                    provider="hashicorp",
+                    config_text='[vault.hashicorp]\nurl = "http://config-vault:8200"\n',
+                    setting_name="vault_url",
+                    expected_value="http://config-vault:8200",
+                ),
+                id="hashicorp",
             ),
-            (
-                "gcp",
-                '[vault.gcp]\nproject_id = "config-project"\n',
-                "project_id",
-                "config-project",
+            pytest.param(
+                _ProviderCase(
+                    provider="gcp",
+                    config_text='[vault.gcp]\nproject_id = "config-project"\n',
+                    setting_name="project_id",
+                    expected_value="config-project",
+                ),
+                id="gcp",
             ),
         ],
     )
-    def test_provider_settings_resolve_from_config(
-        self, tmp_path, monkeypatch, provider, provider_config, setting_name, expected
-    ):
+    def test_provider_settings_resolve_from_config(self, tmp_path, monkeypatch, case):
         """Every verify-vault provider consumes its setting from config."""
         (tmp_path / "envdrift.toml").write_text(
-            f'[vault]\nprovider = "{provider}"\n\n{provider_config}',
+            f'[vault]\nprovider = "{case.provider}"\n\n{case.config_text}',
             encoding="utf-8",
         )
         monkeypatch.setenv("VAULT_ADDR", "http://environment-vault:8200")
@@ -368,10 +389,10 @@ class TestDecryptVerifyVaultSettings:
             verify,
         )
 
-        result = self._invoke(tmp_path, provider, monkeypatch)
+        result = self._invoke(tmp_path, case.provider, monkeypatch)
 
         assert result.exit_code == 0
-        assert verify.call_args.kwargs[setting_name] == expected
+        assert verify.call_args.kwargs[case.setting_name] == case.expected_value
 
     @pytest.mark.parametrize(
         "vault_addr",


### PR DESCRIPTION
## What was broken

`decrypt <file> --verify-vault --provider hashicorp --secret <name>` validated its own raw flags instead of using the shared vault-setting seam. With `VAULT_ADDR=http://127.0.0.1:8200` and no `--vault-url`, the deterministic repro exited 1 before contacting Vault and printed:

```text
[ERROR] --verify-vault with hashicorp requires --vault-url
```

The same seam also had unique missing-setting text for Azure, HashiCorp, and GCP and ignored provider settings from config.

## What changed

- Route decrypt vault verification through the resolver used by vault-push and vault-pull.
- Share one provider URL resolver across sync, vault commands, and decrypt.
- Preserve HashiCorp precedence: explicit flag, config, then stripped `VAULT_ADDR`.
- Treat whitespace-only `VAULT_ADDR` as unset and reuse the shared provider error constants.
- Resolve config settings for all supported providers: Azure, AWS, HashiCorp, and GCP.
- Document config and `VAULT_ADDR` behavior for decrypt verification.

## Regression coverage

- Added message-parity checks across sync, vault-pull, and decrypt for Azure, HashiCorp, and GCP.
- Added config-resolution checks for all four providers.
- Added HashiCorp fallback, padded-value stripping, precedence, and whitespace-only tests.
- Failing-before proof against `origin/main`: 10 failed, 14 passed.
- Fixed focused suite: 24 passed; encryption coverage suite combined: 56 passed.
- Relevant Vault integration file: 8 passed.
- Real Vault dev-container run using only `VAULT_ADDR` and `VAULT_TOKEN`: seeded key verified successfully with exit 0; the temporary secret was deleted afterward.

## Gates

- `uv sync --all-extras`
- `uv run ruff check src tests`
- `uv run ruff format --check .`
- `uv run pyrefly check`
- `uv run bandit -r src -c pyproject.toml`
- `uv run pytest -m "not integration"` (3465 passed, 8 skipped, 2 xfailed)
- `make lint-docs` (0 errors)

Closes #653

🤖 Generated with Codex (gpt-5.6-sol) orchestrated by Claude Code

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jainal09/envdrift/pull/662?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `decrypt --verify-vault` handling for provider settings.
  * Vault URLs and related settings now consistently honor CLI values, configuration, and environment fallbacks.
  * Added support for HashiCorp `VAULT_ADDR` fallback with whitespace trimming.
  * Improved validation and consistency of missing-setting error messages across vault commands.

* **Documentation**
  * Expanded `--verify-vault` guidance, including setting precedence and provider-specific examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes decrypt vault verification use the shared vault settings path. The main changes are:

- Shared provider URL resolution across decrypt, sync, and vault commands.
- Config-based provider settings for Azure, AWS, HashiCorp, and GCP.
- HashiCorp `VAULT_ADDR` fallback with whitespace stripping.
- Matching missing-setting messages across command seams.
- Updated decrypt documentation and regression tests.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/envdrift/cli_commands/encryption.py | Decrypt verification now resolves vault settings through the shared resolver before contacting the vault provider. |
| src/envdrift/cli_commands/vault_helpers.py | Vault setting resolution can reuse an already loaded config object and delegates provider URL lookup to the shared helper. |
| src/envdrift/cli_commands/sync_config_helpers.py | Provider URL resolution is exposed for shared use while preserving CLI, config, and HashiCorp environment precedence. |
| tests/unit/test_vault_error_ux.py | Tests cover decrypt setting resolution, missing-setting message parity, and HashiCorp environment fallback behavior. |
| docs/cli/decrypt.md | Decrypt documentation now describes config resolution, `VAULT_ADDR`, and effective recovery hint values. |

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/verify-vaul..."](https://github.com/jainal09/envdrift/commit/9dd04704789087d8e76947948c50427abfa65dca) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43935441)</sub>

<!-- /greptile_comment -->