### PR TITLE
fix(lock): verify skipped vault secrets before encryption

### DIFF
--- a/docs/cli/lock.md
+++ b/docs/cli/lock.md
@@ -117,6 +117,9 @@ The same hard-failure contract applies: when any mapping's key fails to sync
 (missing vault secret, vault error), `lock` exits 1 **before** encrypting
 anything — even with `--force`. Encrypting past a failed sync would mint a
 fresh local-only key for the very mapping whose vault key is unavailable.
+The verification phase checks that every configured vault secret exists and
+contains usable key material even when its mapping has no local env file yet;
+an unavailable or unusable secret is an error, not a successful skip.
 
 ```bash
 envdrift lock --sync-keys

--- a/src/envdrift/cli_commands/sync_helpers.py
+++ b/src/envdrift/cli_commands/sync_helpers.py
@@ -144,7 +144,12 @@ def _raise_hook_errors(errors: list[str]) -> None:
         raise typer.Exit(code=1)
 
 
-def _new_sync_engine(context: SyncCommandContext, force: bool):
+def _new_sync_engine(
+    context: SyncCommandContext,
+    force: bool,
+    *,
+    verify_skipped_secrets: bool = False,
+):
     from envdrift.sync.engine import SyncEngine, SyncMode
 
     def progress_callback(msg: str) -> None:
@@ -162,7 +167,10 @@ def _new_sync_engine(context: SyncCommandContext, force: bool):
     return SyncEngine(
         config=context.filtered_config,
         vault_client=context.vault_client,
-        mode=SyncMode(force_update=force),
+        mode=SyncMode(
+            force_update=force,
+            verify_skipped_secrets=verify_skipped_secrets,
+        ),
         prompt_callback=prompt_callback,
         progress_callback=progress_callback,
     )

--- a/src/envdrift/cli_commands/sync_lock_keys.py
+++ b/src/envdrift/cli_commands/sync_lock_keys.py
@@ -29,7 +29,11 @@ def _sync_lock_keys(request: LockRequest, context: SyncCommandContext) -> None:
     from envdrift.output.rich import print_service_sync_status, print_sync_result
     from envdrift.sync.config import SyncConfigError
 
-    engine = _new_sync_engine(context, request.force)
+    engine = _new_sync_engine(
+        context,
+        request.force,
+        verify_skipped_secrets=True,
+    )
     try:
         sync_result = engine.sync_all()
     except (VaultError, SyncConfigError, SecretNotFoundError) as exc:

--- a/src/envdrift/sync/engine.py
+++ b/src/envdrift/sync/engine.py
@@ -49,6 +49,8 @@ class SyncMode:
     validate_schema: bool = False
     schema_path: str | None = None
     service_dir: Path | None = None
+    # Sync-capable workflows can promise verification without becoming read-only.
+    verify_skipped_secrets: bool = False
 
 
 @dataclass
@@ -126,7 +128,9 @@ class SyncEngine:
                 or detection.path is None
                 or detection.environment is None
             ):
-                if self.mode.verify_only:
+                # ``lock --sync-keys`` still creates/updates local keys, but its
+                # verification-labeled phase must validate mappings it skips.
+                if self.mode.verify_only or self.mode.verify_skipped_secrets:
                     self._verify_secret_usable(mapping)
                 if detection.status == "multiple_found":
                     # Distinct, truthful skip reason: the folder has several

--- a/tests/integration/test_vault_verify_flows.py
+++ b/tests/integration/test_vault_verify_flows.py
@@ -306,6 +306,58 @@ class TestLockVerifyVaultCannotVerify:
         assert "fresh-plain" not in env_file.read_text(encoding="utf-8")
 
 
+class TestLockSyncKeysVerifySemantics:
+    """#663: lock's key-sync phase makes a verification claim and must honor it."""
+
+    def test_deleted_secret_without_env_file_fails_closed(
+        self,
+        tmp_path: Path,
+        vault_endpoint: str,
+        vault_client,
+        vault_prefix: str,
+        integration_pythonpath: str,
+        envdrift_cmd: list[str],
+    ) -> None:
+        """A deleted secret is an error even when no local env file exists."""
+        env = _child_env(vault_endpoint, integration_pythonpath)
+        secret_path = f"{vault_prefix}/deleted-lock-key"
+        _store_vault_value(
+            vault_client,
+            secret_path,
+            "DOTENV_PRIVATE_KEY_PRODUCTION=deleted-key-value",
+        )
+        vault_client.secrets.kv.v2.delete_metadata_and_all_versions(
+            path=secret_path,
+            mount_point="secret",
+        )
+
+        project = tmp_path / "project"
+        (project / "svc").mkdir(parents=True)
+        (project / "envdrift.toml").write_text(
+            _config_toml(secret_path, "svc"),
+            encoding="utf-8",
+        )
+
+        result = _run(
+            envdrift_cmd,
+            ["lock", "--sync-keys", "--force", "-p", "hashicorp", "--vault-url", vault_endpoint],
+            project,
+            env,
+        )
+
+        out = _norm(result)
+        assert result.returncode == 1, (
+            f"lock --sync-keys accepted a deleted secret with no env file:\n"
+            f"{result.stdout}\n{result.stderr}"
+        )
+        assert "Verifying keys with vault" in out
+        assert secret_path in out
+        assert "not found" in out.lower()
+        assert "All services synced successfully" not in out
+        assert "Encrypting environment files" not in out
+        assert not (project / "svc" / ".env.keys").exists()
+
+
 class TestDecryptVerifyVaultQuotedValue:
     """Item 2 of #473: the quoted dotenvx vault value format must verify, not false-fail."""
 

--- a/tests/unit/coverage/test_cov_cli_commands_sync.py
+++ b/tests/unit/coverage/test_cov_cli_commands_sync.py
@@ -1049,6 +1049,32 @@ class TestLockCommand:
         assert "Verifying keys with vault" in result.output
 
     @patch("envdrift.cli_commands.encryption_helpers.resolve_encryption_backend")
+    def test_lock_sync_keys_missing_secret_without_env_file_fails(
+        self, mock_resolve, tmp_path, loaded_config, no_git_hook
+    ):
+        """#663: the verification step must probe secrets on engine skip paths."""
+        backend = DummyEncryptionBackend()
+        mock_resolve.return_value = (backend, EncryptionProvider.DOTENVX, None)
+        client = MagicMock()
+        client.get_secret.side_effect = SecretNotFoundError("Secret not found: deleted-key")
+        mapping = ServiceMapping(
+            secret_name="deleted-key",
+            folder_path=tmp_path,
+            environment="production",
+        )
+        loaded_config(_sync_config([mapping]), client)
+
+        result = runner.invoke(app, ["lock", "--sync-keys", "--force"])
+        normalized = " ".join(result.output.split())
+
+        assert result.exit_code == 1, result.output
+        assert "Secret not found" in normalized
+        assert "All services synced successfully" not in normalized
+        assert "Encrypting environment files" not in normalized
+        assert backend.encrypt_calls == []
+        client.get_secret.assert_called_once_with("deleted-key")
+
+    @patch("envdrift.cli_commands.encryption_helpers.resolve_encryption_backend")
     def test_lock_sync_keys_error_with_force_still_refuses(
         self, mock_resolve, monkeypatch, tmp_path, loaded_config, no_git_hook
     ):

--- a/tests/unit/test_sync_engine_verify.py
+++ b/tests/unit/test_sync_engine_verify.py
@@ -263,20 +263,36 @@ class TestVerifyModeVaultSecretExistence:
 class TestVerifySkippedSecretsMode:
     """#663: sync workflows that claim verification must probe skip paths."""
 
-    def test_missing_secret_without_env_file_is_error(self, tmp_path: Path) -> None:
-        """A sync-capable verify step must not skip a deleted vault secret."""
+    @pytest.mark.parametrize(
+        ("vault_values", "expected_error"),
+        [
+            pytest.param({}, "test-key", id="missing"),
+            pytest.param(
+                {"test-key": '{"username": "admin", "password": "value"}'},
+                "JSON",
+                id="unusable",
+            ),
+        ],
+    )
+    def test_missing_or_unusable_secret_without_env_file_is_error(
+        self,
+        tmp_path: Path,
+        vault_values: dict[str, str],
+        expected_error: str,
+    ) -> None:
+        """A sync-capable verify step must reject unusable vault state."""
         service_dir = tmp_path / "svc"
         service_dir.mkdir()
         config = SyncConfig(
             mappings=[
                 ServiceMapping(
-                    secret_name="deleted-key",
+                    secret_name="test-key",
                     folder_path=service_dir,
                     environment="production",
                 ),
             ],
         )
-        client = _StoredVaultClient({})
+        client = _StoredVaultClient(vault_values)
 
         engine = SyncEngine(
             config=config,
@@ -287,34 +303,7 @@ class TestVerifySkippedSecretsMode:
 
         service = result.services[0]
         assert service.action == SyncAction.ERROR
-        assert service.error and "deleted-key" in service.error, service
-        assert result.has_errors and result.exit_code == 1
-
-    def test_unusable_secret_without_env_file_is_error(self, tmp_path: Path) -> None:
-        """The sync-capable verification path applies key-shape validation."""
-        service_dir = tmp_path / "svc"
-        service_dir.mkdir()
-        config = SyncConfig(
-            mappings=[
-                ServiceMapping(
-                    secret_name="unusable-key",
-                    folder_path=service_dir,
-                    environment="production",
-                ),
-            ],
-        )
-        client = _StoredVaultClient({"unusable-key": '{"username": "admin", "password": "value"}'})
-
-        engine = SyncEngine(
-            config=config,
-            vault_client=client,
-            mode=SyncMode(force_update=True, verify_skipped_secrets=True),
-        )
-        result = engine.sync_all()
-
-        service = result.services[0]
-        assert service.action == SyncAction.ERROR
-        assert service.error and "JSON" in service.error, service
+        assert service.error and expected_error in service.error, service
         assert result.has_errors and result.exit_code == 1
 
     def test_existing_env_file_still_syncs(self, tmp_path: Path) -> None:

--- a/tests/unit/test_sync_engine_verify.py
+++ b/tests/unit/test_sync_engine_verify.py
@@ -260,6 +260,91 @@ class TestVerifyModeVaultSecretExistence:
         assert result.has_errors
 
 
+class TestVerifySkippedSecretsMode:
+    """#663: sync workflows that claim verification must probe skip paths."""
+
+    def test_missing_secret_without_env_file_is_error(self, tmp_path: Path) -> None:
+        """A sync-capable verify step must not skip a deleted vault secret."""
+        service_dir = tmp_path / "svc"
+        service_dir.mkdir()
+        config = SyncConfig(
+            mappings=[
+                ServiceMapping(
+                    secret_name="deleted-key",
+                    folder_path=service_dir,
+                    environment="production",
+                ),
+            ],
+        )
+        client = _StoredVaultClient({})
+
+        engine = SyncEngine(
+            config=config,
+            vault_client=client,
+            mode=SyncMode(force_update=True, verify_skipped_secrets=True),
+        )
+        result = engine.sync_all()
+
+        service = result.services[0]
+        assert service.action == SyncAction.ERROR
+        assert service.error and "deleted-key" in service.error, service
+        assert result.has_errors and result.exit_code == 1
+
+    def test_unusable_secret_without_env_file_is_error(self, tmp_path: Path) -> None:
+        """The sync-capable verification path applies key-shape validation."""
+        service_dir = tmp_path / "svc"
+        service_dir.mkdir()
+        config = SyncConfig(
+            mappings=[
+                ServiceMapping(
+                    secret_name="unusable-key",
+                    folder_path=service_dir,
+                    environment="production",
+                ),
+            ],
+        )
+        client = _StoredVaultClient({"unusable-key": '{"username": "admin", "password": "value"}'})
+
+        engine = SyncEngine(
+            config=config,
+            vault_client=client,
+            mode=SyncMode(force_update=True, verify_skipped_secrets=True),
+        )
+        result = engine.sync_all()
+
+        service = result.services[0]
+        assert service.action == SyncAction.ERROR
+        assert service.error and "JSON" in service.error, service
+        assert result.has_errors and result.exit_code == 1
+
+    def test_existing_env_file_still_syncs(self, tmp_path: Path) -> None:
+        """Skip-path verification must not make lock key sync read-only."""
+        service_dir = tmp_path / "svc"
+        service_dir.mkdir()
+        (service_dir / ".env.production").write_text("SECRET=encrypted:value\n")
+        (service_dir / ".env.keys").write_text("DOTENV_PRIVATE_KEY_PRODUCTION=old-key\n")
+        config = SyncConfig(
+            mappings=[
+                ServiceMapping(
+                    secret_name="current-key",
+                    folder_path=service_dir,
+                    environment="production",
+                ),
+            ],
+        )
+        client = _StoredVaultClient({"current-key": "DOTENV_PRIVATE_KEY_PRODUCTION=new-key"})
+
+        engine = SyncEngine(
+            config=config,
+            vault_client=client,
+            mode=SyncMode(force_update=True, verify_skipped_secrets=True),
+        )
+        result = engine.sync_all()
+
+        assert result.services[0].action == SyncAction.UPDATED
+        assert "DOTENV_PRIVATE_KEY_PRODUCTION=new-key" in (service_dir / ".env.keys").read_text()
+
+
 class TestProcessingLineIdentity:
     """#441: progress lines identify the mapping, not just the folder."""
 


### PR DESCRIPTION
## What was broken

Against the live HashiCorp Vault container on current `main` (`f460bda`), I
created and then deleted `test/edge663-lock-deleted`, configured a mapping with
an existing folder but no local env file, and ran:

```text
env TERM=dumb COLUMNS=80 NO_COLOR=1 FORCE_COLOR=0 \
  VAULT_ADDR=http://127.0.0.1:8200 VAULT_TOKEN=test-root-token \
  uv run envdrift lock --sync-keys
