### PR TITLE
fix(deps): patch fast-uri, js-yaml and brace-expansion advisories

### DIFF
--- a/envdrift-vscode/package-lock.json
+++ b/envdrift-vscode/package-lock.json
@@ -2107,16 +2107,16 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -3171,9 +3171,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {
@@ -3942,10 +3942,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/envdrift-vscode/package.json
+++ b/envdrift-vscode/package.json
@@ -131,8 +131,10 @@
   },
   "overrides": {
     "serialize-javascript": ">=7.0.5",
-    "brace-expansion": "^5.0.6",
-    "diff": ">=9.0.0"
+    "brace-expansion": "^5.0.9",
+    "diff": ">=9.0.0",
+    "fast-uri": "^3.1.4",
+    "js-yaml": "^4.3.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.0",


### PR DESCRIPTION
## What

Closes three open Dependabot alerts in `envdrift-vscode`, all on transitive dependencies, using the existing `overrides` block in `package.json`.

| Package | Before | After | Alert(s) | Severity |
|---|---|---|---|---|
| `fast-uri` | 3.1.3 | 3.1.5 | [#50](https://github.com/jainal09/envdrift/security/dependabot/50) — host confusion via literal backslash authority delimiter (patched 3.1.4) | high |
| `js-yaml` | 4.1.1 | 4.3.1 | [#49](https://github.com/jainal09/envdrift/security/dependabot/49), [#22](https://github.com/jainal09/envdrift/security/dependabot/22) — quadratic CPU consumption from YAML merge-key chains (patched 4.3.0) | high / medium |
| `brace-expansion` | 5.0.7 | 5.0.9 | Renovate dashboard pending update | — |

## Why in-major pins

The overrides use `^3.1.4` / `^4.3.0` rather than `>=`. An unbounded `>=` resolves to `fast-uri` 4.x and `js-yaml` 5.x, dragging major-version behaviour changes into what should be a security patch. The caret ranges clear every listed advisory while staying inside the current major.

## Verification

- `npm audit` → **0 vulnerabilities**
- `npm run lint` → clean
- `npm run pretest` (tsc + esbuild bundle) → builds, 42.1 kb output
- `npm run test:unit` → **76 passing**

No source changes; lockfile and overrides only.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jainal09/envdrift/pull/709?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated extension dependency requirements and compatibility overrides.
  * Applied maintenance updates for improved dependency consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates dependency overrides and the lockfile for patched in-major releases of `fast-uri`, `js-yaml`, and `brace-expansion`.
- Adds explicit overrides for patched `fast-uri` and `js-yaml` versions.
- Raises the existing `brace-expansion` override and lockfile resolution.
- Keeps the updated packages within their existing major versions.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| envdrift-vscode/package.json | Updates transitive dependency overrides to patched in-major ranges without changing extension source or runtime configuration. |
| envdrift-vscode/package-lock.json | Resolves fast-uri 3.1.5, js-yaml 4.3.1, and brace-expansion 5.0.9 consistently with the updated overrides. |

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into deps/security-n..."](https://github.com/jainal09/envdrift/commit/04d91920dcd19f472d1cff6e739f4d031925fffe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49489770)</sub>

<!-- /greptile_comment -->