### PR TITLE
docs: record the Release-As squash-body gotcha

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,11 +86,13 @@ issue** — don't silently leave it. Cite `file:line` and evidence in the issue.
 
 These have bitten us in CI or review and aren't obvious from the code alone.
 
-- **`Release-As:` footers must survive the squash.** This repo squashes with the **PR body**
-  as the commit body, so a version override belongs in the PR *body* as a standalone,
-  unwrapped `Release-As: x.y.z` line — hard-wrapping the body mid-sentence (or leaving the
-  footer only in a branch commit message) silently loses it and release-please picks the
-  normal bump instead.
+- **`Release-As:` footers must survive the squash.** This repo's squash settings are
+  `squash_merge_commit_title: PR_TITLE` + `squash_merge_commit_message: PR_BODY` (verify with
+  `gh api repos/<owner>/<repo> --jq .squash_merge_commit_message` if in doubt — the guidance
+  below only holds for `PR_BODY`), so a version override belongs in the PR *body* as a
+  standalone, unwrapped `Release-As: x.y.z` line. Hard-wrapping the body mid-sentence (or
+  leaving the footer only in a branch commit message) silently loses it and release-please
+  picks the normal bump instead (how #688 released as 10.18.0 instead of 11.0.0).
 - **release-please force-pushes its release-PR branches.** On every push to
   `main` it rebases each open `release-please--branches--main--components--*`
   branch onto the new `main` and **regenerates** the CHANGELOG + manifest from

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,11 @@ issue** — don't silently leave it. Cite `file:line` and evidence in the issue.
 
 These have bitten us in CI or review and aren't obvious from the code alone.
 
+- **`Release-As:` footers must survive the squash.** This repo squashes with the **PR body**
+  as the commit body, so a version override belongs in the PR *body* as a standalone,
+  unwrapped `Release-As: x.y.z` line — hard-wrapping the body mid-sentence (or leaving the
+  footer only in a branch commit message) silently loses it and release-please picks the
+  normal bump instead.
 - **release-please force-pushes its release-PR branches.** On every push to
   `main` it rebases each open `release-please--branches--main--components--*`
   branch onto the new `main` and **regenerates** the CHANGELOG + manifest from


### PR DESCRIPTION
Documents why #688 released as 10.18.0 instead of 11.0.0: this repo squash-merges with the PR body as the commit body, so Release-As footers must be standalone unwrapped lines in the PR body. This PR both records the gotcha in CLAUDE.md and carries the corrected footer to retarget the open release PR (#689) to the intended stable major.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PmjB1wAMY8zyHpkF2zzmCj

Release-As: 11.0.0

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jainal09/envdrift/pull/690?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR documents the `Release-As:` squash-merge requirement for release-please.

- Adds guidance that the footer must be a standalone PR-body line.
- Notes the repo squash setting that preserves the PR body.
- Includes a check for `squash_merge_commit_message` before relying on the guidance.
- Records the #688 release-version mismatch as the example.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed documentation.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| CLAUDE.md | Adds release guidance for keeping `Release-As:` visible through squash merges. |

<sub>Reviews (2): Last reviewed commit: ["docs: state the verified squash setting ..."](https://github.com/jainal09/envdrift/commit/40391f6da5d7e2ccf11ccbee6a11569522bd6746) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44164703)</sub>

<!-- /greptile_comment -->