### PR TITLE
fix(schema): honor pydantic settings env prefixes

### DIFF
--- a/docs/cli/validate.md
+++ b/docs/cli/validate.md
@@ -25,6 +25,10 @@ Type validation mirrors what the real app does at startup:
   pydantic-settings actually passes through, so an empty `int`/`float`/`bool`
   field fails like the real app (unless the schema sets `env_ignore_empty=True`,
   in which case the value counts as unset).
+- `SettingsConfigDict(env_prefix="MYAPP_")` is applied to plain field names, so
+  `api_key` binds to `MYAPP_API_KEY` under the default case-insensitive matching.
+  Explicit field aliases and validation aliases bypass the prefix, and
+  `case_sensitive=True` requires the prefix and field-name casing to match exactly.
 - Complex fields (`list`, `dict`, nested models) are JSON-decoded first, exactly
   like the pydantic-settings env source: `TAGS=a,b,c` fails for `TAGS: list[str]`
   while `TAGS=["a","b","c"]` passes.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -161,6 +161,12 @@ validator = Validator()
 result = validator.validate(env, schema)
 ```
 
+Schema validation honors pydantic-settings environment bindings. Plain field
+names include `SettingsConfigDict(env_prefix=...)`; explicit aliases bypass the
+prefix, and `case_sensitive=True` uses exact-case matching. Constraint checks
+still pass model field names or aliases to Pydantic rather than prefixed
+environment names.
+
 ### DiffEngine
 
 Compare env files.

--- a/src/envdrift/core/schema.py
+++ b/src/envdrift/core/schema.py
@@ -32,10 +32,14 @@ class FieldMetadata:
     description: str | None
     field_type: type
     annotation: str
-    # The Pydantic alias (the real env-var name) when the attribute name differs,
-    # e.g. a field ``X_API_KEY`` with ``Field(alias='X-API-KEY')``. Validation
-    # matches the .env against this when present so a non-identifier key resolves.
+    # The effective Pydantic validation alias used as the input key for
+    # ``model_validate``. ``validation_alias`` takes precedence over ``alias``.
     alias: str | None = None
+    # The effective environment binding name. Plain fields include the model's
+    # ``env_prefix``; explicit aliases bypass the prefix, matching
+    # pydantic-settings. Kept separate from ``alias`` because model validation
+    # expects field names/aliases, never prefixed environment names (#669).
+    env_name: str | None = None
     # The field's ``FieldInfo.metadata`` — pydantic strips ``Annotated[...]``
     # extras (constraint markers, ``pydantic.Json``, ...) into it, and the
     # env-source complexity/coercion decision needs it: a ``Json`` marker makes
@@ -75,6 +79,9 @@ class SchemaMetadata:
     # when False (the pydantic-settings default) the model sees the empty string
     # and e.g. ``PORT=`` crashes an int field at startup (#472).
     env_ignore_empty: bool = False
+    # Mirrors SettingsConfigDict(case_sensitive=...). Environment binding names
+    # are folded only when False, the pydantic-settings default.
+    case_sensitive: bool = False
 
     @property
     def required_fields(self) -> list[str]:
@@ -265,6 +272,18 @@ class SchemaLoader:
             ignore_empty = getattr(model_config, "env_ignore_empty", False)
         schema.env_ignore_empty = bool(ignore_empty)
 
+        # The prefix is part of the environment-source binding for plain fields,
+        # while an explicit alias bypasses it. Matching folds the resulting name
+        # only when the model is case-insensitive (#669).
+        if isinstance(model_config, dict):
+            raw_env_prefix = model_config.get("env_prefix", "")
+            case_sensitive = model_config.get("case_sensitive", False)
+        else:
+            raw_env_prefix = getattr(model_config, "env_prefix", "")
+            case_sensitive = getattr(model_config, "case_sensitive", False)
+        env_prefix = raw_env_prefix if isinstance(raw_env_prefix, str) else ""
+        schema.case_sensitive = bool(case_sensitive)
+
         # Track whether any field needs real Pydantic validation (a constraint, a
         # non-plain-scalar type such as Literal/EmailStr/a nested model, or a
         # custom validator). A model with only plain str/int/float/bool fields is
@@ -308,10 +327,11 @@ class SchemaLoader:
             else:
                 type_str = "Any"
 
-            # The real env-var name when it differs from the attribute name
-            # (validation_alias takes precedence over alias when both are set).
+            # The model-validation input alias. The environment binding is kept
+            # separately because plain fields add env_prefix while aliases do not.
             field_alias = field_info.validation_alias or field_info.alias
             field_alias = field_alias if isinstance(field_alias, str) else None
+            env_name = field_alias or f"{env_prefix}{field_name}"
 
             schema.fields[field_name] = FieldMetadata(
                 name=field_name,
@@ -322,6 +342,7 @@ class SchemaLoader:
                 field_type=annotation if annotation else type(None),
                 annotation=type_str,
                 alias=field_alias,
+                env_name=env_name,
                 type_metadata=tuple(field_info.metadata),
             )
 

--- a/src/envdrift/core/validator.py
+++ b/src/envdrift/core/validator.py
@@ -76,14 +76,20 @@ def _unparsed_line_warnings(env_file: EnvFile) -> list[str]:
     ]
 
 
-def _field_lookup_key(fm: FieldMetadata) -> str:
-    """Lower-cased env-var name a schema field binds to.
+def _normalize_env_name(name: str, case_sensitive: bool) -> str:
+    """Return the environment lookup key for the model's case policy."""
+    return name if case_sensitive else name.lower()
 
-    A field is matched against the .env by its alias when it has one (the
-    real env-var name, e.g. ``X-API-KEY`` for attribute ``X_API_KEY``),
-    else by its attribute name — mirroring how pydantic-settings binds.
+
+def _field_lookup_key(fm: FieldMetadata, case_sensitive: bool = False) -> str:
+    """Return the normalized env-var name a schema field binds to.
+
+    ``env_name`` is extracted from pydantic-settings configuration: plain
+    fields include ``env_prefix`` while explicit aliases bypass it. The
+    alias/name fallbacks preserve manually constructed metadata.
     """
-    return (fm.alias or fm.name).lower()
+    env_name = fm.env_name or fm.alias or fm.name
+    return _normalize_env_name(env_name, case_sensitive)
 
 
 def _warn_leading_bom(env_file: EnvFile, result: ValidationResult) -> None:
@@ -106,42 +112,41 @@ def _warn_leading_bom(env_file: EnvFile, result: ValidationResult) -> None:
 
 
 def _index_env_variables(
-    env_file: EnvFile, result: ValidationResult
+    env_file: EnvFile, result: ValidationResult, case_sensitive: bool = False
 ) -> tuple[set[str], dict[str, EnvVar]]:
-    """One pass over the env vars deriving everything case-insensitive matching needs.
+    """Index env vars using the schema's case-matching policy.
 
-    (Pydantic Settings defaults to case_insensitive):
-      - env_names_lower: lower-cased names present (missing/extra checks)
-      - env_by_lower:    lower-cased name -> env var, last-wins like Pydantic
-    A case-only collision (e.g. ``API_KEY`` + ``api_key``) is surfaced as
-    a warning instead of silently dropping a value (see issue #306).
+    Pydantic Settings defaults to case-insensitive matching. In that mode a
+    case-only collision is surfaced as a warning instead of silently dropping
+    a value (see issue #306), while the last value wins like Pydantic. With
+    ``case_sensitive=True``, differently cased names stay distinct (#669).
     """
-    env_names_lower: set[str] = set()
-    env_by_lower: dict[str, EnvVar] = {}
+    env_names: set[str] = set()
+    env_by_name: dict[str, EnvVar] = {}
     env_groups: dict[str, list[str]] = {}
     for name, env_var in env_file.variables.items():
-        lower = name.lower()
-        env_names_lower.add(lower)
-        env_by_lower[lower] = env_var  # last-wins, mirroring Pydantic Settings
-        env_groups.setdefault(lower, []).append(name)
+        lookup_name = _normalize_env_name(name, case_sensitive)
+        env_names.add(lookup_name)
+        env_by_name[lookup_name] = env_var  # last-wins, mirroring Pydantic Settings
+        env_groups.setdefault(lookup_name, []).append(name)
 
-    for lower_name, names in env_groups.items():
+    for lookup_name, names in env_groups.items():
         if len(names) > 1:
             kept = names[-1]
             dropped = ", ".join(repr(n) for n in names[:-1])
             result.warnings.append(
-                f"Case-insensitive name collision for {lower_name!r}: "
+                f"Case-insensitive name collision for {lookup_name!r}: "
                 f"{', '.join(repr(n) for n in names)} all map to the same field; "
                 f"value from {kept!r} is used, {dropped} ignored"
             )
 
-    return env_names_lower, env_by_lower
+    return env_names, env_by_name
 
 
 def _check_extra_vars(
     env_file: EnvFile,
     schema: SchemaMetadata,
-    schema_names_lower: set[str],
+    schema_names: set[str],
     result: ValidationResult,
 ) -> None:
     """Record variables the schema does not declare.
@@ -153,7 +158,8 @@ def _check_extra_vars(
     extra = {
         name
         for name in env_file.variables
-        if name.lower() not in schema_names_lower and not is_dotenvx_public_key_var(name)
+        if _normalize_env_name(name, schema.case_sensitive) not in schema_names
+        and not is_dotenvx_public_key_var(name)
     }
     if not extra:
         return
@@ -166,7 +172,7 @@ def _check_extra_vars(
 
 
 def _collect_constraint_values(
-    schema: SchemaMetadata, env_by_lower: dict[str, EnvVar]
+    schema: SchemaMetadata, env_by_name: dict[str, EnvVar]
 ) -> dict[str, Any]:
     """Assemble the values dict the constraint pass feeds to the live model.
 
@@ -176,7 +182,7 @@ def _collect_constraint_values(
     """
     values: dict[str, Any] = {}
     for field_name, field_meta in schema.fields.items():
-        env_var = env_by_lower.get(_field_lookup_key(field_meta))
+        env_var = env_by_name.get(_field_lookup_key(field_meta, schema.case_sensitive))
         if env_var is None:
             continue
         value = env_var.value
@@ -288,19 +294,20 @@ class Validator:
         # Pydantic Settings defaults to case_sensitive=False, loading e.g.
         # `API_KEY` from a conventional UPPERCASE .env into a lowercase
         # `api_key` field. Mirror that here by matching names case-insensitively
-        # (via ``_field_lookup_key``) so an UPPERCASE .env against a lowercase
-        # schema is not falsely reported as both missing_required and
-        # extra_vars (see issue #306).
-        schema_names_lower = {_field_lookup_key(fm) for fm in schema.fields.values()}
-        env_names_lower, env_by_lower = _index_env_variables(env_file, result)
+        # unless the model opts into exact-case matching. ``_field_lookup_key``
+        # also includes ``env_prefix`` for plain fields (#669).
+        schema_names = {
+            _field_lookup_key(fm, schema.case_sensitive) for fm in schema.fields.values()
+        }
+        env_names, env_by_name = _index_env_variables(env_file, result, schema.case_sensitive)
 
-        self._check_missing(schema, env_names_lower, env_by_lower, result)
+        self._check_missing(schema, env_names, env_by_name, result)
         if check_extra:
-            _check_extra_vars(env_file, schema, schema_names_lower, result)
+            _check_extra_vars(env_file, schema, schema_names, result)
         if check_encryption:
-            self._check_sensitive_encryption(env_file, schema, env_by_lower, result)
-        self._check_base_types(schema, env_by_lower, result)
-        self._check_constraints(schema, env_by_lower, result)
+            self._check_sensitive_encryption(env_file, schema, env_by_name, result)
+        self._check_base_types(schema, env_by_name, result)
+        self._check_constraints(schema, env_by_name, result)
 
         # Determine overall validity
         # Note: unencrypted_secrets are warnings, not errors
@@ -312,8 +319,8 @@ class Validator:
     def _check_missing(
         self,
         schema: SchemaMetadata,
-        env_names_lower: set[str],
-        env_by_lower: dict[str, EnvVar],
+        env_names: set[str],
+        env_by_name: dict[str, EnvVar],
         result: ValidationResult,
     ) -> None:
         """Record required fields absent from the .env, and optional ones as warnings.
@@ -326,24 +333,25 @@ class Validator:
         for field_name, field_meta in schema.fields.items():
             if not field_meta.required:
                 continue
-            env_var = env_by_lower.get(_field_lookup_key(field_meta))
+            env_var = env_by_name.get(_field_lookup_key(field_meta, schema.case_sensitive))
             if env_var is None or (env_var.value == "" and schema.env_ignore_empty):
                 result.missing_required.add(field_name)
 
         for field_name, field_meta in schema.fields.items():
-            if not field_meta.required and _field_lookup_key(field_meta) not in env_names_lower:
+            lookup_key = _field_lookup_key(field_meta, schema.case_sensitive)
+            if not field_meta.required and lookup_key not in env_names:
                 result.missing_optional.add(field_name)
 
     def _check_sensitive_encryption(
         self,
         env_file: EnvFile,
         schema: SchemaMetadata,
-        env_by_lower: dict[str, EnvVar],
+        env_by_name: dict[str, EnvVar],
         result: ValidationResult,
     ) -> None:
         """Record schema-sensitive fields left in plaintext, and suspicious lookalikes."""
         for field_name, field_meta in schema.fields.items():
-            env_var = env_by_lower.get(_field_lookup_key(field_meta))
+            env_var = env_by_name.get(_field_lookup_key(field_meta, schema.case_sensitive))
             if env_var is None:
                 continue
 
@@ -355,19 +363,23 @@ class Validator:
         # Also check for suspicious plaintext values. The dotenvx public-key
         # artifact is, by definition, public — its ``*_KEY`` name must not
         # produce a bogus "mark it sensitive" warning (#472).
-        sensitive_lower = {name.lower() for name in schema.sensitive_fields}
+        sensitive_names = {
+            _field_lookup_key(field_meta, schema.case_sensitive)
+            for field_meta in schema.fields.values()
+            if field_meta.sensitive
+        }
         for var_name, env_var in env_file.variables.items():
             if is_dotenvx_public_key_var(var_name):
                 continue
             if env_var.encryption_status == EncryptionStatus.PLAINTEXT:
                 if self.is_value_suspicious(env_var.value):
-                    if var_name.lower() not in sensitive_lower:
+                    if _normalize_env_name(var_name, schema.case_sensitive) not in sensitive_names:
                         result.warnings.append(
                             f"'{var_name}' looks like a secret but "
                             "is not marked sensitive in schema"
                         )
                 if self.is_name_suspicious(var_name):
-                    if var_name.lower() not in sensitive_lower:
+                    if _normalize_env_name(var_name, schema.case_sensitive) not in sensitive_names:
                         result.warnings.append(
                             f"'{var_name}' has a name suggesting sensitive data "
                             "but is not marked sensitive in schema"
@@ -376,7 +388,7 @@ class Validator:
     def _check_base_types(
         self,
         schema: SchemaMetadata,
-        env_by_lower: dict[str, EnvVar],
+        env_by_name: dict[str, EnvVar],
         result: ValidationResult,
     ) -> None:
         """Base type validation against the value pydantic-settings will see.
@@ -388,7 +400,7 @@ class Validator:
         an int field here exactly as it fails the real app at startup.
         """
         for field_name, field_meta in schema.fields.items():
-            env_var = env_by_lower.get(_field_lookup_key(field_meta))
+            env_var = env_by_name.get(_field_lookup_key(field_meta, schema.case_sensitive))
             if env_var is None:
                 continue
             if env_var.value == "" and schema.env_ignore_empty:
@@ -403,7 +415,7 @@ class Validator:
     def _check_constraints(
         self,
         schema: SchemaMetadata,
-        env_by_lower: dict[str, EnvVar],
+        env_by_name: dict[str, EnvVar],
         result: ValidationResult,
     ) -> None:
         """Field-constraint validation (ge/le, Literal, min_length, pattern, ...).
@@ -419,7 +431,7 @@ class Validator:
 
         from pydantic import ValidationError
 
-        values = _collect_constraint_values(schema, env_by_lower)
+        values = _collect_constraint_values(schema, env_by_name)
         try:
             schema.model_class.model_validate(values)
         except ValidationError as exc:

--- a/tests/unit/test_validator.py
+++ b/tests/unit/test_validator.py
@@ -637,13 +637,141 @@ class TestValidatorAliasMatching:
         assert result.valid is False
         assert "X_API_KEY" in result.missing_required
 
+    def test_aliased_sensitive_field_gets_no_contradictory_warning(self, tmp_path):
+        """Sensitive-warning suppression uses the effective env binding (#658)."""
+
+        class AliasedSensitiveSettings(BaseSettings):
+            api_key: str = Field(alias="X_API_KEY", json_schema_extra={"sensitive": True})
+
+        secret = "sk-" + "live-abcdef1234567890"
+        env_file = tmp_path / ".env"
+        env_file.write_text(f"X_API_KEY={secret}\n", encoding="utf-8")
+        env = EnvParser().parse(env_file)
+        schema = SchemaLoader().extract_metadata(AliasedSensitiveSettings)
+
+        result = Validator().validate(env, schema)
+
+        assert "api_key" in result.unencrypted_secrets
+        assert not [warning for warning in result.warnings if "not marked sensitive" in warning]
+
+
+class TestValidatorEnvPrefix:
+    """#669: validation mirrors pydantic-settings ``env_prefix`` bindings."""
+
+    def test_prefixed_sensitive_field_validates_without_contradictory_warnings(self, tmp_path):
+        class Settings(BaseSettings):
+            model_config = SettingsConfigDict(env_prefix="MYAPP_", extra="forbid")
+
+            api_key: str = Field(json_schema_extra={"sensitive": True})
+
+        secret = "sk-" + "live-abcdef1234567890"
+        env_file = tmp_path / ".env"
+        env_file.write_text(f"MYAPP_API_KEY={secret}\n", encoding="utf-8")
+        env = EnvParser().parse(env_file)
+        schema = SchemaLoader().extract_metadata(Settings)
+
+        result = Validator().validate(env, schema)
+
+        assert schema.fields["api_key"].env_name == "MYAPP_api_key"
+        assert result.valid is True
+        assert result.missing_required == set()
+        assert result.extra_vars == set()
+        assert result.unencrypted_secrets == {"api_key"}
+        assert not [warning for warning in result.warnings if "not marked sensitive" in warning]
+
+    def test_prefixed_type_and_constraint_errors_use_model_field_keys(self, tmp_path):
+        class Settings(BaseSettings):
+            model_config = SettingsConfigDict(env_prefix="MYAPP_", extra="forbid")
+
+            port: int
+            retry_count: int = Field(ge=1)
+
+        env_file = tmp_path / ".env"
+        env_file.write_text("MYAPP_PORT=not-an-int\nMYAPP_RETRY_COUNT=0\n", encoding="utf-8")
+        env = EnvParser().parse(env_file)
+        schema = SchemaLoader().extract_metadata(Settings)
+
+        result = Validator().validate(env, schema, check_encryption=False)
+
+        assert result.missing_required == set()
+        assert result.extra_vars == set()
+        assert "Expected integer" in result.type_errors["port"]
+        assert "greater than or equal to 1" in result.type_errors["retry_count"]
+        assert result.valid is False
+
+    def test_aliases_bypass_env_prefix(self, tmp_path):
+        class Settings(BaseSettings):
+            model_config = SettingsConfigDict(env_prefix="MYAPP_", extra="forbid")
+
+            api_key: str = Field(alias="AUTH_TOKEN")
+            legacy_key: str = Field(validation_alias="LEGACY_TOKEN")
+
+        env_file = tmp_path / ".env"
+        env_file.write_text("AUTH_TOKEN=value\nLEGACY_TOKEN=legacy\n", encoding="utf-8")
+        env = EnvParser().parse(env_file)
+        schema = SchemaLoader().extract_metadata(Settings)
+
+        result = Validator().validate(env, schema, check_encryption=False)
+
+        assert schema.fields["api_key"].env_name == "AUTH_TOKEN"
+        assert schema.fields["legacy_key"].env_name == "LEGACY_TOKEN"
+        assert result.missing_required == set()
+        assert result.extra_vars == set()
+        assert result.valid is True
+
+    def test_prefixed_empty_required_field_respects_env_ignore_empty(self, tmp_path):
+        class Settings(BaseSettings):
+            model_config = SettingsConfigDict(
+                env_prefix="MYAPP_", env_ignore_empty=True, extra="forbid"
+            )
+
+            port: int
+
+        env_file = tmp_path / ".env"
+        env_file.write_text("MYAPP_PORT=\n", encoding="utf-8")
+        env = EnvParser().parse(env_file)
+        schema = SchemaLoader().extract_metadata(Settings)
+
+        result = Validator().validate(env, schema, check_encryption=False)
+
+        assert result.missing_required == {"port"}
+        assert result.extra_vars == set()
+        assert result.type_errors == {}
+        assert result.valid is False
+
+    def test_case_sensitive_prefix_and_field_name_require_exact_case(self, tmp_path):
+        class Settings(BaseSettings):
+            model_config = SettingsConfigDict(
+                env_prefix="MyApp_", case_sensitive=True, extra="forbid"
+            )
+
+            api_key: str
+
+        exact_file = tmp_path / ".env.exact"
+        exact_file.write_text("MyApp_api_key=value\n", encoding="utf-8")
+        wrong_case_file = tmp_path / ".env.wrong"
+        wrong_case_file.write_text("MYAPP_API_KEY=value\n", encoding="utf-8")
+        schema = SchemaLoader().extract_metadata(Settings)
+
+        exact = Validator().validate(EnvParser().parse(exact_file), schema, check_encryption=False)
+        wrong_case = Validator().validate(
+            EnvParser().parse(wrong_case_file), schema, check_encryption=False
+        )
+
+        assert schema.case_sensitive is True
+        assert schema.fields["api_key"].env_name == "MyApp_api_key"
+        assert exact.valid is True
+        assert wrong_case.missing_required == {"api_key"}
+        assert wrong_case.extra_vars == {"MYAPP_API_KEY"}
+        assert wrong_case.valid is False
+
 
 class TestKnownValidatorGaps:
-    """Confirmed pre-existing bugs, asserted at their correct behavior (xfail).
+    """Confirmed pre-existing bug, asserted at its correct behavior (xfail).
 
-    Both reproduce identically on pre-refactor main (de834a7) — they are NOT
-    regressions from the #650 decomposition, which is pure code motion. Flip
-    each xfail to a plain assertion in the PR that fixes its issue.
+    It reproduces identically on pre-refactor main (de834a7) and is not a
+    regression from the #650 decomposition, which is pure code motion. Flip
+    the xfail to a plain assertion in the PR that fixes its issue.
     """
 
     @pytest.mark.xfail(
@@ -670,24 +798,3 @@ class TestKnownValidatorGaps:
 
         assert result.valid is False
         assert result.type_errors  # the model-level rejection must be reported
-
-    @pytest.mark.xfail(
-        strict=False,
-        reason="suspicious-plaintext suppression compares the env alias against attribute "
-        "names, so an aliased sensitive field gets contradictory warnings (see #658)",
-    )
-    def test_aliased_sensitive_field_gets_no_contradictory_warning(self, tmp_path):
-        """A field marked sensitive must not also warn 'not marked sensitive' via its alias."""
-
-        class AliasedSensitiveSettings(BaseSettings):
-            api_key: str = Field(alias="X_API_KEY", json_schema_extra={"sensitive": True})
-
-        env_file = tmp_path / ".env"
-        env_file.write_text("X_API_KEY=sk-live-abcdef1234567890\n", encoding="utf-8")
-        env = EnvParser().parse(env_file)
-        schema = SchemaLoader().extract_metadata(AliasedSensitiveSettings)
-
-        result = Validator().validate(env, schema)
-
-        assert "api_key" in result.unencrypted_secrets  # correctly detected as sensitive
-        assert not [w for w in result.warnings if "not marked sensitive" in w]


### PR DESCRIPTION
## What was broken

`SchemaLoader.extract_metadata()` ignored `SettingsConfigDict(env_prefix=...)`.
On current `origin/main`, this deterministic reproduction:

```text
env TERM=dumb COLUMNS=80 NO_COLOR=1 FORCE_COLOR=0 uv run envdrift validate \
  .repro-669/.env --schema settings:Prefixed --service-dir .repro-669 --ci
