### PR TITLE
chore(vscode): drop deprecated glob type stub

### DIFF
--- a/envdrift-vscode/package-lock.json
+++ b/envdrift-vscode/package-lock.json
@@ -14,7 +14,6 @@
       "devDependencies": {
         "@eslint/js": "^10.0.0",
         "@types/cross-spawn": "^6.0.6",
-        "@types/glob": "^9.0.0",
         "@types/mocha": "^10.0.0",
         "@types/node": "^24.0.0",
         "@types/sinon": "^22.0.0",
@@ -1369,17 +1368,6 @@
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/glob": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-9.0.0.tgz",
-      "integrity": "sha512-00UxlRaIUvYm4R4W9WYkN8/J+kV8fmOQ7okeH6YFtGWFMt3odD45tpG5yA5wnL7HE6lLgjaTW5n14ju2hl2NNA==",
-      "deprecated": "This is a stub types definition. glob provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "glob": "*"
-      }
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",

--- a/envdrift-vscode/package.json
+++ b/envdrift-vscode/package.json
@@ -137,7 +137,6 @@
   "devDependencies": {
     "@eslint/js": "^10.0.0",
     "@types/cross-spawn": "^6.0.6",
-    "@types/glob": "^9.0.0",
     "@types/mocha": "^10.0.0",
     "@types/node": "^24.0.0",
     "@types/sinon": "^22.0.0",


### PR DESCRIPTION
## What was broken

The Renovate Dependency Dashboard (#37) flags `@types/glob` as deprecated. The
extension uses glob 13, which ships its own declarations, so the direct stub package
is redundant and emits a deprecation warning during every clean install.

This work also time-boxed the suppressed TypeScript 7 major migration. PR #617
changed only `package.json`; run 29138974497 failed in both Build and VS Code Lint
because `npm ci` found TypeScript 6.0.3 in the lockfile while the manifest required
7.0.2.

A synchronized local trial reached the actual ecosystem blocker:

- `typescript-eslint@8.64.0` and its current canary declare
  `typescript >=4.8.4 <6.1.0`.
- A clean Node 24 `npm ci` with TypeScript 7.0.2 fails with `ERESOLVE`.
- A forced diagnostic compiled successfully, but `npm run lint` crashed inside
  `@typescript-eslint/typescript-estree` while reading the removed `Cjs` API.

The unsupported TypeScript changes were reverted under the migration time box. This
PR supersedes #617 and records why the Renovate TypeScript 7 major remains blocked.
Renovate's ignore notification on #617 suppresses future 7.x PRs until the project
manually upgrades.

## What changed

- Removed the deprecated direct `@types/glob` dev dependency.
- Regenerated `package-lock.json`; glob remains installed at 13.0.6 with its
  bundled declarations.
- Kept the supported TypeScript 6.0.3 / typescript-eslint 8.63.0 toolchain.

## Tests

No new test file was needed for this dependency cleanup. The existing TypeScript
compile exercises the real `glob` import after removing the stub declarations.

Run locally with Node 24.18.0 and npm 11.17.0:

- `npm ci`
- `npm run lint`
- `npm run compile`
- `npm run bundle`
- `npm run test:unit` — 76 passing
- `npm test` — 81 passing in the real VS Code Electron host
- `./node_modules/.bin/vsce package --no-dependencies`
- CI's packaged-runtime verification — cross-spawn is inlined
- `git diff --check`
- `git diff --stat origin/main...HEAD` — only `envdrift-vscode/`

🤖 Generated with Codex (gpt-5.6-sol) orchestrated by Claude Code

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR cleans up the VS Code extension dependency list.

- Removed the deprecated `@types/glob` dev dependency.
- Regenerated the lockfile without the stub package.
- Kept `glob` and the existing TypeScript toolchain in place.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| envdrift-vscode/package.json | Removes the deprecated `@types/glob` dev dependency while keeping `glob` installed. |
| envdrift-vscode/package-lock.json | Updates the lockfile to drop the deprecated stub package entry. |

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into chore/vscode-to..."](https://github.com/jainal09/envdrift/commit/78479e7d28410ce4f029f75d1106601015f5133a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44141931)</sub>

<!-- /greptile_comment -->