```

The command printed `Step 1: Verifying keys with vault...`, skipped the mapping,
reported `All services synced successfully`, continued to the encryption step,
and exited 0 with `Lock complete` even though the configured secret was gone.

`pull` was audited with the same deleted-secret setup. Its phase is explicitly
labeled `Syncing keys from vault`, not verification, so its ordinary sync/skip
semantics remain unchanged.

## What changed

- Added a sync-capable verification mode for skip paths. It reuses the existing
  `_verify_secret_usable()` seam from #661 instead of duplicating Vault fetch,
  normalization, key-shape, or environment-label validation.
- Enabled that mode only for `lock --sync-keys`. Missing or unusable configured
  secrets now produce an error row, block encryption, and exit 1.
- Preserved normal key creation and updates when a mapping has a local env file;
  the lock workflow is still a sync operation rather than read-only verify mode.
- Documented the strict skip-path verification contract in `docs/cli/lock.md`.

## Regression coverage

- Engine tests cover missing and unusable secrets without a local env file, plus
  a guard that existing env files still update.
- A CLI-level lock test proves the Vault secret is queried, success output is
  absent, encryption never starts, and exit status is 1.
- A skip-gated integration test creates and permanently deletes a real KV v2
  secret, then drives the real CLI against Vault and dotenvx.
- Fail-before proof with `git checkout origin/main -- src/`: 2 targeted tests
  failed, including the exact CLI false success (`exit 0`, success banner, and
  encryption step). Restoring the fixed source made all 4 focused tests pass.

## Gates run

- `uv sync --all-extras`
- `uv run ruff check src tests` — clean
- `uv run ruff format --check .` — 241 files formatted
- `uv run pyrefly check` — 0 errors
- `uv run bandit -r src -c pyproject.toml` — 0 findings
- `make lint-docs` — 61 files, 0 errors
- `uv run pytest -m "not integration"` — 3,484 passed, 6 skipped,
  2 xfailed, 557 deselected
- `uv run pytest tests/integration/test_vault_verify_flows.py -q` — 9 passed
- Relevant unit files — 98 passed

Closes #663

🤖 Generated with Codex (gpt-5.6-sol) orchestrated by Claude Code

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes `lock --sync-keys` fail before encryption when configured Vault key material is missing or unusable.

- Adds an opt-in skipped-secret verification mode to the sync engine.
- Enables that mode for the lock key-sync workflow.
- Reuses the existing Vault key-material verification path.
- Documents the stricter lock behavior.
- Adds unit, CLI, and integration tests for the deleted-secret case.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/envdrift/sync/engine.py | Adds skipped-secret verification to the sync engine and turns failed Vault checks into sync errors. |
| src/envdrift/cli_commands/sync_lock_keys.py | Enables skipped-secret verification for `lock --sync-keys` before encryption can run. |
| src/envdrift/cli_commands/sync_helpers.py | Adds an opt-in engine construction flag that defaults to the existing behavior. |
| docs/cli/lock.md | Documents that lock verifies configured Vault secrets even when a local env file is absent. |
| tests/unit/test_sync_engine_verify.py | Adds unit coverage for missing and unusable skipped Vault secrets. |
| tests/unit/coverage/test_cov_cli_commands_sync.py | Adds CLI coverage for failing before encryption when skipped verification fails. |
| tests/integration/test_vault_verify_flows.py | Adds integration coverage for a deleted real Vault KV secret. |

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/lock-sync-k..."](https://github.com/jainal09/envdrift/commit/05fefa53162c463df83aba5f607ea3063e7aa1b5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44010664)</sub>

<!-- /greptile_comment -->