```

exited 1 for a model that pydantic-settings loaded successfully. It reported
`api_key` missing, `MYAPP_API_KEY` extra, missed the sensitive binding, and
emitted two contradictory "not marked sensitive" warnings.

## What changed

- Store each field's effective environment binding separately from its Pydantic
  model-validation alias.
- Prefix plain field bindings while leaving explicit aliases and validation
  aliases unprefixed, matching pydantic-settings.
- Honor `case_sensitive` for prefix and field-name matching.
- Use the effective binding consistently across missing, extra, sensitive,
  type, and constraint checks without passing prefixes to `model_validate()`.
- Document prefix, alias, and case-sensitive validation behavior.

The same CLI reproduction now exits 0, reports no missing or extra variables,
detects `api_key` as unencrypted, and emits no contradictory warnings.

## Tests

Regression coverage includes prefixed end-to-end validation, sensitive detection,
type and constraint failures, alias and validation-alias prefix bypass,
`env_ignore_empty`, and exact-case matching. The binding-aware sensitive check
also converts the existing aliased-sensitive regression from xfail to pass.

Failing-before proof used `git checkout origin/main -- src/`: all five new prefix
tests failed. Restoring the implementation made all five pass.

## Gates

- `uv run ruff check src tests` — passed
- `uv run ruff format --check .` — passed (241 files)
- `uv run pyrefly check` — passed (0 errors)
- `uv run bandit -r src -c pyproject.toml` — passed (0 issues)
- `uv run pytest -m "not integration"` — passed (3486 passed, 6 skipped,
  556 deselected, 1 expected xfail)
- `make lint-docs` — passed (0 errors; npm cache redirected to a writable path)

Closes #669

🤖 Generated with Codex (gpt-5.6-sol) orchestrated by Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Environment-variable validation now supports configured prefixes and case-sensitive matching.
  - Explicit field aliases correctly take precedence over environment prefixes.
  - Validation errors reference model field names while preserving environment-variable bindings.

- **Bug Fixes**
  - Improved handling of sensitive fields, empty values, missing variables, extra variables, and case-insensitive name collisions.
  - Corrected sensitive-field warnings for aliased fields.

- **Documentation**
  - Added guidance on environment prefixes, aliases, case sensitivity, and validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes envdrift validation follow pydantic-settings environment bindings. The main changes are:

- Added effective env binding metadata for schema fields.
- Applied `env_prefix` to plain field names.
- Kept explicit aliases and validation aliases unprefixed.
- Propagated `case_sensitive` matching through validation checks.
- Added tests and docs for prefix, alias, and case-sensitive behavior.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/envdrift/core/schema.py | Extracts separate model-validation aliases and effective environment names for settings fields. |
| src/envdrift/core/validator.py | Uses effective environment names and schema case-sensitivity across missing, extra, sensitive, type, and constraint checks. |
| tests/unit/test_schema_loader.py | Adds schema metadata coverage for alias-path binding behavior. |
| tests/unit/test_validator.py | Adds validation coverage for prefixed fields, aliases, empty values, sensitive checks, and exact-case matching. |
| docs/cli/validate.md | Documents validation behavior for prefixes, aliases, and case-sensitive matching. |
| docs/reference/api.md | Documents API behavior for pydantic-settings environment bindings. |

<sub>Reviews (3): Last reviewed commit: ["refactor(schema): flatten environment bi..."](https://github.com/jainal09/envdrift/commit/f30b89cc9e5ffcc9aef56ac1cb2094c233590137) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44026682)</sub>

<!-- /greptile_comment -->