### PR TITLE
fix(output): route human diagnostics to stderr

### DIFF
--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -53,6 +53,16 @@ The following options are available only on the top-level `envdrift` command:
 --show-completion       Show completion script
 ```
 
+## Output Streams
+
+Human-readable command results are written to stdout. Human `[ERROR]` and
+`[WARN]` diagnostics are written to stderr, so redirecting or piping stdout
+does not hide failures or mix diagnostic prose into downstream input.
+
+Machine-readable modes keep their documented stdout contracts. In particular,
+`diff --format json` and `guard --json`/`guard --sarif` emit machine-readable
+error documents on stdout rather than replacing them with human diagnostics.
+
 ## Quick Examples
 
 ```bash

--- a/src/envdrift/cli_commands/guard.py
+++ b/src/envdrift/cli_commands/guard.py
@@ -65,6 +65,7 @@ from envdrift.scanner.output import (
 )
 
 console = Console()
+diagnostic_console = Console(stderr=True)
 
 # Early-exit prose for the git-discovery branches; emitted only in human mode
 # (machine modes get an empty-findings doc via _emit_empty_or_prose).
@@ -141,7 +142,7 @@ def _emit_error(json_output: bool, sarif: bool, message: str) -> None:
         # names like ``[vault.sync]``) survive Rich markup instead of being
         # interpreted as console tags and silently dropped (mirrors
         # output/rich.py print_error). The static label stays markup.
-        console.print(f"[red]Error:[/red] {escape(message)}")
+        diagnostic_console.print(f"[red]Error:[/red] {escape(message)}")
 
 
 def _machine_mode(json_output: bool, sarif: bool) -> bool:
