### PR TITLE
chore(release): drop the one-shot release-as pin now that v11.0.0 shipped

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,6 @@
   "packages": {
     ".": {
       "release-type": "python",
-      "release-as": "11.0.0",
       "package-name": "envdrift",
       "component": "envdrift",
       "changelog-path": "CHANGELOG.md",


### PR DESCRIPTION
Removes the sticky `release-as: 11.0.0` added by #691 — it forced exactly one release (v11.0.0 via #689) and must not pin future versions. Completes the sequence promised on #691's review thread.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jainal09/envdrift/pull/692?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes a temporary release-please version pin. The main change is:

- Removed the root package `release-as: 11.0.0` override from `release-please-config.json`.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| release-please-config.json | Removes the one-shot root package release override so future releases use the manifest baseline. |

<sub>Reviews (1): Last reviewed commit: ["chore(release): drop the one-shot releas..."](https://github.com/jainal09/envdrift/commit/312a001c120dd52a7a4f7908d48ad33b04eda073) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44172631)</sub>

<!-- /greptile_comment -->