### PR TITLE
chore(release): force the next release to 11.0.0 via release-please config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,6 +5,7 @@
   "packages": {
     ".": {
       "release-type": "python",
+      "release-as": "11.0.0",
       "package-name": "envdrift",
       "component": "envdrift",
       "changelog-path": "CHANGELOG.md",


### PR DESCRIPTION
Sets `release-as: 11.0.0` in release-please-config.json — the parser-proof mechanism after two footer manglings (#688 hard-wrap, #690 bot-appended body content). A follow-up PR removes the sticky field once v11.0.0 ships.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jainal09/envdrift/pull/691?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR forces the next release-please version to 11.0.0.

- Adds `release-as: 11.0.0` for the root package.
- Leaves the existing Python release type and package metadata unchanged.

<h3>Confidence Score: 4/5</h3>

The release override can affect later release-please runs until it is removed.

- The changed config is consumed repeatedly by the release workflow.
- No checked-in guard or cleanup removes the forced version after v11.0.0 ships.
- A later run can reuse the stale override instead of the manifest's next version.

release-please-config.json

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| release-please-config.json | Adds a root package version override that forces release-please to target 11.0.0. |

<sub>Reviews (1): Last reviewed commit: ["chore(release): force the next release t..."](https://github.com/jainal09/envdrift/commit/7a14cb1a00ae644c75ae1a559d2ba85ce1e4eea9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44168285)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->