@@ -824,7 +825,6 @@ def _refuse_unsupported_history(
 def _print_combined_files_warnings(
     combined_files: list[str],
     engine: ScanEngine,
-    output_console: Console,
     json_output: bool,
     sarif: bool,
 ) -> None:
@@ -834,9 +834,9 @@ def _print_combined_files_warnings(
     if combined_files and not _machine_mode(json_output, sarif):
         security_warnings = engine.check_combined_files_security()
         for warning in security_warnings:
-            output_console.print(f"[bold red]{warning}[/bold red]")
+            diagnostic_console.print(f"[bold red]{warning}[/bold red]")
         if security_warnings:
-            output_console.print()
+            diagnostic_console.print()
 
 
 def _print_scan_header(
@@ -1243,7 +1243,7 @@ def guard(
     output_console = _make_output_console(ci, json_output, sarif)
     engine = _create_scan_engine(config, json_output, sarif)
     _refuse_unsupported_history(config, engine, json_output, sarif)
-    _print_combined_files_warnings(combined_files, engine, output_console, json_output, sarif)
+    _print_combined_files_warnings(combined_files, engine, json_output, sarif)
 
     # Show scanner info in verbose mode or when running interactively
     scanner_names = [s.name for s in engine.scanners]

--- a/src/envdrift/output/rich.py
+++ b/src/envdrift/output/rich.py
@@ -19,7 +19,9 @@ from envdrift.core.validator import MODEL_ERROR_KEY, ValidationResult
 if TYPE_CHECKING:
     from envdrift.sync.result import ServiceSyncResult, SyncResult
 
+# Full command reports are stdout payloads; standalone diagnostics use stderr.
 console = Console()
+diagnostic_console = Console(stderr=True)
 
 
 def print_success(message: str) -> None:
@@ -29,24 +31,24 @@ def print_success(message: str) -> None:
 
 def print_error(message: str) -> None:
     """
-    Print a message prefixed with a red "ERROR" badge to the module console.
+    Print a message prefixed with a red "ERROR" badge to stderr.
 
     The message is treated as literal text: any bracketed substrings (e.g. TOML
     table names like ``[vault.sync]``) are escaped so Rich does not interpret
     them as console markup and silently drop them.
     """
-    console.print(f"[red][ERROR][/red] {escape(message)}")
+    diagnostic_console.print(f"[red][ERROR][/red] {escape(message)}")
 
 
 def print_warning(message: str) -> None:
     """
-    Display a yellow "WARN" badge followed by the provided message to the shared console.
+    Display a yellow "WARN" badge followed by the provided message on stderr.
 
     The message is treated as literal text: any bracketed substrings (e.g. TOML
     table names like ``[vault.sync]``) are escaped so Rich does not interpret
     them as console markup and silently drop them.
     """
-    console.print(f"[yellow][WARN][/yellow] {escape(message)}")
+    diagnostic_console.print(f"[yellow][WARN][/yellow] {escape(message)}")
 
 
 def print_validation_result(
@@ -453,15 +455,15 @@ def print_mismatch_warning(
     vault_preview: str,
 ) -> None:
     """
-    Print value mismatch warning.
+    Print a value mismatch diagnostic to stderr.
 
     Parameters:
         service_name (str): Name of the service with mismatched values.
         local_preview (str): Preview of local value (first N chars).
         vault_preview (str): Preview of vault value (first N chars).
     """
-    console.print()
-    console.print(f"[bold yellow]VALUE MISMATCH: {service_name}[/bold yellow]")
-    console.print(f"  Local:  {local_preview}")
-    console.print(f"  Vault:  {vault_preview}")
-    console.print()
+    diagnostic_console.print()
+    diagnostic_console.print(f"[bold yellow]VALUE MISMATCH: {service_name}[/bold yellow]")
+    diagnostic_console.print(f"  Local:  {local_preview}")
+    diagnostic_console.print(f"  Vault:  {vault_preview}")
+    diagnostic_console.print()

--- a/tests/integration/test_diff_cli.py
+++ b/tests/integration/test_diff_cli.py
@@ -467,9 +467,9 @@ def test_diff_format_unknown_value_exits_1(tmp_path: Path, integration_pythonpat
     result = _run_diff([".env.a", ".env.b", "--format", "bogus"], tmp_path, integration_pythonpath)
 
     assert result.returncode == 1
-    combined = result.stdout + result.stderr
-    assert "Invalid --format" in combined
-    assert "bogus" in combined
+    assert result.stdout == ""
+    assert "Invalid --format" in result.stderr
+    assert "bogus" in result.stderr
 
 
 class TestDiffRobustErrors:
@@ -489,7 +489,8 @@ class TestDiffRobustErrors:
         result = _run_diff([str(a), str(d)], tmp_path, integration_pythonpath)
         assert result.returncode == 1
         assert "Traceback" not in result.stderr
-        assert "Not a file" in result.stdout
+        assert result.stdout == ""
+        assert "Not a file" in result.stderr
 
     def test_binary_file_errors_cleanly(self, tmp_path, integration_pythonpath):
         a = self._env(tmp_path)
@@ -498,7 +499,8 @@ class TestDiffRobustErrors:
         result = _run_diff([str(a), str(b)], tmp_path, integration_pythonpath)
         assert result.returncode == 1
         assert "Traceback" not in result.stderr
-        assert "UTF-8" in result.stdout
+        assert result.stdout == ""
+        assert "UTF-8" in result.stderr
 
     def test_json_error_path_is_clean_json(self, tmp_path, integration_pythonpath):
         a = self._env(tmp_path)

--- a/tests/integration/test_guard_cli_e2e.py
+++ b/tests/integration/test_guard_cli_e2e.py
@@ -425,8 +425,9 @@ def test_path_not_found_exits_operational_code(git_repo: Path) -> None:
     """A nonexistent path exits 6 (operational error, distinct from critical's 1, #478)."""
     work_dir = git_repo
     result = _run_envdrift(["guard", "--native-only", "./does_not_exist.py"], cwd=work_dir)
-    assert result.returncode == 6, f"expected 6, got {result.returncode}\n{result.stdout}"
-    assert "Path not found" in (result.stdout + result.stderr)
+    assert result.returncode == 6, f"expected 6, got {result.returncode}\n{result.stderr}"
+    assert result.stdout == ""
+    assert "Path not found" in result.stderr
 
 
 # --- EC-21 (P1): --skip-clear overrides the allowed_clear_files allowlist --------
@@ -945,5 +946,7 @@ def test_combined_file_gitignore_check_handles_non_ascii_name(git_repo: Path) ->
     # security check actually ran and matched against git's answer.
     assert "SECURITY WARNING" in out, out
     assert "unprotected.combined.env" in out, out
+    assert "SECURITY WARNING" not in result.stdout
+    assert "unprotected.combined.env" in result.stderr
     # The gitignored CJK combined file must NOT be flagged.
     assert _CJK_COMBINED_NAME not in out, out

--- a/tests/integration/test_output_streams.py
+++ b/tests/integration/test_output_streams.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import subprocess
 from pathlib import Path
 
@@ -86,3 +87,65 @@ def test_human_warning_is_written_only_to_stderr(
     assert "Drift detected" in result.stdout
     assert "Could not load schema" not in result.stdout
     assert "[WARN] Could not load schema" in result.stderr
+
+
+def test_guard_usage_error_is_written_only_to_stderr(
+    tmp_path: Path,
+    envdrift_cmd: list[str],
+    integration_env: dict[str, str],
+) -> None:
+    """Guard operational errors follow the human-diagnostic stream contract."""
+    result = _run_envdrift(
+        ["guard", "missing.env", "--native-only", "--no-auto-install"],
+        tmp_path,
+        envdrift_cmd,
+        integration_env,
+    )
+
+    assert result.returncode == 6
+    assert result.stdout == ""
+    assert "Error: Path not found: missing.env" in result.stderr
+
+
+def test_guard_human_findings_report_stays_on_stdout(
+    tmp_path: Path,
+    envdrift_cmd: list[str],
+    integration_env: dict[str, str],
+) -> None:
+    """Guard findings are product output, not diagnostics."""
+    secret = "wJalrXUtnFEMI/" + "K7MDENG/bPxRfiCYEXAMPLEKEY"
+    (tmp_path / "config.py").write_text(f'aws_secret_access_key = "{secret}"\n', encoding="utf-8")
+
+    result = _run_envdrift(
+        ["guard", "config.py", "--native-only", "--no-auto-install"],
+        tmp_path,
+        envdrift_cmd,
+        integration_env,
+    )
+
+    assert result.returncode == 1
+    assert "aws-secret-access-key" in result.stdout
+    assert result.stderr == ""
+
+
+def test_guard_json_payload_stays_on_stdout(
+    tmp_path: Path,
+    envdrift_cmd: list[str],
+    integration_env: dict[str, str],
+) -> None:
+    """Guard JSON remains a complete, parseable stdout document."""
+    secret = "wJalrXUtnFEMI/" + "K7MDENG/bPxRfiCYEXAMPLEKEY"
+    (tmp_path / "config.py").write_text(f'aws_secret_access_key = "{secret}"\n', encoding="utf-8")
+
+    result = _run_envdrift(
+        ["guard", "config.py", "--native-only", "--no-auto-install", "--json"],
+        tmp_path,
+        envdrift_cmd,
+        integration_env,
+    )
+
+    payload = json.loads(result.stdout)
+    assert result.returncode == 1
+    assert payload["exit_code"] == 1
+    assert any(finding["rule_id"] == "aws-secret-access-key" for finding in payload["findings"])
+    assert result.stderr == ""

--- a/tests/integration/test_output_streams.py
+++ b/tests/integration/test_output_streams.py
@@ -1,0 +1,88 @@
+"""Real-CLI tests for the stdout/stderr contract."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.integration]
+
+
+def _run_envdrift(
+    args: list[str],
+    cwd: Path,
+    envdrift_cmd: list[str],
+    integration_env: dict[str, str],
+) -> subprocess.CompletedProcess[str]:
+    """Run the installed envdrift entry point with both streams captured."""
+    return subprocess.run(
+        [*envdrift_cmd, *args],
+        cwd=cwd,
+        env=integration_env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def test_human_error_is_written_only_to_stderr(
+    tmp_path: Path,
+    envdrift_cmd: list[str],
+    integration_env: dict[str, str],
+) -> None:
+    """#654: human errors follow the Unix stderr convention."""
+    result = _run_envdrift(
+        ["sync", "--verify", "--provider", "azur"],
+        tmp_path,
+        envdrift_cmd,
+        integration_env,
+    )
+
+    assert result.returncode == 1
+    assert result.stdout == ""
+    assert "[ERROR] No sync configuration found" in result.stderr
+
+
+def test_successful_diff_keeps_stderr_quiet(
+    tmp_path: Path,
+    envdrift_cmd: list[str],
+    integration_env: dict[str, str],
+) -> None:
+    """A happy-path diff can have stdout redirected without exposing diagnostics."""
+    (tmp_path / "a.env").write_text("VALUE=same\n", encoding="utf-8")
+    (tmp_path / "b.env").write_text("VALUE=same\n", encoding="utf-8")
+
+    result = _run_envdrift(
+        ["diff", "a.env", "b.env"],
+        tmp_path,
+        envdrift_cmd,
+        integration_env,
+    )
+
+    assert result.returncode == 0
+    assert "No drift detected" in result.stdout
+    assert result.stderr == ""
+
+
+def test_human_warning_is_written_only_to_stderr(
+    tmp_path: Path,
+    envdrift_cmd: list[str],
+    integration_env: dict[str, str],
+) -> None:
+    """Human warnings stay visible without contaminating a command result."""
+    (tmp_path / "a.env").write_text("VALUE=one\n", encoding="utf-8")
+    (tmp_path / "b.env").write_text("VALUE=two\n", encoding="utf-8")
+
+    result = _run_envdrift(
+        ["diff", "a.env", "b.env", "--schema", "missing.module:Settings"],
+        tmp_path,
+        envdrift_cmd,
+        integration_env,
+    )
+
+    assert result.returncode == 0
+    assert "Drift detected" in result.stdout
+    assert "Could not load schema" not in result.stdout
+    assert "[WARN] Could not load schema" in result.stderr

--- a/tests/integration/test_output_streams.py
+++ b/tests/integration/test_output_streams.py
@@ -11,6 +11,11 @@ import pytest
 pytestmark = [pytest.mark.integration]
 
 
+def _flat(output: str) -> str:
+    """Normalize Rich output for substring assertions at narrow widths."""
+    return " ".join(output.split())
+
+
 def _run_envdrift(
     args: list[str],
     cwd: Path,
@@ -43,7 +48,7 @@ def test_human_error_is_written_only_to_stderr(
 
     assert result.returncode == 1
     assert result.stdout == ""
-    assert "[ERROR] No sync configuration found" in result.stderr
+    assert "[ERROR] No sync configuration found" in _flat(result.stderr)
 
 
 def test_successful_diff_keeps_stderr_quiet(
@@ -63,7 +68,7 @@ def test_successful_diff_keeps_stderr_quiet(
     )
 
     assert result.returncode == 0
-    assert "No drift detected" in result.stdout
+    assert "No drift detected" in _flat(result.stdout)
     assert result.stderr == ""
 
 
@@ -84,9 +89,9 @@ def test_human_warning_is_written_only_to_stderr(
     )
 
     assert result.returncode == 0
-    assert "Drift detected" in result.stdout
-    assert "Could not load schema" not in result.stdout
-    assert "[WARN] Could not load schema" in result.stderr
+    assert "Drift detected" in _flat(result.stdout)
+    assert "Could not load schema" not in _flat(result.stdout)
+    assert "[WARN] Could not load schema" in _flat(result.stderr)
 
 
 def test_guard_usage_error_is_written_only_to_stderr(
@@ -104,7 +109,7 @@ def test_guard_usage_error_is_written_only_to_stderr(
 
     assert result.returncode == 6
     assert result.stdout == ""
-    assert "Error: Path not found: missing.env" in result.stderr
+    assert "Error: Path not found: missing.env" in _flat(result.stderr)
 
 
 def test_guard_human_findings_report_stays_on_stdout(
@@ -124,7 +129,7 @@ def test_guard_human_findings_report_stays_on_stdout(
     )
 
     assert result.returncode == 1
-    assert "aws-secret-access-key" in result.stdout
+    assert "aws-secret-access-key" in _flat(result.stdout)
     assert result.stderr == ""
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -30,7 +30,8 @@ def test_validate_requires_schema() -> None:
     """Test validate command requires --schema."""
     result = runner.invoke(app, ["validate"])
     assert result.exit_code == 1
-    assert "--schema" in result.stdout or "schema" in result.stdout.lower()
+    assert result.stdout == ""
+    assert "--schema" in result.stderr or "schema" in result.stderr.lower()
 
 
 def test_validate_file_not_found(tmp_path) -> None:
@@ -39,7 +40,8 @@ def test_validate_file_not_found(tmp_path) -> None:
         app, ["validate", str(tmp_path / "nonexistent.env"), "--schema", "app:Settings"]
     )
     assert result.exit_code == 1
-    assert "not found" in result.stdout.lower()
+    assert result.stdout == ""
+    assert "not found" in result.stderr.lower()
 
 
 def test_diff_requires_two_files() -> None:
@@ -55,7 +57,8 @@ def test_diff_file_not_found(tmp_path) -> None:
 
     result = runner.invoke(app, ["diff", str(env1), str(tmp_path / "nonexistent.env")])
     assert result.exit_code == 1
-    assert "not found" in result.stdout.lower()
+    assert result.stdout == ""
+    assert "not found" in result.stderr.lower()
 
 
 def test_diff_identical_files(tmp_path) -> None:
@@ -146,7 +149,8 @@ def test_diff_env1_missing(tmp_path) -> None:
 
     result = runner.invoke(app, ["diff", str(tmp_path / "missing.env"), str(env2)])
     assert result.exit_code == 1
-    assert "not found" in result.stdout.lower()
+    assert result.stdout == ""
+    assert "not found" in result.stderr.lower()
 
 
 def test_diff_normalize_default_collapses_bool_casing(tmp_path) -> None:
@@ -182,7 +186,8 @@ def test_diff_schema_load_error_warns_and_continues(tmp_path) -> None:
 
     result = runner.invoke(app, ["diff", str(env1), str(env2), "--schema", "does.not.exist:Nope"])
     assert result.exit_code == 0
-    assert "could not load schema" in result.stdout.lower()
+    assert "could not load schema" not in result.stdout.lower()
+    assert "could not load schema" in result.stderr.lower()
 
 
 def test_encrypt_check_file_not_found(tmp_path) -> None:
@@ -288,7 +293,8 @@ def test_lock_no_config_found(tmp_path) -> None:
         result = runner.invoke(app, ["lock"])
         assert result.exit_code == 1
         # Should indicate no config found
-        assert "No sync configuration found" in result.stdout or "provider" in result.stdout.lower()
+        assert result.stdout == ""
+        assert "No sync configuration found" in result.stderr or "provider" in result.stderr.lower()
     finally:
         os.chdir(original_cwd)
 

--- a/tests/unit/coverage/test_cov_cli_commands_sync.py
+++ b/tests/unit/coverage/test_cov_cli_commands_sync.py
@@ -1649,8 +1649,9 @@ class TestNoConfigErrorGuidance:
         monkeypatch.chdir(tmp_path)
         monkeypatch.setattr("envdrift.config.find_config", lambda: None)
         result = runner.invoke(app, ["pull"])
-        out = " ".join(result.output.split())
+        out = " ".join(result.stderr.split())
         assert result.exit_code == 1
+        assert result.stdout == ""
         # All three config mechanisms must be listed, with their literal
         # section names (print_error escapes Rich markup).
         assert "envdrift.toml" in out

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -2826,9 +2826,10 @@ class TestSyncCommand:
         )
 
         assert result.exit_code == 1
-        normalized = " ".join(result.output.split())
+        normalized = " ".join(result.stderr.split())
         assert "TOML syntax error in" in normalized
         assert "No sync configuration found" not in normalized
+        assert result.stdout == ""
 
     def test_sync_missing_config_file_errors(self, tmp_path: Path):
         """Missing provided config file should exit with error."""
@@ -3089,9 +3090,10 @@ class TestSyncCommand:
         )
 
         assert result.exit_code == 1
-        normalized = " ".join(result.output.split())
+        normalized = " ".join(result.stderr.split())
         assert "[ERROR] TOML syntax error in" in normalized
         assert "No sync configuration found" not in normalized
+        assert result.stdout == ""
 
 
 class TestPullCommand:

--- a/tests/unit/test_config_fail_loudly.py
+++ b/tests/unit/test_config_fail_loudly.py
@@ -430,9 +430,9 @@ class TestEncryptDecryptAbortOnBrokenConfig:
         result = runner.invoke(app, ["encrypt", str(env_file)])
 
         assert result.exit_code == 1, result.output
-        out = _flat(result.output)
+        out = _flat(result.stderr)
         assert "[ERROR] TOML syntax error in" in out
-        assert "[OK] Encrypted" not in out
+        assert result.stdout == ""
         assert env_file.read_text(encoding="utf-8") == "FOO=bar\n"
         assert not (tmp_path / ".env.keys").exists()
 
@@ -446,8 +446,9 @@ class TestEncryptDecryptAbortOnBrokenConfig:
         result = runner.invoke(app, ["decrypt", str(env_file)])
 
         assert result.exit_code == 1, result.output
-        out = _flat(result.output)
+        out = _flat(result.stderr)
         assert "[ERROR] TOML syntax error in" in out
+        assert result.stdout == ""
         assert env_file.read_text(encoding="utf-8") == "FOO=bar\n"
 
 

--- a/tests/unit/test_config_fail_loudly.py
+++ b/tests/unit/test_config_fail_loudly.py
@@ -24,6 +24,10 @@ from typer.testing import CliRunner
 from envdrift.cli import app
 
 runner = CliRunner()
+# Click 8.3 always captures stderr separately and no longer accepts the old
+# ``mix_stderr`` option. Keep a dedicated runner for these stream-contract
+# tests so a future capture-semantics change fails their explicit assertions.
+separate_streams_runner = CliRunner()
 
 
 def _flat(output: str) -> str:
@@ -427,7 +431,7 @@ class TestEncryptDecryptAbortOnBrokenConfig:
         env_file = self._write_broken_sops_project(tmp_path)
         monkeypatch.chdir(tmp_path)
 
-        result = runner.invoke(app, ["encrypt", str(env_file)])
+        result = separate_streams_runner.invoke(app, ["encrypt", str(env_file)])
 
         assert result.exit_code == 1, result.output
         out = _flat(result.stderr)
@@ -443,7 +447,7 @@ class TestEncryptDecryptAbortOnBrokenConfig:
         env_file = self._write_broken_sops_project(tmp_path)
         monkeypatch.chdir(tmp_path)
 
-        result = runner.invoke(app, ["decrypt", str(env_file)])
+        result = separate_streams_runner.invoke(app, ["decrypt", str(env_file)])
 
         assert result.exit_code == 1, result.output
         out = _flat(result.stderr)

--- a/tests/unit/test_guard_cli.py
+++ b/tests/unit/test_guard_cli.py
@@ -89,7 +89,8 @@ def test_guard_missing_path_exits(tmp_path: Path):
     missing = tmp_path / "nope"
     result = runner.invoke(app, ["guard", str(missing)])
     assert result.exit_code == 6
-    assert "path not found" in result.output.lower()
+    assert result.stdout == ""
+    assert "path not found" in result.stderr.lower()
 
 
 def test_guard_invalid_fail_on_exits(tmp_path: Path, monkeypatch):
@@ -100,7 +101,7 @@ def test_guard_invalid_fail_on_exits(tmp_path: Path, monkeypatch):
 
     result = runner.invoke(app, ["guard", str(tmp_path), "--fail-on", "invalid"])
     assert result.exit_code == 6
-    assert "invalid severity" in result.output.lower()
+    assert "invalid severity" in result.stderr.lower()
 
 
 def test_guard_defaults_to_cwd(tmp_path: Path, monkeypatch):
@@ -284,7 +285,7 @@ def test_guard_rejects_custom_env_files_outside_folder(tmp_path: Path, monkeypat
     result = runner.invoke(app, ["guard", str(tmp_path)])
 
     assert result.exit_code == 6  # operational error, distinct from critical's 1 (#478)
-    assert "invalid env_file" in result.output.lower()
+    assert "invalid env_file" in result.stderr.lower()
 
 
 def test_guard_pr_base_fetch_warns_on_failure(tmp_path: Path, monkeypatch):
@@ -309,8 +310,8 @@ def test_guard_pr_base_fetch_warns_on_failure(tmp_path: Path, monkeypatch):
 
     result = runner.invoke(app, ["guard", "--pr-base", "origin/"])
     assert result.exit_code == 0
-    assert "warning" in result.output.lower()
-    assert "could not fetch" in result.output.lower()
+    assert "warning" in result.stderr.lower()
+    assert "could not fetch" in result.stderr.lower()
 
 
 def test_guard_pr_base_strips_only_leading_origin_prefix(tmp_path: Path, monkeypatch):
@@ -791,7 +792,7 @@ def test_guard_staged_without_git_fails(tmp_path: Path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     result = runner.invoke(app, ["guard", "--staged"])
     assert result.exit_code == 6  # operational error (#478)
-    assert "git not found" in result.output.lower()
+    assert "git not found" in result.stderr.lower()
 
 
 def test_guard_pr_base_with_no_changed_files(tmp_path: Path, monkeypatch):
@@ -842,7 +843,7 @@ def test_guard_pr_base_unresolvable_ref_errors(tmp_path: Path, monkeypatch):
     monkeypatch.chdir(tmp_path)
 
     result = runner.invoke(app, ["guard", "--pr-base", "nope"])
-    out = " ".join(result.output.split())
+    out = " ".join(result.stderr.split())
     # Operational error (unresolvable base ref) is exit 6, not critical's 1 (#526).
     assert result.exit_code == 6, out
     assert "Error" in out, out
@@ -895,7 +896,7 @@ def test_guard_staged_git_diff_failure_errors(tmp_path: Path, monkeypatch):
     monkeypatch.chdir(tmp_path)
 
     result = runner.invoke(app, ["guard", "--staged"])
-    out = " ".join(result.output.split())
+    out = " ".join(result.stderr.split())
     assert result.exit_code == 6, out  # operational error, not critical's 1 (#526)
     assert "Error" in out, out
     assert "not a git repository" in out, out
@@ -928,7 +929,7 @@ def test_guard_history_without_capable_scanner_errors(tmp_path: Path, monkeypatc
     monkeypatch.setattr("envdrift.cli_commands.guard.ScanEngine", NoHistoryEngine)
 
     result = runner.invoke(app, ["guard", str(tmp_path), "--history"])
-    out = " ".join(result.output.split())
+    out = " ".join(result.stderr.split())
     assert result.exit_code == 6, out  # operational error, not critical's 1 (#526)
     assert "history" in out.lower(), out
     assert "gitleaks" in out.lower(), out
@@ -993,7 +994,7 @@ def test_guard_staged_unreadable_blob_skipped_with_warning(tmp_path: Path, monke
     monkeypatch.chdir(tmp_path)
 
     result = runner.invoke(app, ["guard", "--staged"])
-    out = " ".join(result.output.split())
+    out = " ".join(result.stderr.split())
     assert result.exit_code == 0, out
     assert "warning" in out.lower(), out
     assert "submodule" in out, out
@@ -1019,7 +1020,7 @@ def test_guard_staged_all_blobs_unreadable_errors(tmp_path: Path, monkeypatch):
     monkeypatch.chdir(tmp_path)
 
     result = runner.invoke(app, ["guard", "--staged"])
-    out = " ".join(result.output.split())
+    out = " ".join(result.stderr.split())
     assert result.exit_code == 6, out  # operational error, not critical's 1 (#526)
     assert "Error" in out, out
     assert "could not read any staged file content" in out, out
@@ -1228,7 +1229,7 @@ def test_guard_pr_base_without_git_fails(tmp_path: Path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     result = runner.invoke(app, ["guard", "--pr-base", "origin/main"])
     assert result.exit_code == 6  # operational error (#478)
-    assert "git not found" in result.output.lower()
+    assert "git not found" in result.stderr.lower()
 
 
 def test_guard_history_flag(tmp_path: Path, monkeypatch):
@@ -1257,7 +1258,7 @@ def test_guard_staged_timeout(tmp_path: Path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     result = runner.invoke(app, ["guard", "--staged"])
     assert result.exit_code == 6  # operational error (#478)
-    assert "timed out" in result.output.lower()
+    assert "timed out" in result.stderr.lower()
 
 
 def test_guard_pr_base_timeout(tmp_path: Path, monkeypatch):
@@ -1275,7 +1276,7 @@ def test_guard_pr_base_timeout(tmp_path: Path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     result = runner.invoke(app, ["guard", "--pr-base", "origin/main"])
     assert result.exit_code == 6  # operational error (#478)
-    assert "timed out" in result.output.lower()
+    assert "timed out" in result.stderr.lower()
 
 
 def test_guard_staged_files_not_exist(tmp_path: Path, monkeypatch):
@@ -1530,9 +1531,8 @@ def test_guard_json_and_sarif_warns_about_precedence(tmp_path: Path):
 
     # The precedence warning lands on stderr.
     assert "--json is ignored" in result.stderr
-    # stdout (the captured output with the stderr portion removed) is a clean,
-    # parseable SARIF document — the warning must NOT leak into it.
-    stdout = result.output.replace(result.stderr, "")
-    assert "--json is ignored" not in stdout
-    sarif = json.loads(stdout)
+    # stdout is a clean, parseable SARIF document — the warning must NOT leak
+    # into it.
+    assert "--json is ignored" not in result.stdout
+    sarif = json.loads(result.stdout)
     assert "runs" in sarif

--- a/tests/unit/test_guard_exit_truthfulness.py
+++ b/tests/unit/test_guard_exit_truthfulness.py
@@ -147,7 +147,7 @@ class TestScanErrorExitCode:
     def test_rich_mode_does_not_print_green_all_clear(self, tmp_path: Path, monkeypatch):
         _patch_engine(monkeypatch, _result([], errors={"talisman": "exit status 128"}))
         result = runner.invoke(app, ["guard", str(tmp_path)])
-        normalized = " ".join(result.output.split())
+        normalized = " ".join(result.stdout.split())
         assert "No secrets or policy violations detected" not in normalized, (
             "an errored scan must not be presented as a clean pass"
         )
@@ -256,7 +256,7 @@ class TestIgnoreRulesShapeValidation:
         monkeypatch.chdir(tmp_path)
         result = runner.invoke(app, ["guard", "--native-only", "--no-auto-install", "."])
         assert result.exit_code == 6
-        normalized = " ".join(result.output.split())
+        normalized = " ".join(result.stderr.split())
         assert "ignore_rules" in normalized
         assert "Traceback" not in result.output
 
@@ -372,7 +372,7 @@ class TestFailOnSeverityValidation:
         monkeypatch.chdir(tmp_path)
         result = runner.invoke(app, ["guard", "--native-only", "--no-auto-install", "."])
         assert result.exit_code == 6
-        assert "fail_on_severity" in " ".join(result.output.split())
+        assert "fail_on_severity" in " ".join(result.stderr.split())
         assert "Traceback" not in result.output
 
 
@@ -456,7 +456,7 @@ class TestOperationalErrorExitCode:
         _patch_engine(monkeypatch, _result([]))
         result = runner.invoke(app, ["guard", str(tmp_path), "--fail-on", "bogus"])
         assert result.exit_code == 6
-        assert "invalid severity" in result.output.lower()
+        assert "invalid severity" in result.stderr.lower()
 
     def test_sarif_error_doc_carries_operational_exit_code(self, tmp_path: Path):
         missing = tmp_path / "does-not-exist"
@@ -579,7 +579,7 @@ class TestDefaultScannerUnavailableSkips:
         scan_dir = self._hide_gitleaks(monkeypatch, tmp_path)
         result = runner.invoke(app, ["guard", "--no-auto-install", str(scan_dir)])
         assert result.exit_code == 0
-        normalized = " ".join(result.output.split())
+        normalized = " ".join(result.stdout.split())
         assert "Scanners Skipped" in normalized
         assert "gitleaks" in normalized
         assert "No secrets or policy violations detected" in normalized

--- a/tests/unit/test_guard_machine_output.py
+++ b/tests/unit/test_guard_machine_output.py
@@ -178,7 +178,7 @@ def test_guard_human_error_preserves_bracketed_literal(tmp_path):
     # split the literal across lines -- normalize whitespace before asserting. The
     # behavior under test is markup-escaping (does "[vault.sync]" survive Rich?),
     # not line wrapping.
-    normalized = "".join(result.stdout.split())
+    normalized = "".join(result.stderr.split())
     assert "[vault.sync].env" in normalized
 
 

--- a/tests/unit/test_rich_output.py
+++ b/tests/unit/test_rich_output.py
@@ -14,6 +14,7 @@ from envdrift.core.schema import FieldMetadata, SchemaMetadata
 from envdrift.core.validator import ValidationResult
 from envdrift.output.rich import (
     console,
+    diagnostic_console,
     print_diff_result,
     print_encryption_report,
     print_error,
@@ -41,7 +42,7 @@ class TestPrintFunctions:
 
     def test_print_error(self):
         """Test print_error outputs red ERROR."""
-        with patch.object(console, "print") as mock_print:
+        with patch.object(diagnostic_console, "print") as mock_print:
             print_error("Something failed")
             mock_print.assert_called_once()
             call_args = str(mock_print.call_args)
@@ -49,7 +50,7 @@ class TestPrintFunctions:
 
     def test_print_warning(self):
         """Test print_warning outputs yellow WARN."""
-        with patch.object(console, "print") as mock_print:
+        with patch.object(diagnostic_console, "print") as mock_print:
             print_warning("Something suspicious")
             mock_print.assert_called_once()
             call_args = str(mock_print.call_args)
@@ -68,7 +69,7 @@ class TestPrintFunctions:
 
         buf = io.StringIO()
         capture = Console(file=buf, force_terminal=False, no_color=True, width=200)
-        with patch.object(rich_module, "console", capture):
+        with patch.object(rich_module, "diagnostic_console", capture):
             rich_module.print_error("Expected [vault.sync] section with [[vault.sync.mappings]]")
         output = buf.getvalue()
         assert "[vault.sync]" in output
@@ -82,7 +83,7 @@ class TestPrintFunctions:
 
         buf = io.StringIO()
         capture = Console(file=buf, force_terminal=False, no_color=True, width=200)
-        with patch.object(rich_module, "console", capture):
+        with patch.object(rich_module, "diagnostic_console", capture):
             rich_module.print_warning("Add a [tool.envdrift.vault.sync] block")
         assert "[tool.envdrift.vault.sync]" in buf.getvalue()
 
@@ -95,6 +96,8 @@ class TestConsole:
         from rich.console import Console
 
         assert isinstance(console, Console)
+        assert isinstance(diagnostic_console, Console)
+        assert diagnostic_console.stderr is True
 
 
 class TestValidationOutput:
@@ -359,7 +362,7 @@ class TestSyncOutput:
 
     def test_print_mismatch_warning(self):
         """Mismatch warning helper."""
-        with patch.object(console, "print") as mock_print:
+        with patch.object(diagnostic_console, "print") as mock_print:
             print_mismatch_warning("svc", "local", "vault")
         joined = " ".join(" ".join(map(str, c.args)) for c in mock_print.call_args_list)
         assert "VALUE MISMATCH" in joined


### PR DESCRIPTION
Closes #654

## What was broken

The deterministic issue repro exited 1 but wrote the full human diagnostic to stdout:

- stdout: `[ERROR] No sync configuration found...`
- stderr: empty

This inverted the Unix stream convention, made stderr redirection ineffective, and polluted stdout pipelines.

## What changed

- Added a dedicated Rich `Console(stderr=True)` for shared human diagnostics.
- Routed `print_error`, `print_warning`, and the mismatch-warning helper to stderr.
- Kept full validation, encryption, diff, and sync reports on stdout because they are command results, even when they contain failure or warning rows.
- Preserved machine-readable stdout contracts: `diff --format json`, `guard --json`, and `guard --sarif` still emit their payloads and machine error documents on stdout.
- Documented the human and machine output-stream behavior.

Click 8.3.1 and Typer 0.20.0 expose `result.output` as combined output while retaining separate `result.stdout` and `result.stderr`. Stream-specific assertions now use the separate properties; command-report assertions remain combined or stdout deliberately.

## Regression tests

Added real installed-CLI subprocess coverage that captures both streams and verifies:

- human errors appear only on stderr with the original exit code;
- human warnings do not contaminate stdout;
- a successful `diff` keeps stderr quiet when stdout is redirected or piped.

The new stream suite was run against the pre-change source: 2 failed and 1 passed. With the fix: 3 passed.

## Gates

- `uv sync --all-extras`
- `uv run ruff check src tests`
- `uv run ruff format --check .`
- `uv run pyrefly check`
- `uv run bandit -r src -c pyproject.toml`
- `make lint-docs`
- `uv run pytest -m "not integration"`: 3495 passed, 6 skipped
- `uv run pytest -m integration`: 456 passed, 104 skipped
- Post-#675 sync/stream focus: 81 passed

Final deterministic repro: exit 1, empty stdout, and the `[ERROR]` block on stderr.

🤖 Generated with Codex (gpt-5.6-sol) orchestrated by Claude Code

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jainal09/envdrift/pull/677?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Human-readable errors, warnings, and mismatch diagnostics now go to stderr, keeping stdout clean.
  * JSON output modes preserve stdout-only machine-readable error documents without mixing diagnostic text.
  * Improved error handling for invalid formats, malformed configuration, missing files, and other CLI failures.

* **Documentation**
  * Added CLI guidance explaining output streams and JSON behavior.

* **Tests**
  * Expanded coverage for stdout/stderr behavior across successful, warning, and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves human diagnostics onto stderr while preserving command output on stdout. The main changes are:

- Added a dedicated Rich console for stderr diagnostics.
- Routed shared error, warning, and mismatch messages to stderr.
- Updated guard diagnostics to keep human errors off stdout.
- Documented the output-stream contract for human and machine modes.
- Added tests for separated stdout and stderr behavior.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/envdrift/cli_commands/guard.py | Guard human errors and combined-file security warnings now use the stderr diagnostic console. |
| src/envdrift/output/rich.py | Shared human diagnostic helpers now write to stderr while full command reports remain on stdout. |
| docs/cli/index.md | The CLI docs now describe the split between human diagnostics and machine-readable stdout payloads. |
| tests/integration/test_output_streams.py | The new integration tests cover installed-CLI stdout and stderr behavior for errors, warnings, and machine output. |

<sub>Reviews (3): Last reviewed commit: ["test(output): harden stream assertions"](https://github.com/jainal09/envdrift/commit/c399d49fa6988d2a41aec5c743885430dc67c88f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44036616)</sub>

<!-- /greptile_comment -->