### PR TITLE
feat: declare envdrift stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,10 @@
 Sync environment variables across your team. No more "it works on my machine."
 
 > **Status: stable.** envdrift v11 marks the first release the project considers
-> production-ready: every feature ships with real-backend integration tests, regression
-> coverage, and a reliability-first review gate. See the
+> production-ready: core features are covered by integration tests against real backends in
+> CI (LocalStack, HashiCorp Vault, Lowkey Vault emulating Azure) and the real encryption
+> binaries, every bug fix ships a regression test, and changes pass a reliability-first
+> review gate. See the
 > [changelog](https://github.com/jainal09/envdrift/blob/main/CHANGELOG.md) for history.
 
 ## The Problem

--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@
 
 Sync environment variables across your team. No more "it works on my machine."
 
+> **Status: stable.** envdrift v11 marks the first release the project considers
+> production-ready: every feature ships with real-backend integration tests, regression
+> coverage, and a reliability-first review gate. See the
+> [changelog](https://github.com/jainal09/envdrift/blob/main/CHANGELOG.md) for history.
+
 ## The Problem
 
 - New developer joins → spends half a day hunting for the right `.env` values

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ keywords = [
     "vault",
 ]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",


### PR DESCRIPTION
Adds the stability declaration to the README and carries `Release-As: 11.0.0`, so on merge
release-please cuts **v11.0.0 — the first release the project declares production-ready**.

Basis for the declaration (owner-directed):

- The entire issue backlog is closed: all 32 findings of the #441 dogfood umbrella, the
  code-health hotspots (#650, #572, #665), validator/schema correctness gaps (#657, #658,
  #669, #673), stream contract (#654), and sync/lock truthfulness (#661, #663).
- Every fix shipped with regression tests proven failing-before, real-backend integration
  coverage (dotenvx, sops, HashiCorp Vault, lowkey-vault), and adversarial review.
- Dependency dashboard drained; pinned toolchain verified against real artifacts.

Merge AFTER #687 (lockfile bumps) per release sequencing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PmjB1wAMY8zyHpdF2zzmCj

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jainal09/envdrift/pull/688?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README to indicate that envdrift v11 is stable and production-ready.
  * Added a reference to the project changelog for release history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR declares envdrift stable for the v11 release. The main changes are:

- Adds a stable and production-ready status note to the README.
- Links the README status note to the project changelog.
- Updates the package classifier to Production/Stable.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| README.md | Adds the stable status note and changelog link. |
| pyproject.toml | Updates the package development-status classifier to Production/Stable. |

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into feat/declare-st..."](https://github.com/jainal09/envdrift/commit/73cb05d5c67605327e57d5f313337ab02480fb89) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44158726)</sub>

<!-- /greptile_comment -->